### PR TITLE
docs(audit): add V2 work3 hardening reports

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-24T06:14:06.830Z for PR creation at branch issue-398-974a2c1185a7 for issue https://github.com/xlabtg/teleton-agent/issues/398

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-24T06:14:06.830Z for PR creation at branch issue-398-974a2c1185a7 for issue https://github.com/xlabtg/teleton-agent/issues/398

--- a/improvements/work3/01-architecture-consistency.md
+++ b/improvements/work3/01-architecture-consistency.md
@@ -1,0 +1,57 @@
+# 01 - Architecture Consistency
+
+## Scope
+
+This report checks whether the V2 features share consistent ownership
+boundaries: route exposure, configuration flow, task runtime handoff, and
+feature-module contracts.
+
+## Summary
+
+Two architecture seams produced confirmed defects:
+
+- V2 route factories are consistently mounted in the WebUI server, but the
+  production Management API mount list did not evolve with the same contract.
+  The detailed finding is [WORK3-H3](04-ui-api-parity.md#work3-h3-management-api-does-not-expose-most-v2-webui-routes).
+- Agent-network ingress writes remote work into the generic scheduled-task
+  table, but the executor for that table is Telegram-message driven. The
+  detailed finding is [WORK3-H2](03-runtime-and-integrations.md#work3-h2-agent-network-ingress-creates-pending-tasks-that-never-execute).
+
+No separate architecture-only defect was filed beyond those two concrete
+runtime/API issues.
+
+## Architecture Observations
+
+### Route Ownership
+
+`src/webui/server.ts` is now the complete V2 route registry for browser
+features, while `src/api/server.ts` manually remounts only a subset under
+`/v1`. This creates an avoidable drift point. Future V2 route additions should
+declare whether the route is WebUI-only, Management API-supported, or an
+internal browser helper.
+
+### Task Ownership
+
+The codebase has multiple task concepts:
+
+- generic scheduled tasks in `src/memory/agent/tasks.ts`
+- autonomous tasks in `src/memory/agent/autonomous-tasks.ts`
+- delegation subtasks in `src/agent/delegation/*`
+- remote network `task_request` messages in `src/services/network/*`
+
+The generic scheduled-task executor in `src/index.ts` is activated by
+Telegram messages with `[TASK:<id>]` prefixes. Network ingress should not rely
+on that table unless it also schedules or dispatches the corresponding runtime
+execution path.
+
+### Configuration Flow
+
+WebUI receives `networkConfig` from `src/index.ts`, but `ApiServerDeps` does
+not carry the same field. That makes route parity fixes for agent network
+impossible without first extending the API dependency adapter.
+
+## Follow-up
+
+Treat route parity as a code-level contract. A low-maintenance guard would be a
+test that compares route group names and requires explicit allowlisting for
+WebUI-only groups.

--- a/improvements/work3/02-security-and-trust.md
+++ b/improvements/work3/02-security-and-trust.md
@@ -1,0 +1,59 @@
+# 02 - Security And Trust
+
+## Scope
+
+This report covers V2 trust boundaries: signed inter-agent ingress,
+allowlist/blocklist enforcement, recipient validation, replay protection,
+authentication surfaces, and privilege boundaries.
+
+## Confirmed Defects
+
+### WORK3-H1: Agent network ingress ignores allowlist and message recipient
+
+- component: Agent network ingress / trust boundary
+  (`src/webui/routes/network.ts`, `src/services/network/messenger.ts`)
+- seriousness: High - security / trust boundary
+- symptoms: A signed `task_request` from a registered verified peer is
+  accepted even when `network.allowlist` excludes that sender. The same ingress
+  endpoint also accepts a message whose `to` field targets a different agent id
+  than the local configured `network.agent_id`.
+- how to reproduce:
+  1. Configure `network.enabled = true`, `network.agent_id = primary`, and
+     `network.allowlist = ["different-agent"]`.
+  2. Register verified peer `agent-003` with a public key.
+  3. POST a valid signed `task_request` from `agent-003` to
+     `/api/agent-network`.
+  4. Repeat with `to = "other-local-agent"`.
+  5. The audit exercise returned HTTP 202 for both requests and inserted two
+     tasks.
+- expected behavior: Ingress rejects non-allowlisted senders and rejects
+  messages not addressed to the local agent id before creating tasks or logging
+  accepted messages.
+- actual behavior: `createCoordinator()` passes `allowlist` and `blocklist`
+  into outbound delegation, but `createMessenger()` constructs an inbound
+  `NetworkMessenger` without a configured `NetworkTrustService`. Inside
+  `NetworkMessenger.receiveMessage()`, the signed envelope is verified, but
+  `message.to` is never compared with `localAgentId`.
+- hypothesis of the cause: Outbound and inbound trust services were wired
+  separately. The outbound path received config, while the inbound path fell
+  back to `new NetworkTrustService()` with no allowlist/blocklist options.
+  Recipient validation was omitted from the canonical signature verification
+  path.
+- recommended fix: Pass a configured `NetworkTrustService` into inbound
+  `NetworkMessenger`, enforce `message.to === localAgentId`, and add route and
+  service tests for allowlist rejection, blocklist rejection, and wrong
+  recipient rejection.
+- link to issue/PR: [#400](https://github.com/xlabtg/teleton-agent/issues/400),
+  PR [#399](https://github.com/xlabtg/teleton-agent/pull/399)
+
+## Cross-linked Security Findings
+
+- Replay/idempotency is also a trust-boundary issue, but it is recorded in the
+  reliability report as [WORK3-M1](06-performance-and-reliability.md#work3-m1-agent-network-accepts-replayed-signed-task-requests).
+
+## Non-findings
+
+- Unsigned agent-network messages are rejected by existing tests and by the
+  signature verification path.
+- The `/api/agent-network` ingress skips browser CSRF intentionally because it
+  uses signed inter-agent messages rather than browser cookies.

--- a/improvements/work3/03-runtime-and-integrations.md
+++ b/improvements/work3/03-runtime-and-integrations.md
@@ -1,0 +1,54 @@
+# 03 - Runtime And Integrations
+
+## Scope
+
+This report checks that V2 APIs connect to the runtime systems they imply:
+agent lifecycle, task execution, schedulers, integration registries, generated
+widgets, and external network messages.
+
+## Confirmed Defects
+
+### WORK3-H2: Agent network ingress creates pending tasks that never execute
+
+- component: Agent network ingress / task runtime integration
+  (`src/webui/routes/network.ts`, `src/index.ts`, `src/telegram/task-executor.ts`)
+- seriousness: High - runtime integration
+- symptoms: A signed remote `task_request` returns HTTP 202 and a `taskId`,
+  but the created row is a generic scheduled-task record with
+  `status = pending`, `scheduled_for = NULL`, and `scheduled_message_id = NULL`.
+  The existing scheduled-task executor only runs when a Telegram saved message
+  in `[TASK:<id>]` format is received, so the network task is accepted but no
+  runtime path starts it.
+- how to reproduce:
+  1. Enable the agent network and register a verified peer with a public key.
+  2. POST a signed `task_request` to `/api/agent-network`.
+  3. Query `tasks` for the returned id.
+  4. The audit exercise observed `status = pending`, `created_by =
+network:agent-003`, `scheduled_for = NULL`, and
+     `scheduled_message_id = NULL`.
+- expected behavior: Remote task ingress either dispatches the task to an
+  executor/manager immediately, schedules the existing task executor through a
+  supported mechanism, or returns a status that clearly indicates the task is
+  only queued and requires operator action.
+- actual behavior: The route only calls `getTaskStore(...).createTask(...)`
+  and returns success. No Telegram scheduling, autonomous manager handoff,
+  lifecycle dispatch, or response callback is wired.
+- hypothesis of the cause: The network implementation reused the generic task
+  table as a durable inbox, but the generic task execution path is driven by
+  Telegram scheduled messages, not database polling.
+- recommended fix: Define the network task execution contract: integrate with
+  `AutonomousTaskManager`/agent runtime, add a database-backed task dispatcher,
+  or rename the behavior to a manual inbox. Add a regression test that a signed
+  ingress request transitions beyond inert `pending` or documents an explicit
+  queued/manual state.
+- link to issue/PR: [#401](https://github.com/xlabtg/teleton-agent/issues/401),
+  PR [#399](https://github.com/xlabtg/teleton-agent/pull/399)
+
+## Integration Notes
+
+- `task_response` messages are accepted and logged, but no local task or
+  delegation result is completed from them. That should be reviewed when
+  [#401](https://github.com/xlabtg/teleton-agent/issues/401) defines the
+  network task lifecycle.
+- Widget preview integration has a data-source parity issue recorded as
+  [WORK3-M2](04-ui-api-parity.md#work3-m2-widget-generator-previews-return-empty-data-for-advertised-sources).

--- a/improvements/work3/04-ui-api-parity.md
+++ b/improvements/work3/04-ui-api-parity.md
@@ -1,0 +1,95 @@
+# 04 - UI/API Parity
+
+## Scope
+
+This report compares browser-facing V2 APIs, the HTTPS Management API, and UI
+features that rely on generated or discovered backend capabilities.
+
+## Confirmed Defects
+
+### WORK3-H3: Management API does not expose most V2 WebUI routes
+
+- component: Management API / UI/API parity
+  (`src/api/server.ts`, `src/webui/server.ts`, `src/api/deps.ts`)
+- seriousness: High - UI/API parity and operational readiness
+- symptoms: The authenticated WebUI exposes many V2 feature routes under
+  `/api/*`, but the HTTPS Management API exposes only a subset under `/v1/*`.
+  Remote operators and API clients cannot access major V2 capabilities through
+  the production management surface.
+- how to reproduce:
+  1. Compare route mounts in `src/webui/server.ts` and `src/api/server.ts`.
+  2. During audit, the WebUI had 42 mounted `/api` route groups while the
+     Management API had 24 mounted `/v1` route groups.
+  3. Missing from `/v1`: `agent-actions`, `agent-network`, `analytics`,
+     `anomalies`, `audit`, `autonomous`, `cache`, `context`, `dashboards`,
+     `export`, `groq`, `health-check`, `metrics`, `mtproto`, `network`,
+     `notifications`, `pipelines`, `predictions`, `security`,
+     `self-improvement`, `sessions`, `widgets`, and `workflows`.
+- expected behavior: For user-facing V2 features that have stable WebUI APIs,
+  the Management API should either expose equivalent `/v1` routes or document
+  that the feature is WebUI-only.
+- actual behavior: `ApiServer.setupRoutes()` mounts only older/shared route
+  factories plus a few newer ones. `ApiServerDeps` also lacks `networkConfig`,
+  so even a direct mount of the network routes would not carry the same runtime
+  configuration as WebUI.
+- hypothesis of the cause: V2 features were added primarily through WebUI
+  route factories, while the Management API mount list and dependency adapter
+  were not updated consistently after each feature PR.
+- recommended fix: Define the API parity policy for V2 features, mount the
+  missing route factories under `/v1` where supported, extend `ApiServerDeps`
+  for required config such as `networkConfig`, and add a route parity
+  regression test that fails when a WebUI API group is unintentionally omitted.
+- link to issue/PR: [#403](https://github.com/xlabtg/teleton-agent/issues/403),
+  PR [#399](https://github.com/xlabtg/teleton-agent/pull/399)
+
+### WORK3-M2: Widget generator previews return empty data for advertised sources
+
+- component: AI widget generator / data-source preview parity
+  (`src/services/data-source-catalog.ts`, `src/webui/routes/widget-generator.ts`)
+- seriousness: Medium - UI/API parity and regression risk
+- symptoms: The widget data-source catalog advertises sources such as
+  `analytics.performance` and `predictions.next`, and prompt generation can
+  select them. The preview route validates those generated definitions and
+  returns HTTP 200, but `readPreviewData()` has no cases for those source ids,
+  so the UI shows an empty preview (`No data yet`) even when the source is a
+  supported catalog option.
+- how to reproduce:
+  1. POST `/api/widgets/generate` with a performance prompt such as
+     `Show error rate and latency performance`.
+  2. The generated definition uses `dataSource.id = analytics.performance`.
+  3. POST that definition to `/api/widgets/preview`.
+  4. The audit exercise observed HTTP 200 with zero preview rows.
+- expected behavior: Every catalog data source selected by the generator should
+  have preview data wired, or the generator should avoid advertising/selecting
+  sources that cannot preview.
+- actual behavior: `createDataSourceCatalog()` includes
+  `analytics.performance` and `predictions.next`, but `readPreviewData()` only
+  handles metrics, memory stats, status, and tasks, then falls through to `[]`
+  for other valid data sources.
+- hypothesis of the cause: The catalog grew faster than the preview switch
+  statement. Validation checks source identity and endpoint consistency but not
+  preview support.
+- recommended fix: Add preview adapters for all catalog sources, or add a
+  `previewSupported` contract and make generation/validation surface
+  unsupported previews clearly. Add route tests for each catalog source id.
+- link to issue/PR: [#404](https://github.com/xlabtg/teleton-agent/issues/404),
+  PR [#399](https://github.com/xlabtg/teleton-agent/pull/399)
+
+## Parity Check Command
+
+The route comparison used this shape:
+
+```bash
+node - <<'NODE'
+const fs = require("fs");
+const web = fs.readFileSync("src/webui/server.ts", "utf8");
+const api = fs.readFileSync("src/api/server.ts", "utf8");
+const webRoutes = [...web.matchAll(/this\.app\.route\("\/api\/([^"]+)"/g)]
+  .map((m) => m[1])
+  .sort();
+const apiRoutes = [...api.matchAll(/this\.app\.route\("\/v1\/([^"]+)"/g)]
+  .map((m) => m[1])
+  .sort();
+console.log(webRoutes.filter((route) => !apiRoutes.includes(route)));
+NODE
+```

--- a/improvements/work3/05-regressions-and-compatibility.md
+++ b/improvements/work3/05-regressions-and-compatibility.md
@@ -1,0 +1,41 @@
+# 05 - Regressions And Compatibility
+
+## Scope
+
+This report checks whether V2 changes preserve existing external behavior and
+whether newly added feature surfaces can be consumed consistently by existing
+users, scripts, and operators.
+
+## Confirmed Compatibility Findings
+
+The main confirmed compatibility issue is
+[WORK3-H3](04-ui-api-parity.md#work3-h3-management-api-does-not-expose-most-v2-webui-routes).
+It is recorded in the UI/API parity report because that is the primary failure
+mode, but it is also a compatibility problem:
+
+- Existing Management API users expect production HTTPS access to operational
+  capabilities.
+- New V2 browser features are not consistently reachable through `/v1`, so
+  scripts and remote operators cannot automate the same workflows shown in the
+  WebUI.
+- `ApiServerDeps` does not include `networkConfig`, which means later attempts
+  to expose the network route under `/v1` need dependency-shape changes, not
+  just another route mount.
+
+## Regression Notes
+
+- Prior audit issues from `improvements/work` and `improvements/work2` were not
+  re-filed. The confirmed findings here are distinct from the closed audit
+  findings `#252` through `#329`.
+- The network findings are tied to the V2-21 feature added in PR
+  [#397](https://github.com/xlabtg/teleton-agent/pull/397), not to older
+  autonomous-mode findings from the first two audits.
+- The widget preview finding is tied to the V2-18 widget generator added in PR
+  [#391](https://github.com/xlabtg/teleton-agent/pull/391), not to the dynamic
+  dashboard base engine itself.
+
+## Recommended Compatibility Guard
+
+Add an explicit route parity allowlist near `src/api/server.ts` so the
+Management API can intentionally omit browser-only routes while catching
+accidental drift. The test should fail with the missing route group names.

--- a/improvements/work3/06-performance-and-reliability.md
+++ b/improvements/work3/06-performance-and-reliability.md
@@ -1,0 +1,59 @@
+# 06 - Performance And Reliability
+
+## Scope
+
+This report checks reliability behavior under duplicate delivery, partial
+integration, empty data, and operational repeatability. Performance-specific
+load testing was not part of this issue; confirmed findings here focus on
+reliability risks with clear reproduction.
+
+## Confirmed Defects
+
+### WORK3-M1: Agent network accepts replayed signed task requests
+
+- component: Agent network messaging / replay protection
+  (`src/services/network/messenger.ts`, `src/services/network/discovery.ts`,
+  `src/memory/schema.ts`)
+- seriousness: Medium - reliability / trust boundary
+- symptoms: Posting the exact same signed `task_request` envelope twice within
+  the allowed clock-skew window returns HTTP 202 twice and creates two local
+  tasks. `network_messages` records duplicate rows with the same
+  `correlation_id`.
+- how to reproduce:
+  1. Enable the network and register a verified peer with a public key.
+  2. Build one signed `task_request` envelope with a fixed `correlationId`.
+  3. POST the exact same JSON body twice to `/api/agent-network` within five
+     minutes.
+  4. Query `network_messages` and `tasks`.
+  5. The audit exercise observed two HTTP 202 responses, two
+     `network_messages` rows for the same correlation id, and two created
+     tasks.
+- expected behavior: The second delivery of the same signed envelope should be
+  idempotent or rejected as a replay. It should not create another task.
+- actual behavior: The schema has only a non-unique index on
+  `network_messages.correlation_id`, and `receiveMessage()` does not check
+  prior envelopes or correlation ids before logging and routing the message.
+- hypothesis of the cause: The implementation verifies signature and timestamp
+  skew but lacks nonce/correlation uniqueness semantics for inbound messages.
+- recommended fix: Add replay protection keyed by sender + recipient +
+  correlation id, or by a hash of the canonical signed envelope. Enforce it
+  with a unique index and route-level idempotency behavior, then cover
+  duplicate `task_request`, `heartbeat`, and `task_response` cases in tests.
+- link to issue/PR: [#402](https://github.com/xlabtg/teleton-agent/issues/402),
+  PR [#399](https://github.com/xlabtg/teleton-agent/pull/399)
+
+## Cross-linked Reliability Findings
+
+- [WORK3-H2](03-runtime-and-integrations.md#work3-h2-agent-network-ingress-creates-pending-tasks-that-never-execute)
+  is a runtime reliability issue because accepted remote work can remain
+  pending indefinitely.
+- [WORK3-M2](04-ui-api-parity.md#work3-m2-widget-generator-previews-return-empty-data-for-advertised-sources)
+  is a UI reliability issue because valid generated widgets can render as empty
+  previews even when the route returns success.
+
+## Performance Notes
+
+- No new algorithmic hot path was confirmed as a performance defect in this
+  pass.
+- Agent-network replay protection should be enforced with database constraints
+  or indexed lookups to avoid turning idempotency into an unbounded scan.

--- a/improvements/work3/07-final-v2-summary.md
+++ b/improvements/work3/07-final-v2-summary.md
@@ -1,0 +1,50 @@
+# 07 - Final V2 Summary
+
+## Result
+
+This audit created a structured `improvements/work3` workspace for issue
+[`#398`](https://github.com/xlabtg/teleton-agent/issues/398) and filed five
+confirmed follow-up defects as separate GitHub issues.
+
+## Confirmed Findings By Area
+
+| Area                | Finding                                                                      | Issue                                                      |
+| ------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Security / trust    | WORK3-H1: Agent network ingress ignores allowlist and message recipient      | [#400](https://github.com/xlabtg/teleton-agent/issues/400) |
+| Runtime integration | WORK3-H2: Agent network ingress creates pending tasks that never execute     | [#401](https://github.com/xlabtg/teleton-agent/issues/401) |
+| Reliability         | WORK3-M1: Agent network accepts replayed signed task requests                | [#402](https://github.com/xlabtg/teleton-agent/issues/402) |
+| UI/API parity       | WORK3-H3: Management API does not expose most V2 WebUI routes                | [#403](https://github.com/xlabtg/teleton-agent/issues/403) |
+| UI/API parity       | WORK3-M2: Widget generator previews return empty data for advertised sources | [#404](https://github.com/xlabtg/teleton-agent/issues/404) |
+
+## Recommended Fix Order
+
+1. [#400](https://github.com/xlabtg/teleton-agent/issues/400) - close the
+   agent-network trust-boundary gap before enabling cross-agent task ingress in
+   production.
+2. [#401](https://github.com/xlabtg/teleton-agent/issues/401) - define and wire
+   the remote task execution lifecycle so accepted work is not inert.
+3. [#402](https://github.com/xlabtg/teleton-agent/issues/402) - add replay
+   protection before high-volume or unreliable network delivery is expected.
+4. [#403](https://github.com/xlabtg/teleton-agent/issues/403) - restore
+   production API parity for V2 operations and add a drift guard.
+5. [#404](https://github.com/xlabtg/teleton-agent/issues/404) - make generated
+   widget previews match advertised data-source support.
+
+## Verification Performed
+
+- Read issue `#398`; no issue comments were present at audit start.
+- Reviewed prior audit work folders and recent audit PR context to avoid
+  duplicates.
+- Searched current open and closed issues before filing each new issue.
+- Installed dependencies with `npm ci`; install completed with zero
+  vulnerabilities reported by npm.
+- Ran in-memory route exercises for agent-network allowlist/recipient behavior,
+  pending task creation, replayed signed messages, route parity, and widget
+  preview behavior.
+
+## Out Of Scope
+
+- Fixing the five filed defects in this PR. The issue requested an audit
+  workspace and separate issues for confirmed defects.
+- Load testing or runtime soak testing.
+- Re-auditing all findings from `improvements/work` and `improvements/work2`.

--- a/improvements/work3/README.md
+++ b/improvements/work3/README.md
@@ -1,0 +1,70 @@
+# V2 Full Audit Work Folder
+
+This folder is the audit workspace for
+[`#398`](https://github.com/xlabtg/teleton-agent/issues/398). It is not a
+scratchpad: each report covers one requested audit lane, and each confirmed
+defect uses the same record format.
+
+## Scope
+
+- Architecture consistency
+- Security and trust boundaries
+- Runtime integration
+- UI/API parity
+- Regression and backward compatibility
+- Performance and reliability
+- Operational readiness
+
+The audit was performed against branch `issue-398-974a2c1185a7` after the V2
+feature series had landed on `main`, including the recent multi-agent network,
+adaptive prompting, widget generator, audit trail, webhooks/event bus,
+integrations, dynamic dashboards, feedback learning, and agent network work.
+
+## Reports
+
+| File                                                                       | Purpose                                                        |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [01-architecture-consistency.md](01-architecture-consistency.md)           | Cross-feature architecture shape and ownership boundaries      |
+| [02-security-and-trust.md](02-security-and-trust.md)                       | Signed ingress, trust config, replay, and privilege boundaries |
+| [03-runtime-and-integrations.md](03-runtime-and-integrations.md)           | Whether V2 endpoints connect to executable runtime paths       |
+| [04-ui-api-parity.md](04-ui-api-parity.md)                                 | WebUI route, Management API, and generated-widget parity       |
+| [05-regressions-and-compatibility.md](05-regressions-and-compatibility.md) | Backward compatibility and externally visible route behavior   |
+| [06-performance-and-reliability.md](06-performance-and-reliability.md)     | Idempotency, duplicate work, and preview reliability           |
+| [07-final-v2-summary.md](07-final-v2-summary.md)                           | Final summary, issue index, and follow-up order                |
+
+## Confirmed Findings
+
+| ID       | Seriousness | Primary Report                                                                                                                           | GitHub Issue                                               | Status |
+| -------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------ |
+| WORK3-H1 | High        | [02-security-and-trust.md](02-security-and-trust.md#work3-h1-agent-network-ingress-ignores-allowlist-and-message-recipient)              | [#400](https://github.com/xlabtg/teleton-agent/issues/400) | Filed  |
+| WORK3-H2 | High        | [03-runtime-and-integrations.md](03-runtime-and-integrations.md#work3-h2-agent-network-ingress-creates-pending-tasks-that-never-execute) | [#401](https://github.com/xlabtg/teleton-agent/issues/401) | Filed  |
+| WORK3-M1 | Medium      | [06-performance-and-reliability.md](06-performance-and-reliability.md#work3-m1-agent-network-accepts-replayed-signed-task-requests)      | [#402](https://github.com/xlabtg/teleton-agent/issues/402) | Filed  |
+| WORK3-H3 | High        | [04-ui-api-parity.md](04-ui-api-parity.md#work3-h3-management-api-does-not-expose-most-v2-webui-routes)                                  | [#403](https://github.com/xlabtg/teleton-agent/issues/403) | Filed  |
+| WORK3-M2 | Medium      | [04-ui-api-parity.md](04-ui-api-parity.md#work3-m2-widget-generator-previews-return-empty-data-for-advertised-sources)                   | [#404](https://github.com/xlabtg/teleton-agent/issues/404) | Filed  |
+
+## Method
+
+- Read issue `#398`, prior audit folders `improvements/work` and
+  `improvements/work2`, and recent audit PR context to avoid duplicate
+  findings.
+- Compared current WebUI route mounts against Management API route mounts.
+- Exercised signed agent-network ingress in memory with Hono, SQLite, and
+  Ed25519 keys to verify trust, recipient, pending-task, and replay behavior.
+- Exercised widget generation and preview route behavior for an advertised
+  performance data source.
+- Checked all new findings against the current open issue list before filing
+  separate GitHub issues.
+
+## Finding Format
+
+Each detailed defect entry uses this structure:
+
+- component
+- seriousness
+- symptoms
+- how to reproduce
+- expected behavior
+- actual behavior
+- hypothesis of the cause
+- recommended fix
+- link to issue/PR


### PR DESCRIPTION
## Summary

Adds `improvements/work3/` as the structured audit workspace requested by #398. The workspace includes an index plus the seven category reports requested in the issue:

- `01-architecture-consistency.md`
- `02-security-and-trust.md`
- `03-runtime-and-integrations.md`
- `04-ui-api-parity.md`
- `05-regressions-and-compatibility.md`
- `06-performance-and-reliability.md`
- `07-final-v2-summary.md`

The audit records five confirmed V2 defects using a single format and files separate GitHub issues for follow-up:

| Finding | Issue |
| --- | --- |
| WORK3-H1: Agent network ingress ignores allowlist and message recipient | #400 |
| WORK3-H2: Agent network ingress creates pending tasks that never execute | #401 |
| WORK3-M1: Agent network accepts replayed signed task requests | #402 |
| WORK3-H3: Management API does not expose most V2 WebUI routes | #403 |
| WORK3-M2: Widget generator previews return empty data for advertised sources | #404 |

This PR is documentation-only; the confirmed defects are intentionally left for their separate issue/PR flow.

Fixes xlabtg/teleton-agent#398

## Verification

- `npm ci`
- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm test` - 193 files / 3405 tests passed
- `npx prettier --check "improvements/work3/*.md"`
- `git diff --check`
- `git diff --cached --check`

## Notes

The first `npm run typecheck` attempt failed before `npm run build:sdk` because `@teleton-agent/sdk` had not yet produced local declarations. After building the SDK workspace, typecheck passed.