### PR TITLE
fix(memory): detect Upstash vector dimension mismatch

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-21T23:15:37.280Z for PR creation at branch issue-242-aaa23d0a8190 for issue https://github.com/xlabtg/teleton-agent/issues/242
+# Updated: 2026-04-22T01:46:49.972Z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Prediction engine**: Behavior event tracking, Markov-style next-action predictions, topic-to-tool suggestions, WebUI prediction APIs, and dashboard suggestions with feedback.
 - **`web_download_binary` tool**: Download public HTTP(S) binary files into workspace `downloads/` with MIME validation, a 10 MB size cap, redirect support, and optional request headers for authorized URLs.
 
+### Fixed
+- **Vector memory sync**: Detect Upstash Vector index/embedding dimension mismatches before upsert, surface the configured index dimension in semantic memory status and sync responses, and log an actionable warning at startup (closes xlabtg/teleton-agent#246).
+
 ## [0.8.1] - 2026-03-05
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teleton",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teleton",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teleton",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "workspaces": [
     "packages/*"
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -574,7 +574,21 @@ ${blue}  ┌──────────────────────�
     if (this.memory.embedder.warmup) {
       await this.memory.embedder.warmup();
     }
-    await this.memory.vectorStore.logStatus();
+    const vectorStatus = await this.memory.vectorStore.logStatus();
+    if (
+      vectorStatus.mode === "online" &&
+      typeof vectorStatus.indexDimension === "number" &&
+      vectorStatus.indexDimension > 0 &&
+      this.memory.embedder.dimensions > 0 &&
+      vectorStatus.indexDimension !== this.memory.embedder.dimensions
+    ) {
+      log.warn(
+        `Semantic Memory: embedding dimension ${this.memory.embedder.dimensions} ` +
+          `(${this.memory.embedder.id}/${this.memory.embedder.model}) does not match ` +
+          `Upstash Vector index dimension ${vectorStatus.indexDimension}. Upstash will reject ` +
+          `vector upserts. Reprovision the index or switch the embedding provider to align dimensions.`
+      );
+    }
 
     // Index knowledge base (MEMORY.md, memory/*.md)
     // Force re-index if embedding dimensions changed (model switch)

--- a/src/memory/__tests__/semantic-vector-memory.test.ts
+++ b/src/memory/__tests__/semantic-vector-memory.test.ts
@@ -168,8 +168,63 @@ describe("Semantic vector memory", () => {
     expect(result.semantic.upserted).toBe(0);
     expect(result.semantic.failed).toBe(1);
     expect(result.semantic.errors.join("\n")).toContain("dimension mismatch");
+    expect(result.semantic.errors.join("\n")).toMatch(/reprovision the Upstash index/i);
 
     rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("detects Upstash index dimension mismatch before attempting upsert", async () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), "teleton-memory-"));
+    const memoryFile = join(workspaceDir, "MEMORY.md");
+    writeFileSync(memoryFile, "# Memory\n\nRemember the 10% rule for conservative risk.");
+
+    // Local all-MiniLM-L6-v2 produces 384-dim vectors; the user's Upstash
+    // index is configured for 768. Repro for issue #246.
+    const embedder = makeEmbedder(new Array(384).fill(0.001));
+    const upsertKnowledge = vi.fn().mockResolvedValue(undefined);
+    const vectorStore = makeSemanticStore({
+      healthCheck: vi.fn().mockResolvedValue({ mode: "online", indexDimension: 768 }),
+      upsertKnowledge,
+    });
+    const indexer = new KnowledgeIndexer(db, workspaceDir, embedder, false, vectorStore);
+
+    const result = await indexer.indexAll();
+
+    expect(result.indexed).toBe(1);
+    expect(result.semantic.upserted).toBe(0);
+    expect(result.semantic.failed).toBe(1);
+    expect(upsertKnowledge).not.toHaveBeenCalled();
+    const message = result.semantic.errors.join("\n");
+    expect(message).toContain("384");
+    expect(message).toContain("768");
+    expect(message).toMatch(/dimension/i);
+
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("surfaces the Upstash index dimension in the semantic memory status", async () => {
+    const upstashInfoPayload = {
+      vectorCount: 42,
+      pendingVectorCount: 0,
+      indexSize: 0,
+      dimension: 768,
+      similarityFunction: "COSINE" as const,
+      namespaces: {},
+    };
+    const store = new UpstashSemanticVectorStore({
+      url: "https://steady-fox-123.upstash.io",
+      token: "upstash-token-12345",
+    });
+
+    // Swap in a stubbed Upstash index to avoid live HTTP.
+    const fakeIndex = { info: vi.fn().mockResolvedValue(upstashInfoPayload) };
+    (store as unknown as { index: typeof fakeIndex }).index = fakeIndex;
+
+    const status = await store.healthCheck();
+
+    expect(status.mode).toBe("online");
+    expect(status.indexDimension).toBe(768);
+    expect(fakeIndex.info).toHaveBeenCalled();
   });
 
   it("reports semantic vector sync failures when embeddings are disabled", async () => {

--- a/src/memory/agent/knowledge.ts
+++ b/src/memory/agent/knowledge.ts
@@ -76,8 +76,10 @@ export class KnowledgeIndexer {
     let skipped = 0;
     const semantic = emptySemanticStats();
 
+    const indexDimension = await this.resolveIndexDimension();
+
     for (const file of files) {
-      const result = await this.indexFile(file, options?.force);
+      const result = await this.indexFile(file, options?.force, indexDimension);
       addSemanticStats(semantic, result.semantic);
       if (result.indexed) {
         indexed++;
@@ -89,7 +91,11 @@ export class KnowledgeIndexer {
     return { indexed, skipped, semantic };
   }
 
-  async indexFile(absPath: string, force?: boolean): Promise<KnowledgeFileIndexResult> {
+  async indexFile(
+    absPath: string,
+    force?: boolean,
+    indexDimension?: number
+  ): Promise<KnowledgeFileIndexResult> {
     if (!existsSync(absPath) || !absPath.endsWith(".md")) {
       return { indexed: false, semantic: emptySemanticStats() };
     }
@@ -157,15 +163,35 @@ export class KnowledgeIndexer {
       }
     })();
 
+    const resolvedIndexDimension = indexDimension ?? (await this.resolveIndexDimension());
+
     const semantic = await this.syncSemanticVectorStore(
       relPath,
       fileHash,
       existingIds,
       chunks,
-      embeddings
+      embeddings,
+      resolvedIndexDimension
     );
 
     return { indexed: true, semantic };
+  }
+
+  /**
+   * Ask Upstash Vector for the index's configured dimension so we can
+   * short-circuit upserts that would be rejected with a 400 dimension error.
+   * Returns undefined if the store is absent, misconfigured, or unreachable
+   * (the upsert path still catches the real error in that case).
+   */
+  private async resolveIndexDimension(): Promise<number | undefined> {
+    const store = this.semanticVectorStore;
+    if (!store?.isConfigured) return undefined;
+    try {
+      const status = await store.healthCheck();
+      return status.indexDimension;
+    } catch {
+      return undefined;
+    }
   }
 
   private getExistingChunkIds(relPath: string): string[] {
@@ -197,7 +223,8 @@ export class KnowledgeIndexer {
     fileHash: string,
     oldIds: string[],
     chunks: KnowledgeChunk[],
-    embeddings: number[][]
+    embeddings: number[][],
+    indexDimension?: number
   ): Promise<SemanticVectorIndexStats> {
     const stats = emptySemanticStats();
     const store = this.semanticVectorStore;
@@ -235,6 +262,38 @@ export class KnowledgeIndexer {
       return stats;
     }
 
+    // Upstash rejects an upsert when the vector length does not match the
+    // dimension the index was provisioned with. Detect the mismatch here
+    // so the error points at the configuration instead of a cryptic 400
+    // buried inside the SDK.
+    const embeddingDimension = vectors[0]?.vector.length ?? this.embedder.dimensions;
+    if (
+      typeof indexDimension === "number" &&
+      indexDimension > 0 &&
+      embeddingDimension > 0 &&
+      embeddingDimension !== indexDimension
+    ) {
+      stats.failed = 1;
+      stats.skipped += vectors.length;
+      const message =
+        `${relPath}: Embedding dimension ${embeddingDimension} (${this.embedder.id}/${this.embedder.model}) ` +
+        `does not match Upstash Vector index dimension ${indexDimension}. ` +
+        `Reprovision the index with dimension ${embeddingDimension}, or switch the embedding ` +
+        `provider/model so it produces ${indexDimension}-dim vectors.`;
+      stats.errors.push(message);
+      log.warn(
+        {
+          path: relPath,
+          embeddingDimension,
+          indexDimension,
+          provider: this.embedder.id,
+          model: this.embedder.model,
+        },
+        "Semantic memory sync aborted: embedding/index dimension mismatch"
+      );
+      return stats;
+    }
+
     try {
       await store.upsertKnowledge(vectors);
       stats.upserted = vectors.length;
@@ -253,7 +312,11 @@ export class KnowledgeIndexer {
       this.setSemanticMigrationHash(relPath, fileHash);
     } catch (error) {
       stats.failed++;
-      stats.errors.push(`${relPath}: ${getErrorMessage(error)}`);
+      const baseMessage = getErrorMessage(error);
+      const hint = /dimension/i.test(baseMessage)
+        ? ` Embedding provider ${this.embedder.id}/${this.embedder.model} produces ${embeddingDimension}-dim vectors; reprovision the Upstash index with a matching dimension or switch providers.`
+        : "";
+      stats.errors.push(`${relPath}: ${baseMessage}${hint}`);
       log.warn({ err: error, path: relPath }, "Semantic memory sync failed; local fallback ready");
     }
 

--- a/src/memory/vector-store.ts
+++ b/src/memory/vector-store.ts
@@ -11,6 +11,8 @@ export interface SemanticMemoryStatus {
   reason?: string;
   vectorCount?: number;
   pendingVectorCount?: number;
+  /** Dimension the Upstash index was provisioned with (reported by /info). */
+  indexDimension?: number;
 }
 
 export type SemanticMemoryMetadata = Record<string, unknown> & {
@@ -139,6 +141,7 @@ export class UpstashSemanticVectorStore implements SemanticVectorStore {
         mode: "online",
         vectorCount: info.vectorCount,
         pendingVectorCount: info.pendingVectorCount,
+        indexDimension: typeof info.dimension === "number" ? info.dimension : undefined,
       };
     } catch (error) {
       return {
@@ -153,8 +156,9 @@ export class UpstashSemanticVectorStore implements SemanticVectorStore {
     if (status.mode !== this.lastLoggedMode) {
       this.lastLoggedMode = status.mode;
       if (status.mode === "online") {
+        const dim = status.indexDimension ? `, dimension=${status.indexDimension}` : "";
         log.info(
-          `Semantic Memory: Online (Upstash Vector, namespace=${this.namespace}, vectors=${status.vectorCount ?? 0})`
+          `Semantic Memory: Online (Upstash Vector, namespace=${this.namespace}, vectors=${status.vectorCount ?? 0}${dim})`
         );
       } else if (status.mode === "standby") {
         log.info(

--- a/src/webui/__tests__/memory-routes.test.ts
+++ b/src/webui/__tests__/memory-routes.test.ts
@@ -116,6 +116,51 @@ describe("memory routes", () => {
     expect(json.data.message).toContain("No vectors were uploaded");
   });
 
+  it("explains vector dimension mismatch in the sync-vector response", async () => {
+    const indexAll = vi.fn().mockResolvedValue({
+      indexed: 1,
+      skipped: 0,
+      semantic: {
+        upserted: 0,
+        deleted: 0,
+        skipped: 3,
+        failed: 1,
+        errors: [
+          "MEMORY.md: Embedding dimension 384 (local/Xenova/all-MiniLM-L6-v2) does not match Upstash Vector index dimension 768. Reprovision the index with dimension 384, or switch the embedding provider/model so it produces 768-dim vectors.",
+        ],
+      },
+    });
+    const healthCheck = vi
+      .fn()
+      .mockResolvedValueOnce({ mode: "online", vectorCount: 0, indexDimension: 768 })
+      .mockResolvedValueOnce({ mode: "online", vectorCount: 0, indexDimension: 768 });
+
+    const app = createTestApp({
+      memory: {
+        db: {} as WebUIServerDeps["memory"]["db"],
+        embedder: {} as WebUIServerDeps["memory"]["embedder"],
+        knowledge: { indexAll } as unknown as WebUIServerDeps["memory"]["knowledge"],
+        vectorStore: {
+          isConfigured: true,
+          namespace: "teleton-memory",
+          healthCheck,
+        } as unknown as WebUIServerDeps["memory"]["vectorStore"],
+      },
+    });
+
+    const res = await app.request("/api/memory/sync-vector", { method: "POST" });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.synced).toBe(false);
+    expect(json.data.vectorsUpserted).toBe(0);
+    expect(json.data.status.indexDimension).toBe(768);
+    expect(json.data.message).toMatch(/dimension mismatch/i);
+    expect(json.data.vectorErrors[0]).toContain("384");
+    expect(json.data.vectorErrors[0]).toContain("768");
+  });
+
   it("keeps local memory active and skips vector sync when Upstash is not configured", async () => {
     const indexAll = vi.fn();
     const healthCheck = vi.fn().mockResolvedValue({

--- a/src/webui/routes/memory.ts
+++ b/src/webui/routes/memory.ts
@@ -52,6 +52,9 @@ function vectorSyncMessage(params: {
     if (indexed === 0 && skipped === 0) {
       return "No memory files were found to upload to Upstash Vector.";
     }
+    if (semantic.errors.some((err) => /dimension/i.test(err))) {
+      return `No vectors were uploaded to Upstash Vector because of an embedding dimension mismatch. Align the embedding provider with the Upstash index dimension.${firstError}`;
+    }
     return `No vectors were uploaded to Upstash Vector. Check that memory files contain content and embeddings are enabled.${firstError}`;
   }
   if (semantic.failed > 0) {

--- a/src/webui/types.ts
+++ b/src/webui/types.ts
@@ -173,6 +173,7 @@ export interface SemanticMemoryStatusInfo {
   reason?: string;
   vectorCount?: number;
   pendingVectorCount?: number;
+  indexDimension?: number;
 }
 
 export interface MemoryVectorSyncResult {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -354,6 +354,7 @@ export interface SemanticMemoryStatusInfo {
   reason?: string;
   vectorCount?: number;
   pendingVectorCount?: number;
+  indexDimension?: number;
 }
 
 export interface MemoryVectorSyncResult {


### PR DESCRIPTION
## Summary

Fixes xlabtg/teleton-agent#246.

Upstash Vector rejects every upsert when the embedding length does not match the dimension the index was provisioned with (`Invalid vector dimension: 384, expected: 768`). After #227 and #235 the WebUI reported `No vectors were uploaded to Upstash Vector`, but the root cause — an index/embedding dimension mismatch — was buried in the raw SDK error and not surfaced in a way operators could act on. The Upstash dashboard showed "requests" (each rejected upsert counts as a request) but no vector updates, which matches the behavior described in the issue.

This PR closes the visibility gap and stops the sync early with an actionable message.

## What Changed

- `UpstashSemanticVectorStore.healthCheck()` reads `dimension` from the Upstash `info` response and exposes it on `SemanticMemoryStatus.indexDimension`.
- `logStatus()` now includes the index dimension when online, so the startup log shows both the namespace and the dimension the live index expects.
- On startup, `Teleton` compares the live embedding provider's `dimensions` to the reported index dimension and logs a clear `warn` (with remediation: reprovision or switch provider) when they disagree.
- `KnowledgeIndexer` resolves the index dimension once per `indexAll()` and short-circuits each file's semantic sync with a failure + remediation message when the embedding dimension does not match. The error includes both dimensions, the provider id, and the model.
- When Upstash still surfaces a "dimension" error from the SDK (e.g. the health check was unavailable), we append the same remediation hint to the caught error so the first entry in `vectorErrors` points at the fix.
- `POST /api/memory/sync-vector` returns the new `indexDimension` on `status` and produces a distinct "dimension mismatch" top-level message when every vector failed for that reason.
- Web API types (`web/src/lib/api.ts`, `src/webui/types.ts`) carry the new field through to the UI.
- `package.json` / `package-lock.json` bumped to `0.8.9`; CHANGELOG entry added under Unreleased → Fixed.

## How To Reproduce The Old Behavior

1. Provision an Upstash Vector index with dimension 768 (e.g. via the Upstash console default for a bge-style embedding model).
2. Leave the embedding provider on the default `local` + `Xenova/all-MiniLM-L6-v2` (384 dim).
3. Open WebUI → Memory → Sync Vector.
4. Before this PR: the response said vectors were not uploaded but gave no direction. Upstash dashboard showed growing request count and zero vector updates, matching `C:\Users\User\.teleton\workspace\MEMORY.md: Invalid vector dimension: 384, expected: 768`.
5. After this PR: the response message is `No vectors were uploaded to Upstash Vector because of an embedding dimension mismatch. Align the embedding provider with the Upstash index dimension.` and `vectorErrors[0]` reads `MEMORY.md: Embedding dimension 384 (local/Xenova/all-MiniLM-L6-v2) does not match Upstash Vector index dimension 768. Reprovision the index with dimension 384, or switch the embedding provider/model so it produces 768-dim vectors.`. `status.indexDimension` is `768`. A `warn` is also emitted at startup.

## Automated Coverage

- `src/memory/__tests__/semantic-vector-memory.test.ts`
  - `detects Upstash index dimension mismatch before attempting upsert` — reproduces the 384/768 scenario from the issue; asserts `upsertKnowledge` is never called and the error names both dimensions.
  - `surfaces the Upstash index dimension in the semantic memory status` — health check populates `indexDimension` from the Upstash `info` payload.
  - Existing `reports semantic vector sync failures when Upstash rejects an upsert` now also asserts the remediation hint is appended.
- `src/webui/__tests__/memory-routes.test.ts`
  - `explains vector dimension mismatch in the sync-vector response` — asserts the sync endpoint surfaces `status.indexDimension` and the specific top-level message.

## Verification

- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test` — 139 files / 2930 tests pass
- `npm run build`