### PR TITLE
feat(workflows): implement workflow execution engine

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-21T23:15:37.280Z for PR creation at branch issue-242-aaa23d0a8190 for issue https://github.com/xlabtg/teleton-agent/issues/242

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -191,6 +191,7 @@ export class AgentRuntime {
   private hookRunner?: ReturnType<typeof createHookRunner>;
   private userHookEvaluator?: UserHookEvaluator;
   private lastRagMemoryIds: string[] = [];
+  private onToolCompleteCallback?: (toolName: string) => void;
 
   constructor(config: Config, soul?: string, toolRegistry?: ToolRegistry) {
     this.config = config;
@@ -230,6 +231,10 @@ export class AgentRuntime {
 
   setHookRunner(runner: ReturnType<typeof createHookRunner>): void {
     this.hookRunner = runner;
+  }
+
+  setOnToolCompleteCallback(cb: ((toolName: string) => void) | undefined): void {
+    this.onToolCompleteCallback = cb;
   }
 
   setUserHookEvaluator(evaluator: UserHookEvaluator): void {
@@ -949,6 +954,15 @@ export class AgentRuntime {
                 log.warn({ err }, "tool:after hook failed");
               })
             );
+          }
+
+          // Notify workflow tool.complete observers
+          if (!plan.blocked && exec.result.success && this.onToolCompleteCallback) {
+            try {
+              this.onToolCompleteCallback(block.name);
+            } catch {
+              // ignore
+            }
           }
 
           // Record tool invocation metric (skipped for blocked tools)

--- a/src/api/deps.ts
+++ b/src/api/deps.ts
@@ -9,6 +9,7 @@ import type { AgentLifecycle } from "../agent/lifecycle.js";
 import type { UserHookEvaluator } from "../agent/hooks/user-hook-evaluator.js";
 import type { MarketplaceDeps } from "../webui/types.js";
 import type { AutonomousTaskManager } from "../autonomous/manager.js";
+import type { WorkflowScheduler } from "../services/workflow-scheduler.js";
 import { HTTPException } from "hono/http-exception";
 
 export interface ApiServerDeps {
@@ -31,6 +32,7 @@ export interface ApiServerDeps {
   marketplace?: MarketplaceDeps | null;
   userHookEvaluator?: UserHookEvaluator | null;
   autonomousManager?: AutonomousTaskManager | null;
+  workflowScheduler?: (() => WorkflowScheduler | null) | WorkflowScheduler | null;
 }
 
 /**
@@ -50,7 +52,8 @@ export function createDepsAdapter(apiDeps: ApiServerDeps): WebUIServerDeps {
         prop === "lifecycle" ||
         prop === "userHookEvaluator" ||
         prop === "marketplace" ||
-        prop === "autonomousManager"
+        prop === "autonomousManager" ||
+        prop === "workflowScheduler"
       ) {
         return value;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ import { CacheInvalidationWatcher, initPreloader } from "./services/preloader.js
 import { initAlerting } from "./services/alerting.js";
 import { initAnomalyDetector } from "./services/anomaly-detector.js";
 import { flushOffsets } from "./telegram/offset-store.js";
+import { WorkflowScheduler } from "./services/workflow-scheduler.js";
 
 const log = createLogger("App");
 
@@ -90,6 +91,7 @@ export class TeletonApp {
   private messagesProcessed: number = 0;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private heartbeatRunning = false;
+  private workflowScheduler: WorkflowScheduler | null = null;
 
   private configPath: string;
 
@@ -372,6 +374,7 @@ ${blue}  ┌──────────────────────�
           },
           userHookEvaluator: this.userHookEvaluator,
           autonomousManager,
+          workflowScheduler: () => this.workflowScheduler,
         });
         await this.webuiServer.start();
       } catch (error) {
@@ -409,6 +412,7 @@ ${blue}  ┌──────────────────────�
             },
             userHookEvaluator: this.userHookEvaluator,
             autonomousManager,
+            workflowScheduler: () => this.workflowScheduler,
           },
           this.config.api
         );
@@ -801,6 +805,19 @@ ${blue}  ┌──────────────────────�
       };
       await this.hookRunner.runObservingHook("agent:start", agentStartEvent);
     }
+
+    // Start workflow scheduler
+    this.workflowScheduler = new WorkflowScheduler(getDatabase().getDb(), this.bridge);
+    this.workflowScheduler.start();
+    const scheduler = this.workflowScheduler;
+    this.agent.setOnToolCompleteCallback((_toolName: string) => {
+      void scheduler.fireEvent("tool.complete").catch((err: unknown) => {
+        log.warn({ err }, "Workflow tool.complete event failed");
+      });
+    });
+    void this.workflowScheduler.fireEvent("agent.start").catch((err: unknown) => {
+      log.warn({ err }, "Workflow agent.start event failed");
+    });
 
     // Start heartbeat timer if enabled
     if (this.config.heartbeat.enabled) {
@@ -1454,6 +1471,18 @@ ${blue}  ┌──────────────────────�
    * Called by lifecycle.stop() — do NOT call directly.
    */
   private async stopAgent(): Promise<void> {
+    // Fire workflow agent.stop event and stop scheduler
+    if (this.workflowScheduler) {
+      try {
+        await this.workflowScheduler.fireEvent("agent.stop");
+      } catch (err) {
+        log.warn({ err }, "Workflow agent.stop event failed");
+      }
+      this.workflowScheduler.stop();
+      this.workflowScheduler = null;
+      this.agent.setOnToolCompleteCallback(undefined);
+    }
+
     // Stop heartbeat timer
     if (this.heartbeatTimer) {
       clearInterval(this.heartbeatTimer);

--- a/src/services/__tests__/workflow-executor.test.ts
+++ b/src/services/__tests__/workflow-executor.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { WorkflowStore } from "../workflows.js";
+import { WorkflowExecutor } from "../workflow-executor.js";
+import type { Workflow } from "../workflows.js";
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workflows (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT,
+      enabled INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
+      config TEXT NOT NULL DEFAULT '{}',
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      last_run_at INTEGER,
+      run_count INTEGER NOT NULL DEFAULT 0,
+      last_error TEXT
+    );
+  `);
+  return db;
+}
+
+function makeWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    id: "test-id",
+    name: "Test",
+    description: null,
+    enabled: true,
+    config: {
+      trigger: { type: "cron", cron: "0 9 * * 1" },
+      actions: [],
+    },
+    createdAt: 0,
+    updatedAt: 0,
+    lastRunAt: null,
+    runCount: 0,
+    lastError: null,
+    ...overrides,
+  };
+}
+
+describe("WorkflowExecutor", () => {
+  let db: Database.Database;
+  let store: WorkflowStore;
+
+  beforeEach(() => {
+    db = createTestDb();
+    store = new WorkflowStore(db);
+  });
+
+  it("calls recordRun with no error on success", async () => {
+    const wf = store.create({
+      name: "Test",
+      config: { trigger: { type: "cron", cron: "0 9 * * 1" }, actions: [] },
+    });
+    const executor = new WorkflowExecutor({ store });
+    await executor.execute(wf);
+    const updated = store.get(wf.id)!;
+    expect(updated.runCount).toBe(1);
+    expect(updated.lastError).toBeNull();
+  });
+
+  it("executes set_variable action and interpolates variables", async () => {
+    const wf = store.create({
+      name: "Var test",
+      config: {
+        trigger: { type: "cron", cron: "0 9 * * 1" },
+        actions: [{ type: "set_variable", name: "greeting", value: "hello" }],
+      },
+    });
+    const executor = new WorkflowExecutor({ store });
+    await executor.execute(wf);
+    const updated = store.get(wf.id)!;
+    expect(updated.runCount).toBe(1);
+    expect(updated.lastError).toBeNull();
+  });
+
+  it("records error when send_message bridge is unavailable", async () => {
+    const wf = store.create({
+      name: "Msg test",
+      config: {
+        trigger: { type: "cron", cron: "0 9 * * 1" },
+        actions: [{ type: "send_message", chatId: "123", text: "hi" }],
+      },
+    });
+    const executor = new WorkflowExecutor({ store }); // no bridge
+    await executor.execute(wf);
+    const updated = store.get(wf.id)!;
+    expect(updated.runCount).toBe(1);
+    expect(updated.lastError).toContain("send_message");
+  });
+
+  it("sends message via bridge when available", async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const bridge = { isAvailable: () => true, sendMessage } as unknown as Parameters<
+      typeof WorkflowExecutor
+    >[0]["bridge"];
+    const wf = store.create({
+      name: "Send test",
+      config: {
+        trigger: { type: "cron", cron: "0 9 * * 1" },
+        actions: [{ type: "send_message", chatId: "456", text: "hello" }],
+      },
+    });
+    const executor = new WorkflowExecutor({ store, bridge });
+    await executor.execute(wf);
+    expect(sendMessage).toHaveBeenCalledWith({ chatId: "456", text: "hello" });
+    const updated = store.get(wf.id)!;
+    expect(updated.runCount).toBe(1);
+    expect(updated.lastError).toBeNull();
+  });
+
+  it("interpolates variables in send_message", async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const bridge = { isAvailable: () => true, sendMessage } as unknown as Parameters<
+      typeof WorkflowExecutor
+    >[0]["bridge"];
+    const wf = store.create({
+      name: "Interp test",
+      config: {
+        trigger: { type: "cron", cron: "0 9 * * 1" },
+        actions: [
+          { type: "set_variable", name: "name", value: "World" },
+          { type: "send_message", chatId: "123", text: "Hello {{name}}" },
+        ],
+      },
+    });
+    const executor = new WorkflowExecutor({ store, bridge });
+    await executor.execute(wf);
+    expect(sendMessage).toHaveBeenCalledWith({ chatId: "123", text: "Hello World" });
+  });
+});

--- a/src/services/__tests__/workflow-scheduler.test.ts
+++ b/src/services/__tests__/workflow-scheduler.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { WorkflowStore } from "../workflows.js";
+import { WorkflowScheduler } from "../workflow-scheduler.js";
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+function createTestDb(): Database.Database {
+  const db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workflows (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT,
+      enabled INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
+      config TEXT NOT NULL DEFAULT '{}',
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      last_run_at INTEGER,
+      run_count INTEGER NOT NULL DEFAULT 0,
+      last_error TEXT
+    );
+  `);
+  return db;
+}
+
+describe("WorkflowScheduler", () => {
+  let db: Database.Database;
+  let store: WorkflowStore;
+
+  beforeEach(() => {
+    db = createTestDb();
+    store = new WorkflowStore(db);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fireEvent triggers matching event workflows", async () => {
+    const wf = store.create({
+      name: "On start",
+      config: {
+        trigger: { type: "event", event: "agent.start" },
+        actions: [],
+      },
+    });
+
+    const scheduler = new WorkflowScheduler(db);
+    await scheduler.fireEvent("agent.start");
+
+    const updated = store.get(wf.id)!;
+    expect(updated.runCount).toBe(1);
+  });
+
+  it("fireEvent does not trigger disabled workflows", async () => {
+    const wf = store.create({
+      name: "Disabled",
+      enabled: false,
+      config: {
+        trigger: { type: "event", event: "agent.start" },
+        actions: [],
+      },
+    });
+
+    const scheduler = new WorkflowScheduler(db);
+    await scheduler.fireEvent("agent.start");
+
+    const updated = store.get(wf.id)!;
+    expect(updated.runCount).toBe(0);
+  });
+
+  it("fireEvent does not trigger workflows with different event", async () => {
+    const wf = store.create({
+      name: "Stop only",
+      config: {
+        trigger: { type: "event", event: "agent.stop" },
+        actions: [],
+      },
+    });
+
+    const scheduler = new WorkflowScheduler(db);
+    await scheduler.fireEvent("agent.start");
+
+    const updated = store.get(wf.id)!;
+    expect(updated.runCount).toBe(0);
+  });
+
+  it("handleWebhook triggers matching webhook workflows", async () => {
+    const wf = store.create({
+      name: "Webhook",
+      config: {
+        trigger: { type: "webhook", secret: "my-secret-token" },
+        actions: [],
+      },
+    });
+
+    const scheduler = new WorkflowScheduler(db);
+    const triggered = await scheduler.handleWebhook("my-secret-token");
+
+    expect(triggered).toBe(true);
+    const updated = store.get(wf.id)!;
+    expect(updated.runCount).toBe(1);
+  });
+
+  it("handleWebhook returns false for unknown secret", async () => {
+    const scheduler = new WorkflowScheduler(db);
+    const triggered = await scheduler.handleWebhook("nonexistent");
+    expect(triggered).toBe(false);
+  });
+
+  it("handleWebhook does not trigger disabled webhook workflows", async () => {
+    const wf = store.create({
+      name: "Disabled webhook",
+      enabled: false,
+      config: {
+        trigger: { type: "webhook", secret: "secret123" },
+        actions: [],
+      },
+    });
+
+    const scheduler = new WorkflowScheduler(db);
+    const triggered = await scheduler.handleWebhook("secret123");
+
+    expect(triggered).toBe(false);
+    const updated = store.get(wf.id)!;
+    expect(updated.runCount).toBe(0);
+  });
+
+  it("start and stop do not throw", () => {
+    const scheduler = new WorkflowScheduler(db);
+    scheduler.start();
+    scheduler.stop();
+  });
+
+  it("start is idempotent", () => {
+    const scheduler = new WorkflowScheduler(db);
+    scheduler.start();
+    scheduler.start(); // should not throw or create duplicate timers
+    scheduler.stop();
+  });
+});
+
+describe("Cron matching (via tick)", () => {
+  let db: Database.Database;
+  let store: WorkflowStore;
+
+  beforeEach(() => {
+    db = createTestDb();
+    store = new WorkflowStore(db);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires cron workflow when time matches", async () => {
+    // Start 1 second before 09:00 UTC on a Monday so the interval fires AT 09:00
+    vi.setSystemTime(new Date("2024-01-01T08:59:00.000Z")); // Monday, 1 min before target
+
+    const wf = store.create({
+      name: "Monday 9am",
+      config: {
+        trigger: { type: "cron", cron: "0 9 * * 1" }, // Monday at 9am UTC
+        actions: [],
+      },
+    });
+
+    const scheduler = new WorkflowScheduler(db);
+    scheduler.start();
+
+    // Advance to exactly 09:00 UTC (60 seconds forward)
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    const updated = store.get(wf.id)!;
+    expect(updated.runCount).toBe(1);
+
+    scheduler.stop();
+  });
+
+  it("does not fire cron workflow when time does not match", async () => {
+    // Set time to 2024-01-01 10:00 UTC (9am cron won't match)
+    vi.setSystemTime(new Date("2024-01-01T10:00:00.000Z"));
+
+    const wf = store.create({
+      name: "Monday 9am",
+      config: {
+        trigger: { type: "cron", cron: "0 9 * * 1" },
+        actions: [],
+      },
+    });
+
+    const scheduler = new WorkflowScheduler(db);
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    const updated = store.get(wf.id)!;
+    expect(updated.runCount).toBe(0);
+
+    scheduler.stop();
+  });
+});

--- a/src/services/workflow-executor.ts
+++ b/src/services/workflow-executor.ts
@@ -1,0 +1,71 @@
+import type { TelegramBridge } from "../telegram/bridge.js";
+import type { WorkflowStore } from "./workflows.js";
+import type { Workflow, WorkflowAction } from "./workflows.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("WorkflowExecutor");
+
+export interface WorkflowExecutorDeps {
+  bridge?: TelegramBridge;
+  store: WorkflowStore;
+}
+
+export class WorkflowExecutor {
+  private variables = new Map<string, string>();
+
+  constructor(private deps: WorkflowExecutorDeps) {}
+
+  async execute(workflow: Workflow): Promise<void> {
+    const errors: string[] = [];
+
+    for (const action of workflow.config.actions) {
+      try {
+        await this.runAction(action);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.warn({ workflowId: workflow.id, action: action.type, err }, "Action failed");
+        errors.push(`${action.type}: ${msg}`);
+      }
+    }
+
+    this.deps.store.recordRun(workflow.id, errors.length > 0 ? errors.join("; ") : undefined);
+  }
+
+  private interpolate(text: string): string {
+    return text.replace(/\{\{(\w+)\}\}/g, (_, name: string) => this.variables.get(name) ?? "");
+  }
+
+  private async runAction(action: WorkflowAction): Promise<void> {
+    if (action.type === "send_message") {
+      const bridge = this.deps.bridge;
+      if (!bridge || !bridge.isAvailable()) {
+        throw new Error("Telegram bridge unavailable");
+      }
+      await bridge.sendMessage({
+        chatId: this.interpolate(action.chatId),
+        text: this.interpolate(action.text),
+      });
+      return;
+    }
+
+    if (action.type === "call_api") {
+      const init: RequestInit = { method: action.method };
+      if (action.headers) {
+        init.headers = action.headers;
+      }
+      if (action.body && action.method !== "GET" && action.method !== "DELETE") {
+        init.body = this.interpolate(action.body);
+      }
+      const res = await fetch(action.url, init);
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status} from ${action.url}`);
+      }
+      return;
+    }
+
+    if (action.type === "set_variable") {
+      this.variables.set(action.name, this.interpolate(action.value));
+      return;
+    }
+  }
+}

--- a/src/services/workflow-scheduler.ts
+++ b/src/services/workflow-scheduler.ts
@@ -1,0 +1,146 @@
+import type Database from "better-sqlite3";
+import type { TelegramBridge } from "../telegram/bridge.js";
+import { WorkflowStore } from "./workflows.js";
+import type { CronTrigger, EventTrigger } from "./workflows.js";
+import { WorkflowExecutor } from "./workflow-executor.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("WorkflowScheduler");
+
+const TICK_INTERVAL_MS = 60_000;
+
+export type WorkflowEventName = "agent.start" | "agent.stop" | "agent.error" | "tool.complete";
+
+export class WorkflowScheduler {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private store: WorkflowStore;
+
+  constructor(
+    private db: Database.Database,
+    private bridge?: TelegramBridge
+  ) {
+    this.store = new WorkflowStore(db);
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      void this.tick().catch((err) => {
+        log.warn({ err }, "Workflow scheduler tick failed");
+      });
+    }, TICK_INTERVAL_MS);
+    this.timer.unref?.();
+    log.info("Workflow scheduler started");
+  }
+
+  stop(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+    log.info("Workflow scheduler stopped");
+  }
+
+  async fireEvent(event: WorkflowEventName): Promise<void> {
+    const workflows = this.store.list();
+    const enabled = workflows.filter(
+      (w) =>
+        w.enabled &&
+        w.config.trigger.type === "event" &&
+        (w.config.trigger as EventTrigger).event === event
+    );
+    for (const wf of enabled) {
+      log.info({ workflowId: wf.id, event }, "Firing event workflow");
+      await this.execute(wf.id);
+    }
+  }
+
+  async handleWebhook(secret: string): Promise<boolean> {
+    const workflows = this.store.list();
+    const matching = workflows.filter(
+      (w) =>
+        w.enabled &&
+        w.config.trigger.type === "webhook" &&
+        (w.config.trigger as { type: "webhook"; secret?: string }).secret === secret
+    );
+    if (matching.length === 0) return false;
+    for (const wf of matching) {
+      log.info({ workflowId: wf.id }, "Firing webhook workflow");
+      await this.execute(wf.id);
+    }
+    return true;
+  }
+
+  private async tick(): Promise<void> {
+    const now = new Date();
+    const workflows = this.store.list();
+    const cronWorkflows = workflows.filter((w) => w.enabled && w.config.trigger.type === "cron");
+    for (const wf of cronWorkflows) {
+      const trigger = wf.config.trigger as CronTrigger;
+      if (cronMatches(trigger.cron, now)) {
+        log.info({ workflowId: wf.id, cron: trigger.cron }, "Firing cron workflow");
+        await this.execute(wf.id);
+      }
+    }
+  }
+
+  private async execute(workflowId: string): Promise<void> {
+    const wf = this.store.get(workflowId);
+    if (!wf) return;
+    const executor = new WorkflowExecutor({ store: this.store, bridge: this.bridge });
+    try {
+      await executor.execute(wf);
+    } catch (err) {
+      log.error({ err, workflowId }, "Workflow execution failed");
+    }
+  }
+}
+
+// ── Cron matching ─────────────────────────────────────────────────────────────
+
+function cronMatches(expr: string, date: Date): boolean {
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length !== 5) return false;
+
+  const [minuteF, hourF, domF, monthF, dowF] = parts;
+
+  const minute = date.getUTCMinutes();
+  const hour = date.getUTCHours();
+  const dom = date.getUTCDate();
+  const month = date.getUTCMonth() + 1; // 1-12
+  const dow = date.getUTCDay(); // 0=Sunday
+
+  return (
+    fieldMatches(minuteF, minute) &&
+    fieldMatches(hourF, hour) &&
+    fieldMatches(domF, dom) &&
+    fieldMatches(monthF, month) &&
+    (fieldMatches(dowF, dow) || fieldMatches(dowF, dow === 0 ? 7 : dow))
+  );
+}
+
+function fieldMatches(field: string, value: number): boolean {
+  if (field === "*") return true;
+
+  if (field.includes("/")) {
+    const [range, stepStr] = field.split("/");
+    const step = Number(stepStr);
+    if (!Number.isInteger(step) || step < 1) return false;
+    if (range === "*") return value % step === 0;
+    const start = Number(range);
+    if (!Number.isInteger(start)) return false;
+    return value >= start && (value - start) % step === 0;
+  }
+
+  if (field.includes(",")) {
+    return field.split(",").some((v) => fieldMatches(v, value));
+  }
+
+  if (field.includes("-")) {
+    const [startStr, endStr] = field.split("-");
+    const start = Number(startStr);
+    const end = Number(endStr);
+    return value >= start && value <= end;
+  }
+
+  return Number(field) === value;
+}

--- a/src/webui/routes/workflows.ts
+++ b/src/webui/routes/workflows.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { randomUUID } from "node:crypto";
 import type { WebUIServerDeps, APIResponse } from "../types.js";
 import { getWorkflowStore, type WorkflowConfig, type Workflow } from "../../services/workflows.js";
 import { getErrorMessage } from "../../utils/errors.js";
@@ -74,11 +75,16 @@ export function createWorkflowsRoutes(deps: WebUIServerDeps) {
           ? body.description.trim().slice(0, MAX_DESCRIPTION_LENGTH)
           : undefined;
 
+      const config = body.config;
+      if (config.trigger.type === "webhook" && !config.trigger.secret) {
+        config.trigger.secret = randomUUID().replace(/-/g, "");
+      }
+
       const wf = store().create({
         name,
         description,
         enabled: body.enabled !== false,
-        config: body.config,
+        config,
       });
 
       return c.json<APIResponse<Workflow>>({ success: true, data: wf }, 201);
@@ -176,6 +182,33 @@ export function createWorkflowsRoutes(deps: WebUIServerDeps) {
       const deleted = store().delete(c.req.param("id"));
       if (!deleted) {
         return c.json<APIResponse>({ success: false, error: "Workflow not found" }, 404);
+      }
+      return c.json<APIResponse<null>>({ success: true, data: null });
+    } catch (err) {
+      return c.json<APIResponse>({ success: false, error: getErrorMessage(err) }, 500);
+    }
+  });
+
+  // Webhook trigger endpoint — public, authenticated via secret token in URL
+  app.post("/webhook/:secret", async (c) => {
+    try {
+      const secret = c.req.param("secret");
+      const scheduler =
+        typeof deps.workflowScheduler === "function"
+          ? deps.workflowScheduler()
+          : deps.workflowScheduler;
+      if (!scheduler) {
+        return c.json<APIResponse>(
+          { success: false, error: "Workflow scheduler unavailable" },
+          503
+        );
+      }
+      const triggered = await scheduler.handleWebhook(secret);
+      if (!triggered) {
+        return c.json<APIResponse>(
+          { success: false, error: "No workflow found for this webhook" },
+          404
+        );
       }
       return c.json<APIResponse<null>>({ success: true, data: null });
     } catch (err) {

--- a/src/webui/types.ts
+++ b/src/webui/types.ts
@@ -9,6 +9,7 @@ import type { SDKDependencies } from "../sdk/index.js";
 import type { AgentLifecycle } from "../agent/lifecycle.js";
 import type { UserHookEvaluator } from "../agent/hooks/user-hook-evaluator.js";
 import type { AutonomousTaskManager } from "../autonomous/manager.js";
+import type { WorkflowScheduler } from "../services/workflow-scheduler.js";
 
 export interface LoadedPlugin {
   name: string;
@@ -47,6 +48,7 @@ export interface WebUIServerDeps {
   marketplace?: MarketplaceDeps;
   userHookEvaluator?: UserHookEvaluator | null;
   autonomousManager?: AutonomousTaskManager;
+  workflowScheduler?: (() => WorkflowScheduler | null) | WorkflowScheduler;
 }
 
 // ── Marketplace types ───────────────────────────────────────────────

--- a/web/src/pages/Workflows.tsx
+++ b/web/src/pages/Workflows.tsx
@@ -6,6 +6,7 @@ import type {
   WorkflowTrigger,
   WorkflowAction,
   CronTrigger,
+  WebhookTrigger,
   EventTrigger,
   SendMessageAction,
   CallApiAction,
@@ -28,7 +29,10 @@ function triggerLabel(trigger: WorkflowTrigger): string {
   if (trigger.type === "cron") {
     return (trigger as CronTrigger).label || `Cron: ${(trigger as CronTrigger).cron}`;
   }
-  if (trigger.type === "webhook") return "Webhook";
+  if (trigger.type === "webhook")
+    return (trigger as WebhookTrigger).secret
+      ? `Webhook (POST /api/workflows/webhook/${(trigger as WebhookTrigger).secret})`
+      : "Webhook";
   if (trigger.type === "event") return `Event: ${(trigger as EventTrigger).event}`;
   return "Unknown trigger";
 }
@@ -145,8 +149,9 @@ function TriggerEditor({
             fontSize: "13px",
           }}
         >
-          A unique webhook URL will be available at <code>/api/webhooks/&#123;id&#125;</code> once
-          saved.
+          A unique webhook URL will be available at{" "}
+          <code>/api/workflows/webhook/&#123;secret&#125;</code> once saved. POST to this URL to
+          trigger the workflow.
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Implements the missing workflow execution engine for the workflow automation system introduced in PR #106.

**Root cause**: The workflows UI and API were fully functional (CRUD, toggle, validation, persistence), but workflows were never actually executed — no scheduler, no cron matching, no event dispatching, no webhook receiver existed.

### What was added

- **`WorkflowExecutor`** (`src/services/workflow-executor.ts`): Executes workflow action chains — `send_message` (via TelegramBridge), `call_api` (via `fetch`), `set_variable` (with `{{variable}}` interpolation). Records run count and last error in the database.

- **`WorkflowScheduler`** (`src/services/workflow-scheduler.ts`): Drives workflow execution:
  - **Cron**: minute-tick interval checks active cron workflows against current UTC time (no external cron library needed)
  - **Events**: `fireEvent("agent.start" | "agent.stop" | "tool.complete")` dispatches to matching enabled workflows
  - **Webhooks**: `handleWebhook(secret)` matches and fires the workflow with that secret token

- **Wired into app lifecycle** (`src/index.ts`): Scheduler starts/stops with the agent; `agent.start` and `agent.stop` events fire automatically; `tool.complete` fires via `setOnToolCompleteCallback` on `AgentRuntime`

- **Webhook endpoint** (`POST /api/workflows/webhook/:secret`): External systems can trigger webhook workflows by POST-ing to this URL

- **Auto-generated webhook secrets**: When creating a webhook-triggered workflow, the backend auto-generates a random 32-char hex secret if one isn't provided

- **Fixed frontend webhook URL**: Was showing `/api/webhooks/{id}` (wrong path); now shows the correct `/api/workflows/webhook/{secret}` URL in the workflow details

## Test plan

- [x] All 139 existing tests pass (0 regressions)
- [x] 15 new unit tests covering WorkflowExecutor and WorkflowScheduler:
  - Cron tick fires matching workflows, skips non-matching times
  - `fireEvent` dispatches to enabled event workflows, skips disabled/mismatched
  - `handleWebhook` fires by secret, returns false for unknown secrets
  - `send_message` with/without bridge, variable interpolation
  - `recordRun` called with error details on failure


Fixes xlabtg/teleton-agent#242