### PR TITLE
fix(autonomous): persist PolicyEngine state across pause/resume (AUDIT-C3)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-21T23:15:37.280Z for PR creation at branch issue-242-aaa23d0a8190 for issue https://github.com/xlabtg/teleton-agent/issues/242
 # Updated: 2026-04-22T01:46:49.972Z
 # Updated: 2026-04-22T04:22:46.159Z
+# Updated: 2026-04-22T19:55:42.372Z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Vector memory sync**: Detect Upstash Vector index/embedding dimension mismatches before upsert, surface the configured index dimension in semantic memory status and sync responses, and log an actionable warning at startup (closes xlabtg/teleton-agent#246).
+- **Autonomous policy bypass via pause/resume (AUDIT-C3)**: `AutonomousLoop` now persists and hydrates `PolicyEngine` state (rate-limit sliding windows, loop-detection recent actions, uncertainty counter) through a new `policy_state` table so that scripted `pauseTask()` + `resumeTask()` cycles can no longer reset the 100 tool-calls-per-hour limit or the 5-identical-actions loop detector. Adds migration 1.23.0 and regression tests covering 10 pause/resume cycles (closes xlabtg/teleton-agent#256).
 
 ## [0.8.1] - 2026-03-05
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teleton",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "workspaces": [
     "packages/*"
   ],

--- a/src/autonomous/__tests__/manager.test.ts
+++ b/src/autonomous/__tests__/manager.test.ts
@@ -94,4 +94,53 @@ describe("AutonomousTaskManager", () => {
     expect(restored).toBe(1);
     expect(manager.isTaskRunning(wip.id)).toBe(true);
   });
+
+  // ─── Regression: issue #256 ────────────────────────────────────────────────
+  // Pause + resume must not reset the PolicyEngine rate-limit / uncertainty /
+  // loop-detection state. The legacy bug (AUDIT-C3) was that runLoop() always
+  // constructed a fresh PolicyEngine, giving anyone who could trigger
+  // pause/resume a trivial bypass of the 100 tool-calls-per-hour limit.
+
+  it("pause + resume rehydrates policy_state from storage (issue #256)", async () => {
+    const store = getAutonomousTaskStore(db);
+    const task = await manager.startTask({ goal: "state must persist" });
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Pre-seed the persisted state so the rehydrated loop picks it up.
+    const seeded = {
+      toolCallTimestamps: [Date.now(), Date.now(), Date.now()],
+      apiCallTimestamps: [Date.now()],
+      consecutiveUncertainCount: 2,
+      recentActions: ["web_fetch", "web_fetch", "web_fetch"],
+    };
+    store.savePolicyState(task.id, seeded);
+
+    manager.pauseTask(task.id);
+    manager.resumeTask(task.id);
+    await new Promise((r) => setTimeout(r, 20));
+
+    // After resume the loop should have hydrated the state AND overwritten
+    // the snapshot with its own updates. The key invariant is that the
+    // pre-seeded windows are NOT wiped to empty by the resume.
+    const persisted = store.getPolicyState(task.id) as
+      | {
+          toolCallTimestamps?: number[];
+          apiCallTimestamps?: number[];
+          consecutiveUncertainCount?: number;
+          recentActions?: string[];
+        }
+      | undefined;
+
+    expect(persisted).toBeDefined();
+    // The resumed loop immediately calls recordApiCall() inside planNextAction,
+    // so apiCallTimestamps should contain at least the seeded entry plus any
+    // additions. It must never shrink below the seeded count.
+    expect((persisted?.apiCallTimestamps ?? []).length).toBeGreaterThanOrEqual(1);
+    // consecutiveUncertainCount: the resumed loop won't run selfReflect until
+    // at least one step completes, so the hydrated value of 2 must still be
+    // present (or reset via resetUncertainCount only if reflection said
+    // not-stuck). With hanging planNextAction the loop never reaches
+    // reflection, so the counter stays at 2.
+    expect(persisted?.consecutiveUncertainCount).toBe(2);
+  });
 });

--- a/src/autonomous/__tests__/policy-persistence.test.ts
+++ b/src/autonomous/__tests__/policy-persistence.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { ensureSchema } from "../../memory/schema.js";
+import {
+  getAutonomousTaskStore,
+  type AutonomousTaskStore,
+  type AutonomousTask,
+} from "../../memory/agent/autonomous-tasks.js";
+import { AutonomousLoop } from "../loop.js";
+import type { LoopDependencies, PlannedAction, ToolExecutionResult, Reflection } from "../loop.js";
+import { DEFAULT_POLICY_CONFIG, PolicyEngine } from "../policy-engine.js";
+import type { PolicyConfig, PolicyEngineState } from "../policy-engine.js";
+
+function makeDeps(overrides: Partial<LoopDependencies> = {}): LoopDependencies {
+  return {
+    planNextAction: vi.fn().mockResolvedValue({
+      toolName: "web_fetch",
+      params: { url: "https://example.com" },
+      reasoning: "Fetch data",
+      confidence: 0.9,
+    } satisfies PlannedAction),
+
+    executeTool: vi.fn().mockResolvedValue({
+      success: true,
+      data: { result: "fetched" },
+      durationMs: 1,
+    } satisfies ToolExecutionResult),
+
+    // Never succeed — we want to count iterations, not complete.
+    evaluateSuccess: vi.fn().mockResolvedValue(false),
+
+    selfReflect: vi.fn().mockResolvedValue({
+      progressSummary: "Making progress",
+      isStuck: false,
+    } satisfies Reflection),
+
+    escalate: vi.fn().mockResolvedValue(undefined),
+
+    ...overrides,
+  };
+}
+
+/**
+ * Regression tests for issue #256 (AUDIT-C3):
+ * Pause/resume must not reset PolicyEngine's sliding-window state.
+ *
+ * Each test simulates the exact bypass pattern described in the audit:
+ *   pauseTask() → resumeTask() → pauseTask() → resumeTask() → …
+ * and asserts the counters are hydrated from persistent storage instead of
+ * being re-initialised to zero.
+ */
+describe("PolicyEngine state persistence across pause/resume (issue #256)", () => {
+  let db: InstanceType<typeof Database>;
+  let store: AutonomousTaskStore;
+  let task: AutonomousTask;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    ensureSchema(db);
+    store = getAutonomousTaskStore(db);
+    task = store.createTask({
+      goal: "Persistence test",
+      constraints: { maxIterations: 100000 },
+    });
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("serialize/hydrate roundtrips all mutable fields", () => {
+    const a = new PolicyEngine(DEFAULT_POLICY_CONFIG);
+    a.recordToolCall();
+    a.recordToolCall();
+    a.recordApiCall();
+    a.recordUncertain();
+    a.recordAction("web_fetch");
+    a.recordAction("web_fetch");
+
+    const snapshot = a.serialize();
+    expect(snapshot.toolCallTimestamps).toHaveLength(2);
+    expect(snapshot.apiCallTimestamps).toHaveLength(1);
+    expect(snapshot.consecutiveUncertainCount).toBe(1);
+    expect(snapshot.recentActions).toEqual(["web_fetch", "web_fetch"]);
+
+    const b = new PolicyEngine(DEFAULT_POLICY_CONFIG);
+    b.hydrate(snapshot);
+    const roundtrip = b.serialize();
+    expect(roundtrip).toEqual(snapshot);
+  });
+
+  it("hydrate() ignores unknown / missing fields safely", () => {
+    const engine = new PolicyEngine(DEFAULT_POLICY_CONFIG);
+    engine.hydrate(undefined);
+    engine.hydrate({});
+    // Should not throw, should be blank state.
+    const s = engine.serialize();
+    expect(s.toolCallTimestamps).toEqual([]);
+    expect(s.apiCallTimestamps).toEqual([]);
+    expect(s.consecutiveUncertainCount).toBe(0);
+    expect(s.recentActions).toEqual([]);
+  });
+
+  it("onStateChange fires on every mutation so storage is always current", () => {
+    const engine = new PolicyEngine(DEFAULT_POLICY_CONFIG);
+    const states: PolicyEngineState[] = [];
+    engine.setOnStateChange((s) => states.push(s));
+
+    engine.recordApiCall();
+    engine.recordToolCall();
+    engine.recordUncertain();
+    engine.recordAction("x");
+    engine.resetUncertainCount();
+
+    expect(states.length).toBe(5);
+    expect(states[4].consecutiveUncertainCount).toBe(0);
+  });
+
+  it("resetUncertainCount() does NOT fire onStateChange when already zero", () => {
+    // Avoid needless DB writes during the common non-stuck path.
+    const engine = new PolicyEngine(DEFAULT_POLICY_CONFIG);
+    const cb = vi.fn();
+    engine.setOnStateChange(cb);
+
+    engine.resetUncertainCount();
+    expect(cb).not.toHaveBeenCalled();
+
+    engine.recordUncertain();
+    cb.mockClear();
+    engine.resetUncertainCount();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes policy_state to the store on each tool call", async () => {
+    // Bound to two iterations by having evaluateSuccess return true on the
+    // 2nd step. That makes this test deterministic (no timing-based stop).
+    // The assertion after run() inspects the last on-disk snapshot before
+    // terminal cleanup fires, so we peek inside the callback instead.
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY_CONFIG,
+      rateLimit: { apiCallsPerMinute: 100000, toolCallsPerHour: 100000 },
+      loopDetection: { enabled: false, maxIdenticalActions: 999 },
+    };
+
+    let midRunSnapshot: Partial<PolicyEngineState> | undefined;
+    const deps = makeDeps();
+    // Capture a snapshot of what's been persisted right before we let the
+    // loop finish. Completion clears policy_state, but mid-run it should
+    // contain at least one recorded tool call.
+    (deps.evaluateSuccess as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      midRunSnapshot = store.getPolicyState(task.id) as Partial<PolicyEngineState> | undefined;
+      return Promise.resolve(true);
+    });
+
+    const loop = new AutonomousLoop(store, deps, policy);
+    const result = await loop.run(task);
+
+    expect(result.status).toBe("completed");
+    expect(midRunSnapshot).toBeDefined();
+    expect(Array.isArray(midRunSnapshot?.toolCallTimestamps)).toBe(true);
+    expect((midRunSnapshot?.toolCallTimestamps ?? []).length).toBeGreaterThan(0);
+  });
+
+  it("tool-call rate limit still fires after 10 pause/resume cycles", async () => {
+    // Tight limit so the bypass shows up quickly.
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY_CONFIG,
+      rateLimit: { apiCallsPerMinute: 10000, toolCallsPerHour: 5 },
+    };
+
+    // Simulate exactly the bypass pattern: record 5 tool calls spread
+    // across 10 pause/resume cycles, then ensure the next policy check
+    // triggers the limit.
+    for (let cycle = 0; cycle < 10; cycle++) {
+      const engine = new PolicyEngine(policy);
+      const existing = store.getPolicyState(task.id) as Partial<PolicyEngineState> | undefined;
+      engine.hydrate(existing);
+      engine.setOnStateChange((s) => store.savePolicyState(task.id, s));
+      // Each "session" records half a tool call worth of work; after 10
+      // cycles we'll have hit the limit.
+      if (cycle < 5) engine.recordToolCall();
+    }
+
+    const finalEngine = new PolicyEngine(policy);
+    finalEngine.hydrate(store.getPolicyState(task.id));
+    const check = finalEngine.checkAction({ ...task, currentStep: 0 }, { toolName: "web_fetch" });
+
+    expect(check.violations.some((v) => v.type === "rate_limit")).toBe(true);
+  });
+
+  it("identical-action loop detection persists across pause/resume", async () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY_CONFIG,
+      loopDetection: { enabled: true, maxIdenticalActions: 5 },
+    };
+
+    // Accumulate recentActions across 5 pause/resume cycles (1 action each).
+    for (let cycle = 0; cycle < 5; cycle++) {
+      const engine = new PolicyEngine(policy);
+      engine.hydrate(store.getPolicyState(task.id));
+      engine.setOnStateChange((s) => store.savePolicyState(task.id, s));
+      engine.recordAction("web_fetch");
+    }
+
+    const finalEngine = new PolicyEngine(policy);
+    finalEngine.hydrate(store.getPolicyState(task.id));
+    const recent = [...finalEngine.getRecentActions()];
+    expect(recent).toHaveLength(5);
+
+    const check = finalEngine.checkAction(
+      { ...task, currentStep: 0 },
+      { toolName: "web_fetch", recentActions: recent }
+    );
+    expect(check.violations.some((v) => v.type === "loop_detected")).toBe(true);
+    expect(check.requiresEscalation).toBe(true);
+  });
+
+  it("consecutiveUncertainCount is not reset by pause/resume", async () => {
+    const policy = DEFAULT_POLICY_CONFIG;
+
+    // Two uncertain markers, one pause/resume in the middle.
+    let engine = new PolicyEngine(policy);
+    engine.hydrate(store.getPolicyState(task.id));
+    engine.setOnStateChange((s) => store.savePolicyState(task.id, s));
+    expect(engine.recordUncertain()).toBe(false); // count=1
+
+    // Resume: new PolicyEngine, hydrate from DB.
+    engine = new PolicyEngine(policy);
+    engine.hydrate(store.getPolicyState(task.id));
+    engine.setOnStateChange((s) => store.savePolicyState(task.id, s));
+    expect(engine.recordUncertain()).toBe(false); // count=2
+
+    // One more resume.
+    engine = new PolicyEngine(policy);
+    engine.hydrate(store.getPolicyState(task.id));
+    engine.setOnStateChange((s) => store.savePolicyState(task.id, s));
+    // Reaching the threshold (3) should fire even though each session
+    // only recorded a single uncertain event.
+    expect(engine.recordUncertain()).toBe(true); // count=3
+  });
+
+  it("AutonomousLoop hydrates persisted state on resume (end-to-end)", async () => {
+    // Pre-seed policy_state so a resume starts with a nearly-full rate-limit
+    // window. Without hydration the loop would blow past this limit; with
+    // hydration the first tool call tips it over and the loop fails.
+    const now = Date.now();
+    const preState: PolicyEngineState = {
+      toolCallTimestamps: [now, now, now, now, now],
+      apiCallTimestamps: [],
+      consecutiveUncertainCount: 0,
+      recentActions: [],
+    };
+    store.savePolicyState(task.id, preState as unknown as Record<string, unknown>);
+
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY_CONFIG,
+      rateLimit: { apiCallsPerMinute: 100000, toolCallsPerHour: 5 },
+      loopDetection: { enabled: false, maxIdenticalActions: 999 },
+    };
+    const deps = makeDeps();
+    const loop = new AutonomousLoop(store, deps, policy);
+
+    const result = await loop.run(task);
+
+    // With hydration, the very first policy check trips the rate limit
+    // because the pre-seeded window already contains 5 timestamps.
+    expect(result.status).toBe("failed");
+    expect(result.error).toMatch(/rate limit/i);
+  });
+
+  it("terminal success clears policy_state", async () => {
+    store.savePolicyState(task.id, {
+      toolCallTimestamps: [Date.now()],
+      apiCallTimestamps: [],
+      consecutiveUncertainCount: 0,
+      recentActions: [],
+    });
+    expect(store.getPolicyState(task.id)).toBeDefined();
+
+    const deps = makeDeps({
+      evaluateSuccess: vi.fn().mockResolvedValue(true),
+    });
+    const loop = new AutonomousLoop(store, deps, DEFAULT_POLICY_CONFIG);
+    const result = await loop.run(task);
+
+    expect(result.status).toBe("completed");
+    expect(store.getPolicyState(task.id)).toBeUndefined();
+  });
+
+  it("pause preserves policy_state for the next resume", async () => {
+    // Race-free pause: transition the task to 'paused' from inside the
+    // evaluateSuccess hook. On the next iteration the loop sees the
+    // paused status and returns status='paused' without clearing
+    // policy_state.
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY_CONFIG,
+      rateLimit: { apiCallsPerMinute: 100000, toolCallsPerHour: 100000 },
+      loopDetection: { enabled: false, maxIdenticalActions: 999 },
+    };
+    const deps = makeDeps();
+    (deps.evaluateSuccess as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      store.updateTaskStatus(task.id, "paused");
+      return Promise.resolve(false);
+    });
+
+    const loop = new AutonomousLoop(store, deps, policy);
+    const result = await loop.run(task);
+
+    expect(result.status).toBe("paused");
+    const persisted = store.getPolicyState(task.id);
+    expect(persisted).toBeDefined();
+  });
+});

--- a/src/autonomous/loop.ts
+++ b/src/autonomous/loop.ts
@@ -1,7 +1,7 @@
 import type { AutonomousTask, TaskCheckpoint } from "../memory/agent/autonomous-tasks.js";
 import type { AutonomousTaskStore } from "../memory/agent/autonomous-tasks.js";
 import { PolicyEngine, DEFAULT_POLICY_CONFIG } from "./policy-engine.js";
-import type { PolicyConfig } from "./policy-engine.js";
+import type { PolicyConfig, PolicyEngineState } from "./policy-engine.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("AutonomousLoop");
@@ -68,7 +68,6 @@ export interface LoopResult {
 export class AutonomousLoop {
   private policyEngine: PolicyEngine;
   private abortController: AbortController;
-  private recentActions: string[] = [];
 
   constructor(
     private store: AutonomousTaskStore,
@@ -77,6 +76,14 @@ export class AutonomousLoop {
   ) {
     this.policyEngine = new PolicyEngine(policyConfig ?? DEFAULT_POLICY_CONFIG);
     this.abortController = new AbortController();
+  }
+
+  /**
+   * Exposed for tests only — lets assertions observe the engine whose state
+   * survives pause/resume (see issue #256).
+   */
+  getPolicyEngine(): PolicyEngine {
+    return this.policyEngine;
   }
 
   /** Request graceful stop of the loop */
@@ -89,6 +96,21 @@ export class AutonomousLoop {
     let current = task;
 
     log.info({ taskId: task.id, goal: task.goal }, "Starting autonomous loop");
+
+    // Hydrate PolicyEngine from persisted state (if any) before we start
+    // recording — resume must not reset rate-limit / loop-detection windows
+    // (issue #256). Wire up write-through persistence afterwards so every
+    // mutation is flushed to disk.
+    const persistedState = this.store.getPolicyState(task.id) as
+      | Partial<PolicyEngineState>
+      | undefined;
+    if (persistedState) {
+      this.policyEngine.hydrate(persistedState);
+      log.debug({ taskId: task.id }, "Hydrated PolicyEngine from persisted state");
+    }
+    this.policyEngine.setOnStateChange((state) => {
+      this.store.savePolicyState(task.id, state);
+    });
 
     // Mark task as running
     this.store.updateTaskStatus(task.id, "running");
@@ -111,11 +133,18 @@ export class AutonomousLoop {
 
     const history: unknown[] = [];
 
+    const clearStateOnTerminal = (): void => {
+      // Completed / failed / cancelled tasks won't resume, so drop their
+      // policy snapshot. Paused tasks keep theirs for the next resume().
+      this.store.clearPolicyState(task.id);
+    };
+
     try {
       while (!this.abortController.signal.aborted) {
         current = this.store.getTask(task.id) ?? current;
 
         if (current.status === "cancelled") {
+          clearStateOnTerminal();
           return {
             status: "cancelled",
             totalSteps: current.currentStep,
@@ -148,6 +177,7 @@ export class AutonomousLoop {
             message: `Planning failed: ${error}`,
           });
           this.store.updateTaskStatus(task.id, "failed", { error });
+          clearStateOnTerminal();
           return {
             status: "failed",
             error,
@@ -168,7 +198,7 @@ export class AutonomousLoop {
         const policyCheck = this.policyEngine.satisfiesPolicies(current, {
           toolName: action.toolName,
           tonAmount: action.tonAmount,
-          recentActions: this.recentActions,
+          recentActions: [...this.policyEngine.getRecentActions()],
         });
 
         if (!policyCheck.allowed) {
@@ -181,6 +211,7 @@ export class AutonomousLoop {
             message: `Policy violation: ${reasons}`,
           });
           this.store.updateTaskStatus(task.id, "failed", { error: `Policy violation: ${reasons}` });
+          clearStateOnTerminal();
           return {
             status: "failed",
             error: reasons,
@@ -238,8 +269,7 @@ export class AutonomousLoop {
         });
 
         history.push({ action, result });
-        this.recentActions.push(action.toolName);
-        if (this.recentActions.length > 20) this.recentActions.shift();
+        this.policyEngine.recordAction(action.toolName);
 
         // 4. Self-reflection
         log.debug({ taskId: task.id }, "Self-reflecting on progress");
@@ -326,6 +356,7 @@ export class AutonomousLoop {
           this.store.updateTaskStatus(task.id, "completed", {
             result: JSON.stringify(result.data ?? "completed"),
           });
+          clearStateOnTerminal();
           return {
             status: "completed",
             output: result.data,
@@ -335,10 +366,21 @@ export class AutonomousLoop {
         }
       }
 
-      // Aborted via stop()
-      this.store.updateTaskStatus(task.id, "cancelled");
+      // Aborted via stop(). If the caller already transitioned the task
+      // (pauseTask → "paused" or stopTask → "cancelled"), preserve that.
+      // Only fall back to marking it cancelled when no external status
+      // change was recorded. Paused tasks MUST keep their policy snapshot
+      // so the next resume doesn't reset the rate-limit window (issue #256).
+      current = this.store.getTask(task.id) ?? current;
+      if (current.status !== "paused" && current.status !== "cancelled") {
+        this.store.updateTaskStatus(task.id, "cancelled");
+        current.status = "cancelled";
+      }
+      if (current.status === "cancelled") {
+        clearStateOnTerminal();
+      }
       return {
-        status: "cancelled",
+        status: current.status === "paused" ? "paused" : "cancelled",
         totalSteps: current.currentStep,
         durationMs: Date.now() - startTime,
       };
@@ -346,12 +388,17 @@ export class AutonomousLoop {
       const error = err instanceof Error ? err.message : String(err);
       log.error({ taskId: task.id, err }, "Autonomous loop crashed");
       this.store.updateTaskStatus(task.id, "failed", { error });
+      clearStateOnTerminal();
       return {
         status: "failed",
         error,
         totalSteps: current.currentStep,
         durationMs: Date.now() - startTime,
       };
+    } finally {
+      // Disconnect write-through persistence so a leftover loop object
+      // can't scribble into another loop's state window.
+      this.policyEngine.setOnStateChange(undefined);
     }
   }
 }

--- a/src/autonomous/policy-engine.ts
+++ b/src/autonomous/policy-engine.ts
@@ -47,6 +47,19 @@ export const DEFAULT_POLICY_CONFIG: PolicyConfig = {
   },
 };
 
+/**
+ * Snapshot of the mutable rate-limit / loop / uncertainty state that must
+ * survive pause/resume cycles. Persisted by the loop; hydrated into a new
+ * PolicyEngine on resume so the sliding-window limits are not bypassed by
+ * scripting pause/resume (see issue #256).
+ */
+export interface PolicyEngineState {
+  toolCallTimestamps: number[];
+  apiCallTimestamps: number[];
+  consecutiveUncertainCount: number;
+  recentActions: string[];
+}
+
 export type PolicyViolation =
   | { type: "budget_exceeded"; message: string; requiresConfirmation: boolean }
   | { type: "restricted_tool"; message: string; toolName: string }
@@ -65,8 +78,50 @@ export class PolicyEngine {
   private toolCallTimestamps: number[] = [];
   private apiCallTimestamps: number[] = [];
   private consecutiveUncertainCount = 0;
+  private recentActions: string[] = [];
+  private onStateChange?: (state: PolicyEngineState) => void;
 
   constructor(private config: PolicyConfig = DEFAULT_POLICY_CONFIG) {}
+
+  /**
+   * Register a callback invoked after any mutation to the engine's runtime
+   * state. The loop uses this to persist state so that pause/resume cannot
+   * bypass rate-limit and loop-detection windows (issue #256).
+   */
+  setOnStateChange(cb: ((state: PolicyEngineState) => void) | undefined): void {
+    this.onStateChange = cb;
+  }
+
+  /** Dump mutable runtime state for persistence. */
+  serialize(): PolicyEngineState {
+    return {
+      toolCallTimestamps: [...this.toolCallTimestamps],
+      apiCallTimestamps: [...this.apiCallTimestamps],
+      consecutiveUncertainCount: this.consecutiveUncertainCount,
+      recentActions: [...this.recentActions],
+    };
+  }
+
+  /**
+   * Restore state produced by a previous `serialize()` call. Unknown fields
+   * are ignored so the engine stays forward-compatible with older snapshots.
+   */
+  hydrate(state: Partial<PolicyEngineState> | undefined | null): void {
+    if (!state) return;
+    this.toolCallTimestamps = Array.isArray(state.toolCallTimestamps)
+      ? [...state.toolCallTimestamps]
+      : [];
+    this.apiCallTimestamps = Array.isArray(state.apiCallTimestamps)
+      ? [...state.apiCallTimestamps]
+      : [];
+    this.consecutiveUncertainCount =
+      typeof state.consecutiveUncertainCount === "number" ? state.consecutiveUncertainCount : 0;
+    this.recentActions = Array.isArray(state.recentActions) ? [...state.recentActions] : [];
+  }
+
+  private notifyChange(): void {
+    if (this.onStateChange) this.onStateChange(this.serialize());
+  }
 
   checkAction(
     task: AutonomousTask,
@@ -178,19 +233,38 @@ export class PolicyEngine {
 
   recordToolCall(): void {
     this.toolCallTimestamps.push(Date.now());
+    this.notifyChange();
   }
 
   recordApiCall(): void {
     this.apiCallTimestamps.push(Date.now());
+    this.notifyChange();
   }
 
   recordUncertain(): boolean {
     this.consecutiveUncertainCount++;
+    this.notifyChange();
     return this.consecutiveUncertainCount >= this.config.uncertainty.maxConsecutiveUncertain;
   }
 
   resetUncertainCount(): void {
+    if (this.consecutiveUncertainCount === 0) return;
     this.consecutiveUncertainCount = 0;
+    this.notifyChange();
+  }
+
+  /**
+   * Record a tool name the loop just executed. The engine stores a bounded
+   * window (length 20) used for loop detection.
+   */
+  recordAction(toolName: string): void {
+    this.recentActions.push(toolName);
+    if (this.recentActions.length > 20) this.recentActions.shift();
+    this.notifyChange();
+  }
+
+  getRecentActions(): readonly string[] {
+    return this.recentActions;
   }
 
   satisfiesPolicies(

--- a/src/memory/__tests__/schema.test.ts
+++ b/src/memory/__tests__/schema.test.ts
@@ -1113,7 +1113,7 @@ describe("Memory Schema", () => {
     });
 
     it("CURRENT_SCHEMA_VERSION is set to expected value", () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe("1.22.0");
+      expect(CURRENT_SCHEMA_VERSION).toBe("1.23.0");
     });
   });
 

--- a/src/memory/agent/autonomous-tasks.ts
+++ b/src/memory/agent/autonomous-tasks.ts
@@ -398,6 +398,41 @@ export class AutonomousTaskStore {
       .all(taskId, limit) as ExecutionLogRow[];
     return rows.map(rowToLogEntry);
   }
+
+  /**
+   * Persist PolicyEngine runtime state for a task. Called on every mutation
+   * (tool call / api call / uncertain / action) so that pause+resume does
+   * not reset rate-limit windows or loop-detection history (issue #256).
+   */
+  savePolicyState(taskId: string, state: object): void {
+    const now = Math.floor(Date.now() / 1000);
+    this.db
+      .prepare(
+        `INSERT INTO policy_state (task_id, state, updated_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT(task_id) DO UPDATE SET
+           state = excluded.state,
+           updated_at = excluded.updated_at`
+      )
+      .run(taskId, JSON.stringify(state), now);
+  }
+
+  /** Load last-persisted PolicyEngine state for a task, if any. */
+  getPolicyState(taskId: string): Record<string, unknown> | undefined {
+    const row = this.db.prepare(`SELECT state FROM policy_state WHERE task_id = ?`).get(taskId) as
+      | { state: string }
+      | undefined;
+    if (!row) return undefined;
+    try {
+      return JSON.parse(row.state) as Record<string, unknown>;
+    } catch {
+      return undefined;
+    }
+  }
+
+  clearPolicyState(taskId: string): void {
+    this.db.prepare(`DELETE FROM policy_state WHERE task_id = ?`).run(taskId);
+  }
 }
 
 const instances = new WeakMap<Database.Database, AutonomousTaskStore>();

--- a/src/memory/migrations/1.23.0.sql
+++ b/src/memory/migrations/1.23.0.sql
@@ -1,0 +1,14 @@
+-- Migration 1.23.0: Policy Engine state persistence (issue #256)
+-- Adds a per-task table that stores PolicyEngine sliding-window state
+-- (rate-limit timestamps, loop-detection recent actions, uncertainty counter)
+-- so pause/resume cycles cannot bypass policy windows.
+
+CREATE TABLE IF NOT EXISTS policy_state (
+  task_id TEXT PRIMARY KEY,
+  state TEXT NOT NULL DEFAULT '{}',           -- JSON: PolicyEngineState
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  FOREIGN KEY (task_id) REFERENCES autonomous_tasks(id) ON DELETE CASCADE
+);
+
+-- Update schema version
+UPDATE meta SET value = '1.23.0', updated_at = unixepoch() WHERE key = 'schema_version';

--- a/src/memory/schema.ts
+++ b/src/memory/schema.ts
@@ -507,6 +507,16 @@ export function ensureSchema(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_exec_logs_task ON execution_logs(task_id, created_at DESC);
     CREATE INDEX IF NOT EXISTS idx_exec_logs_type ON execution_logs(event_type);
 
+    -- Policy engine runtime state, keyed by task. Persists rate-limit
+    -- timestamps, loop-detection recent actions, and uncertainty counter so
+    -- that pause/resume cannot bypass policy windows (issue #256).
+    CREATE TABLE IF NOT EXISTS policy_state (
+      task_id TEXT PRIMARY KEY,
+      state TEXT NOT NULL DEFAULT '{}',
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      FOREIGN KEY (task_id) REFERENCES autonomous_tasks(id) ON DELETE CASCADE
+    );
+
     -- =====================================================
     -- JOURNAL (Trading & Business Operations)
     -- =====================================================
@@ -563,7 +573,7 @@ export function setSchemaVersion(db: Database.Database, version: string): void {
   ).run(version);
 }
 
-export const CURRENT_SCHEMA_VERSION = "1.22.0";
+export const CURRENT_SCHEMA_VERSION = "1.23.0";
 
 export function runMigrations(db: Database.Database): void {
   const currentVersion = getSchemaVersion(db);
@@ -1140,6 +1150,24 @@ export function runMigrations(db: Database.Database): void {
       log.info("Migration 1.22.0 complete: memory prioritization tables created");
     } catch (error) {
       log.error({ err: error }, "Migration 1.22.0 failed");
+      throw error;
+    }
+  }
+
+  if (!currentVersion || versionLessThan(currentVersion, "1.23.0")) {
+    log.info("Running migration 1.23.0: Add policy_state table for policy engine persistence");
+    try {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS policy_state (
+          task_id TEXT PRIMARY KEY,
+          state TEXT NOT NULL DEFAULT '{}',
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          FOREIGN KEY (task_id) REFERENCES autonomous_tasks(id) ON DELETE CASCADE
+        );
+      `);
+      log.info("Migration 1.23.0 complete: policy_state table created");
+    } catch (error) {
+      log.error({ err: error }, "Migration 1.23.0 failed");
       throw error;
     }
   }


### PR DESCRIPTION
## Summary

Closes #256 (AUDIT-C3). Before this change, `AutonomousTaskManager.runLoop()` constructed a brand-new `PolicyEngine` on every start **and** resume, so every `pauseTask()` + `resumeTask()` cycle silently reset:

- `toolCallTimestamps` → bypassing `rateLimit.toolCallsPerHour` (default 100)
- `apiCallTimestamps` → bypassing `rateLimit.apiCallsPerMinute` (default 30)
- `recentActions` → disarming the 5-identical-actions loop detector
- `consecutiveUncertainCount` → disarming the uncertainty escalator

The loop now hydrates a single `PolicyEngine` from a new `policy_state` table keyed by `task_id`, and registers a write-through callback that flushes a snapshot on every mutation. Snapshots are cleared only on terminal task states (`completed` / `failed` / `cancelled`); paused tasks keep their state for the next resume.

## Changes

**Persistence**
- New table `policy_state (task_id PK, state JSON, updated_at, FK → autonomous_tasks ON DELETE CASCADE)`
- Schema migration `1.23.0` (`src/memory/schema.ts` + `src/memory/migrations/1.23.0.sql`)
- `AutonomousTaskStore.savePolicyState()` / `getPolicyState()` / `clearPolicyState()`

**PolicyEngine**
- New `PolicyEngineState` interface (`toolCallTimestamps`, `apiCallTimestamps`, `consecutiveUncertainCount`, `recentActions`)
- New `serialize()`, `hydrate()`, `setOnStateChange()`, `recordAction()`, `getRecentActions()` methods
- `recordToolCall` / `recordApiCall` / `recordUncertain` / `resetUncertainCount` / `recordAction` now trigger the `onStateChange` callback. `resetUncertainCount` no-ops (and does not write to DB) when the counter is already zero, which is the common non-stuck path.

**Loop**
- `AutonomousLoop.run()` hydrates the engine from `policy_state` before the first policy check and wires the write-through callback.
- `recentActions` moved from an in-memory field on the loop into the engine so it is covered by the same snapshot contract.
- Terminal transitions (`completed`, `failed`, `cancelled`, `max_iterations`, `rate_limit`, planning failure, crash) clear `policy_state`. The abort path (e.g. graceful stop during pause) preserves state.

**Housekeeping**
- `CURRENT_SCHEMA_VERSION` bumped to `1.23.0`
- `package.json` version bumped to `0.8.11` (to trigger the release workflow)
- `CHANGELOG.md` entry under Unreleased / Fixed

## Acceptance criteria coverage (from the issue)

- [x] Migration / schema for `policy_state` created (migration 1.23.0 + schema entry).
- [x] `PolicyEngine` is hydrated from storage on resume; state is persisted on every `record*` call.
- [x] Unit test: 10 pause/resume cycles do not reset `toolCallsPerHour`.
- [x] Unit test: identical-action detector persists through pause/resume.
- [x] Unit test: `consecutiveUncertainCount` is not cleared by pause/resume.
- [x] Regression integration test added under `src/autonomous/__tests__/`.

## Reproduction

Before the fix, this would let an agent make unlimited tool calls:

```ts
for (let i = 0; i < 1000; i++) {
  // burn through the 100/hour budget
  manager.pauseTask(id);
  manager.resumeTask(id); // fresh PolicyEngine — counter reset to 0
}
```

After the fix, the rate-limit check trips on attempt #101 regardless of how many pause/resume cycles are injected. The new test `tool-call rate limit still fires after 10 pause/resume cycles` encodes exactly that scenario.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (max-warnings 0)
- [x] `npm run format:check` — clean
- [x] `npm test` — **2942 passed / 140 files**
- [x] New suite `src/autonomous/__tests__/policy-persistence.test.ts` — 11/11 passed
- [x] Manager regression test for issue #256 — passing