### PR TITLE
fix(autonomous): restrict real TON wallet tools by name (AUDIT-C1)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-21T23:15:37.280Z for PR creation at branch issue-242-aaa23d0a8190 for issue https://github.com/xlabtg/teleton-agent/issues/242
 # Updated: 2026-04-22T01:46:49.972Z
 # Updated: 2026-04-22T04:22:46.159Z
+# Updated: 2026-04-22T19:49:36.488Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-21T23:15:37.280Z for PR creation at branch issue-242-aaa23d0a8190 for issue https://github.com/xlabtg/teleton-agent/issues/242
 # Updated: 2026-04-22T01:46:49.972Z
 # Updated: 2026-04-22T04:22:46.159Z
-# Updated: 2026-04-22T19:49:36.488Z

--- a/docs/AUTONOMOUS_MODE.md
+++ b/docs/AUTONOMOUS_MODE.md
@@ -86,7 +86,7 @@ Higher priority tasks are queued first when the agent restarts.
     "maxIterations": 100,
     "maxDurationHours": 4,
     "allowedTools": ["web_fetch", "exec_run", "telegram_send_message"],
-    "restrictedTools": ["wallet:send"],
+    "restrictedTools": ["ton_send", "jetton_send"],
     "budgetTON": 0.5
   },
   "strategy": "balanced",

--- a/src/autonomous/__tests__/loop.test.ts
+++ b/src/autonomous/__tests__/loop.test.ts
@@ -97,7 +97,7 @@ describe("AutonomousLoop", () => {
   it("pauses and escalates when policy requires escalation", async () => {
     const deps = makeDeps({
       planNextAction: vi.fn().mockResolvedValue({
-        toolName: "wallet:send",
+        toolName: "ton_send",
         params: { amount: 0.6 },
         tonAmount: 0.6, // above confirmation threshold (0.5 TON) but below perTask budget (1 TON)
       }),

--- a/src/autonomous/__tests__/policy-engine.test.ts
+++ b/src/autonomous/__tests__/policy-engine.test.ts
@@ -98,9 +98,30 @@ describe("PolicyEngine", () => {
 
   it("requires escalation for globally restricted tools", () => {
     const task = makeTask();
-    const result = engine.checkAction(task, { toolName: "wallet:send" });
+    const result = engine.checkAction(task, { toolName: "ton_send" });
 
     expect(result.requiresEscalation).toBe(true);
+  });
+
+  it("requires escalation for every real TON wallet tool in the default config", () => {
+    const task = makeTask();
+
+    for (const toolName of ["ton_send", "jetton_send", "exec", "exec_run"]) {
+      const result = engine.checkAction(task, { toolName });
+      expect(result.requiresEscalation, `expected ${toolName} to escalate`).toBe(true);
+    }
+  });
+
+  it("uses real tool names in DEFAULT_POLICY_CONFIG.restrictedTools (no placeholder names)", () => {
+    // Regression test for AUDIT-C1: placeholder names like "wallet:send"
+    // would silently bypass the escalation gate because no registered tool
+    // uses those names.
+    expect(DEFAULT_POLICY_CONFIG.restrictedTools).toEqual(
+      expect.arrayContaining(["ton_send", "jetton_send"])
+    );
+    expect(DEFAULT_POLICY_CONFIG.restrictedTools).not.toContain("wallet:send");
+    expect(DEFAULT_POLICY_CONFIG.restrictedTools).not.toContain("contract:deploy");
+    expect(DEFAULT_POLICY_CONFIG.restrictedTools).not.toContain("system:exec");
   });
 
   it("requires escalation for task-level restricted tools", () => {
@@ -118,14 +139,14 @@ describe("PolicyEngine", () => {
     const task = makeTask({
       constraints: { budgetTON: 0.5 },
     });
-    const result = engine.checkAction(task, { toolName: "wallet:send", tonAmount: 1.0 });
+    const result = engine.checkAction(task, { toolName: "ton_send", tonAmount: 1.0 });
 
     expect(result.violations.some((v) => v.type === "budget_exceeded")).toBe(true);
   });
 
   it("requires escalation for TON above confirmation threshold", () => {
     const task = makeTask();
-    const result = engine.checkAction(task, { toolName: "wallet:send", tonAmount: 0.6 });
+    const result = engine.checkAction(task, { toolName: "ton_send", tonAmount: 0.6 });
 
     expect(result.requiresEscalation).toBe(true);
   });

--- a/src/autonomous/policy-engine.ts
+++ b/src/autonomous/policy-engine.ts
@@ -31,7 +31,7 @@ export const DEFAULT_POLICY_CONFIG: PolicyConfig = {
     daily: 5,
     requireConfirmationAbove: 0.5,
   },
-  restrictedTools: ["wallet:send", "contract:deploy", "system:exec"],
+  restrictedTools: ["ton_send", "jetton_send", "exec", "exec_run"],
   requireHumanApproval: "above-threshold",
   uncertainty: {
     threshold: 0.7,

--- a/web/src/pages/Autonomous.tsx
+++ b/web/src/pages/Autonomous.tsx
@@ -440,7 +440,7 @@ function CreateTaskForm({ onCreated, onCancel }: { onCreated: () => void; onCanc
           <textarea
             value={form.restrictedTools}
             onChange={(e) => update("restrictedTools", e.target.value)}
-            placeholder={"wallet:send\ncontract:deploy"}
+            placeholder={"ton_send\njetton_send"}
             rows={2}
             style={{ width: "100%", resize: "vertical" }}
           />


### PR DESCRIPTION
## Summary

Fixes #252 (AUDIT-C1 — critical).

`DEFAULT_POLICY_CONFIG.restrictedTools` used placeholder names (`wallet:send`, `contract:deploy`, `system:exec`) that no registered tool ever uses. As a result `PolicyEngine.checkAction()` never matched a real TON tool and never set `requiresEscalation`, so autonomous tasks could call `ton_send` / `jetton_send` without human confirmation up to the TON budget — bypassing the human-in-the-loop safeguard on real funds.

## Changes

- `src/autonomous/policy-engine.ts`: replace placeholder names with the registered tool names — `["ton_send", "jetton_send", "exec", "exec_run"]`.
- `src/autonomous/__tests__/policy-engine.test.ts`:
  - update existing escalation/budget tests to use a tool name that is actually on the blacklist (`ton_send`);
  - add a regression test that iterates over every default restricted tool and asserts `requiresEscalation` is set;
  - add a regression test asserting `DEFAULT_POLICY_CONFIG.restrictedTools` contains `ton_send`/`jetton_send` and no longer contains the old placeholder names.
- `src/autonomous/__tests__/loop.test.ts`: switch the loop escalation test to `ton_send` so the blacklist path is exercised end-to-end.
- `docs/AUTONOMOUS_MODE.md` and `web/src/pages/Autonomous.tsx`: update user-facing examples/placeholders to real tool names.

## How to reproduce the bug (before this PR)

```ts
import { PolicyEngine, DEFAULT_POLICY_CONFIG } from "./policy-engine.js";

const engine = new PolicyEngine(DEFAULT_POLICY_CONFIG);
const task = /* an AutonomousTask with default constraints */;

engine.checkAction(task, { toolName: "ton_send" }).requiresEscalation;
// → false   ❌ should be true
engine.checkAction(task, { toolName: "jetton_send" }).requiresEscalation;
// → false   ❌ should be true
```

After this PR both return `true`.

## Acceptance criteria from #252

- [x] Root cause fixed — `DEFAULT_POLICY_CONFIG.restrictedTools` now lists real registered tool names.
- [x] Regression unit test added: `ton_send` and `jetton_send` trigger escalation.
- [x] Loop-level test: `AutonomousLoop` test exercises the blacklist path with a real tool name (`ton_send`) → task pauses with `requiresEscalation`.
- [x] Docs updated (`docs/AUTONOMOUS_MODE.md`, web UI placeholder).
- [x] `npm run lint`, `npm run typecheck`, `npm run format:check`, `npm test` all green (2932 tests).

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] `npm test` — 139 files, 2932 tests pass

## Notes for reviewer

Long-term follow-up proposed in the issue — tagging tools by category (e.g. `tool.category = "wallet_write"`) and matching on category rather than exact name — is intentionally out of scope for this fix and should be filed as a separate issue to avoid delaying the security fix.