### PR TITLE
fix(autonomous): stop task loops on agent shutdown (AUDIT-C2)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-21T23:15:37.280Z for PR creation at branch issue-242-aaa23d0a8190 for issue https://github.com/xlabtg/teleton-agent/issues/242
 # Updated: 2026-04-22T01:46:49.972Z
 # Updated: 2026-04-22T04:22:46.159Z
+# Updated: 2026-04-22T19:53:43.537Z

--- a/src/autonomous/__tests__/manager.test.ts
+++ b/src/autonomous/__tests__/manager.test.ts
@@ -94,4 +94,99 @@ describe("AutonomousTaskManager", () => {
     expect(restored).toBe(1);
     expect(manager.isTaskRunning(wip.id)).toBe(true);
   });
+
+  describe("stopAllAndWait() — AUDIT-C2 shutdown leak", () => {
+    /**
+     * Build deps whose `planNextAction` blocks on a caller-controlled promise.
+     * Lets tests hold the loop in a predictable "running, waiting on the
+     * planner" state and then release the in-flight step after stop() — the
+     * exact shape of the shutdown race described in AUDIT-C2.
+     */
+    function gatedDeps(gate: Promise<unknown>): LoopDependencies {
+      return {
+        planNextAction: vi.fn().mockImplementation(async () => {
+          await gate;
+          return { toolName: "noop", params: {}, reasoning: "drain", confidence: 1 };
+        }),
+        executeTool: vi.fn().mockResolvedValue({ success: true, durationMs: 1 }),
+        evaluateSuccess: vi.fn().mockResolvedValue(false),
+        selfReflect: vi.fn().mockResolvedValue({ progressSummary: "", isStuck: false }),
+        escalate: vi.fn().mockResolvedValue(undefined),
+      };
+    }
+
+    it("waits for in-flight loop promises to settle before resolving", async () => {
+      let release: ((v: unknown) => void) | undefined;
+      const gate = new Promise((r) => {
+        release = r;
+      });
+      const localManager = new AutonomousTaskManager(db, gatedDeps(gate));
+
+      const task1 = await localManager.startTask({ goal: "Task 1" });
+      const task2 = await localManager.startTask({ goal: "Task 2" });
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(localManager.isTaskRunning(task1.id)).toBe(true);
+      expect(localManager.isTaskRunning(task2.id)).toBe(true);
+
+      // Start shutdown, then release the in-flight planner so the loop
+      // wakes up, sees the abort signal, and its `.finally()` runs.
+      const stopPromise = localManager.stopAllAndWait();
+      release?.(undefined);
+      await stopPromise;
+
+      expect(localManager.isTaskRunning(task1.id)).toBe(false);
+      expect(localManager.isTaskRunning(task2.id)).toBe(false);
+      expect(localManager.getRunningTaskIds()).toHaveLength(0);
+    });
+
+    it("no SQLite writes happen after stopAllAndWait() resolves — safe to close the DB", async () => {
+      const localDb = new Database(":memory:");
+      localDb.pragma("foreign_keys = ON");
+      ensureSchema(localDb);
+
+      let release: ((v: unknown) => void) | undefined;
+      const gate = new Promise((r) => {
+        release = r;
+      });
+      const localManager = new AutonomousTaskManager(localDb, gatedDeps(gate));
+
+      await localManager.startTask({ goal: "Shutdown-race test" });
+      await new Promise((r) => setTimeout(r, 20));
+
+      const stopPromise = localManager.stopAllAndWait();
+      // Release the in-flight planner *after* stop() — the loop must not
+      // continue writing to the DB once abort has been observed.
+      release?.(undefined);
+      await stopPromise;
+
+      // Closing the DB must not throw; no async loop iteration should be
+      // trying to write after stopAllAndWait() resolved.
+      expect(() => localDb.close()).not.toThrow();
+    });
+
+    it("restart scenario: after stopAllAndWait() the old loop is gone", async () => {
+      let release1: ((v: unknown) => void) | undefined;
+      const gate1 = new Promise((r) => {
+        release1 = r;
+      });
+      const localManager = new AutonomousTaskManager(db, gatedDeps(gate1));
+
+      const first = await localManager.startTask({ goal: "Old cycle" });
+      await new Promise((r) => setTimeout(r, 20));
+      expect(localManager.isTaskRunning(first.id)).toBe(true);
+
+      const stopPromise = localManager.stopAllAndWait();
+      release1?.(undefined);
+      await stopPromise;
+
+      // Old loop is fully drained — running map is empty.
+      expect(localManager.getRunningTaskIds()).toHaveLength(0);
+      expect(localManager.isTaskRunning(first.id)).toBe(false);
+    });
+
+    it("is a no-op when no loops are running", async () => {
+      await expect(manager.stopAllAndWait()).resolves.toBeUndefined();
+    });
+  });
 });

--- a/src/autonomous/manager.ts
+++ b/src/autonomous/manager.ts
@@ -38,6 +38,7 @@ export interface CreateTaskInput {
 export class AutonomousTaskManager {
   private store: AutonomousTaskStore;
   private runningLoops = new Map<string, AutonomousLoop>();
+  private loopCompletions = new Map<string, Promise<void>>();
   private config: Required<AutonomousManagerConfig>;
   private loopDeps: LoopDependencies;
 
@@ -85,7 +86,10 @@ export class AutonomousTaskManager {
     const loop = new AutonomousLoop(this.store, this.loopDeps, this.config.policyConfig);
     this.runningLoops.set(task.id, loop);
 
-    loop
+    // Use a composite key so pause/resume (which replaces the runningLoops
+    // entry) still tracks each loop individually for stopAllAndWait().
+    const completionKey = `${task.id}:${Date.now()}:${Math.random()}`;
+    const completion = loop
       .run(task)
       .then((result: LoopResult) => {
         log.info({ taskId: task.id, result }, "Autonomous loop finished");
@@ -99,7 +103,10 @@ export class AutonomousTaskManager {
         if (this.runningLoops.get(task.id) === loop) {
           this.runningLoops.delete(task.id);
         }
+        this.loopCompletions.delete(completionKey);
       });
+
+    this.loopCompletions.set(completionKey, completion);
   }
 
   /** Pause a running task. */
@@ -144,6 +151,20 @@ export class AutonomousTaskManager {
       loop.stop();
     }
     this.runningLoops.clear();
+  }
+
+  /**
+   * Request stop on all running loops and wait for their in-flight steps to
+   * finish. Resolves once every loop's `.finally` handler has run so the
+   * caller can safely close the database without racing a pending write.
+   */
+  async stopAllAndWait(): Promise<void> {
+    const pending = Array.from(this.loopCompletions.values());
+    this.stopAll();
+    if (pending.length === 0) return;
+    // Completions are built from `.then().catch().finally()` chains and never
+    // reject, but guard against that anyway so shutdown always resolves.
+    await Promise.allSettled(pending);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ export class TeletonApp {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private heartbeatRunning = false;
   private workflowScheduler: WorkflowScheduler | null = null;
+  private autonomousManager: AutonomousTaskManager | null = null;
 
   private configPath: string;
 
@@ -330,10 +331,11 @@ ${blue}  ┌──────────────────────�
     );
 
     // Shared manager so WebUI and Management API drive the same task queue.
-    let autonomousManager: AutonomousTaskManager | undefined;
+    // Stored on the instance so stopAgent() can halt its loops — otherwise
+    // autonomous tasks keep writing to SQLite after shutdown (AUDIT-C2).
     if (this.config.webui.enabled || this.config.api?.enabled) {
       const { createAutonomousManager } = await import("./autonomous/integration.js");
-      autonomousManager = createAutonomousManager({
+      this.autonomousManager = createAutonomousManager({
         agent: this.agent,
         toolRegistry: this.toolRegistry,
         bridge: this.bridge,
@@ -341,7 +343,7 @@ ${blue}  ┌──────────────────────�
       });
       // Resume tasks that were "running" when the agent last stopped so a
       // server restart doesn't leave them stuck forever.
-      autonomousManager.restoreInterruptedTasks().catch((err: unknown) => {
+      this.autonomousManager.restoreInterruptedTasks().catch((err: unknown) => {
         log.warn({ err }, "Failed to restore interrupted autonomous tasks");
       });
     }
@@ -373,7 +375,7 @@ ${blue}  ┌──────────────────────�
             rewireHooks: () => this.wirePluginEventHooks(),
           },
           userHookEvaluator: this.userHookEvaluator,
-          autonomousManager,
+          autonomousManager: this.autonomousManager ?? undefined,
           workflowScheduler: () => this.workflowScheduler,
         });
         await this.webuiServer.start();
@@ -411,7 +413,7 @@ ${blue}  ┌──────────────────────�
               rewireHooks: () => this.wirePluginEventHooks(),
             },
             userHookEvaluator: this.userHookEvaluator,
-            autonomousManager,
+            autonomousManager: this.autonomousManager,
             workflowScheduler: () => this.workflowScheduler,
           },
           this.config.api
@@ -1572,6 +1574,16 @@ ${blue}  ┌──────────────────────�
         await mod.stop?.();
       } catch (e) {
         log.error({ err: e }, `⚠️ Module "${mod.name}" stop failed`);
+      }
+    }
+
+    // Drain autonomous task loops before bridge/DB are torn down so their
+    // in-flight SQLite writes don't race a closed database (AUDIT-C2).
+    if (this.autonomousManager) {
+      try {
+        await this.autonomousManager.stopAllAndWait();
+      } catch (e) {
+        log.error({ err: e }, "⚠️ Autonomous manager stop failed");
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes xlabtg/teleton-agent#254 (AUDIT-C2).

`AutonomousTaskManager` was a local variable inside `TeletonApp.start()`,
unreachable from `stopAgent()`. On SIGTERM the agent tore down the bridge
and closed SQLite while task loops were still mid-step, causing
`SqliteError: database is closed` and truncated checkpoints. A WebUI
stop+start cycle risked leaving old loops running against a stale DB handle.

### Changes

- `src/index.ts` — promote `autonomousManager` to a private instance field
  (`this.autonomousManager`) so `stopAgent()` can reach it, and invoke
  `stopAllAndWait()` just before `bridge.disconnect()`.
- `src/autonomous/manager.ts` — new `stopAllAndWait()` helper that signals
  every loop to stop and awaits each loop's `.finally()` chain, so the DB
  is safe to close. Tracked via a `loopCompletions` map keyed by a unique
  per-run token (so pause/resume and restart scenarios remain isolated).
- `src/autonomous/__tests__/manager.test.ts` — regression coverage:
  - `stopAllAndWait()` resolves only after every in-flight loop step settles.
  - DB close does not throw after `stopAllAndWait()` returns.
  - After a stop, `runningLoops` is empty (restart leaves no stale entries).
  - No-op when no loops are running.

### Acceptance criteria

- [x] `autonomousManager` is an instance field, not a local variable.
- [x] `stopAgent()` calls `stopAll()` (via `stopAllAndWait()`) and waits for
      loops to settle.
- [x] Regression tests fail on `main` (no waiting for completion) and pass
      with this change.
- [x] Restart scenario: after `stopAllAndWait()` no old loops remain in
      memory.

## Test plan

- [x] `npm run typecheck` — passes.
- [x] `npm run lint` — passes (0 warnings).
- [x] `npm run format:check` — passes.
- [x] `npx vitest run src/autonomous/__tests__/manager.test.ts` — 9/9 pass.
- [x] `npx vitest run` — 2934/2934 pass.