### PR TITLE
fix(network): enforce ingress trust and recipient checks

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-24T11:49:08.876Z for PR creation at branch issue-400-8e6e52ede93c for issue https://github.com/xlabtg/teleton-agent/issues/400

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-24T11:49:08.876Z for PR creation at branch issue-400-8e6e52ede93c for issue https://github.com/xlabtg/teleton-agent/issues/400

--- a/src/services/network/__tests__/network.test.ts
+++ b/src/services/network/__tests__/network.test.ts
@@ -5,6 +5,7 @@ import { ensureSchema } from "../../../memory/schema.js";
 import { NetworkTaskCoordinator } from "../coordinator.js";
 import { getAgentNetworkStore } from "../discovery.js";
 import { NetworkMessenger, signNetworkMessage, verifyNetworkMessage } from "../messenger.js";
+import { NetworkTrustService } from "../trust.js";
 import type { AgentNetworkAdvertisement } from "../types.js";
 
 describe("agent network services", () => {
@@ -109,6 +110,72 @@ describe("agent network services", () => {
 
     expect(record.status).toBe("received");
     expect(() => messenger.receiveMessage(message)).toThrow("Invalid signature");
+  });
+
+  it("rejects inbound messages addressed to another local agent", () => {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    const store = getAgentNetworkStore(db);
+    store.registerAgent(
+      {
+        agentId: "research-remote",
+        name: "Remote Research",
+        endpoint: "https://remote.example.com/api/agent-network",
+        capabilities: ["summarization"],
+        status: "available",
+        load: 0.2,
+        publicKey: publicKey.export({ format: "pem", type: "spki" }).toString(),
+      },
+      { trustLevel: "verified" }
+    );
+    const messenger = new NetworkMessenger({ store, localAgentId: "primary" });
+    const message = {
+      type: "task_request" as const,
+      from: "research-remote",
+      to: "other-local-agent",
+      correlationId: "corr-wrong-recipient",
+      timestamp: new Date().toISOString(),
+      payload: { description: "Summarize this document" },
+    };
+
+    expect(() => messenger.receiveMessage(signNetworkMessage(message, privateKey))).toThrow(
+      "not addressed to local agent"
+    );
+    expect(store.listMessages({ from: "research-remote" })).toHaveLength(0);
+  });
+
+  it("applies configured inbound trust policy before logging received messages", () => {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    const store = getAgentNetworkStore(db);
+    store.registerAgent(
+      {
+        agentId: "research-remote",
+        name: "Remote Research",
+        endpoint: "https://remote.example.com/api/agent-network",
+        capabilities: ["summarization"],
+        status: "available",
+        load: 0.2,
+        publicKey: publicKey.export({ format: "pem", type: "spki" }).toString(),
+      },
+      { trustLevel: "verified" }
+    );
+    const messenger = new NetworkMessenger({
+      store,
+      localAgentId: "primary",
+      trustService: new NetworkTrustService({ allowlist: ["other-agent"] }),
+    });
+    const message = {
+      type: "task_request" as const,
+      from: "research-remote",
+      to: "primary",
+      correlationId: "corr-not-allowlisted",
+      timestamp: new Date().toISOString(),
+      payload: { description: "Summarize this document" },
+    };
+
+    expect(() => messenger.receiveMessage(signNetworkMessage(message, privateKey))).toThrow(
+      "not allowlisted"
+    );
+    expect(store.listMessages({ from: "research-remote" })).toHaveLength(0);
   });
 
   it("delegates work to the least-loaded verified capable agent and logs the message", async () => {

--- a/src/services/network/messenger.ts
+++ b/src/services/network/messenger.ts
@@ -101,7 +101,7 @@ export class NetworkMessenger {
 
   constructor(options: NetworkMessengerOptions) {
     this.store = options.store;
-    this.localAgentId = options.localAgentId ?? "primary";
+    this.localAgentId = options.localAgentId?.trim() || "primary";
     this.privateKey = options.privateKey ?? null;
     this.fetcher = options.fetcher ?? fetch;
     this.timeoutMs = options.timeoutMs ?? 15_000;
@@ -170,6 +170,12 @@ export class NetworkMessenger {
   }
 
   receiveMessage(message: NetworkMessageEnvelope): NetworkMessageRecord {
+    if (message.to !== this.localAgentId) {
+      throw new Error(
+        `Network message to ${message.to} is not addressed to local agent ${this.localAgentId}`
+      );
+    }
+
     const sender = this.store.getAgent(message.from);
     if (!sender) {
       throw new Error(`Unknown network sender: ${message.from}`);

--- a/src/webui/__tests__/network-routes.test.ts
+++ b/src/webui/__tests__/network-routes.test.ts
@@ -2,7 +2,9 @@ import { generateKeyPairSync } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import Database from "better-sqlite3";
+import { getTaskStore } from "../../memory/agent/tasks.js";
 import { ensureSchema } from "../../memory/schema.js";
+import { getAgentNetworkStore } from "../../services/network/discovery.js";
 import { signNetworkMessage } from "../../services/network/messenger.js";
 import { createAgentNetworkIngressRoutes, createNetworkRoutes } from "../routes/network.js";
 import type { WebUIServerDeps } from "../types.js";
@@ -59,6 +61,57 @@ function buildDeps(
   };
 }
 
+function buildNetworkApp(
+  db: InstanceType<typeof Database>,
+  networkConfigOverrides: Partial<NonNullable<WebUIServerDeps["networkConfig"]>> = {}
+): Hono {
+  const networkApp = new Hono();
+  const deps = buildDeps(db, networkConfigOverrides);
+  networkApp.route("/api/network", createNetworkRoutes(deps));
+  networkApp.route("/api/agent-network", createAgentNetworkIngressRoutes(deps));
+  return networkApp;
+}
+
+async function registerSignedAgent(
+  networkApp: Hono,
+  agentId: string,
+  publicKey: string
+): Promise<void> {
+  const res = await networkApp.request("/api/network/agents", {
+    method: "POST",
+    body: JSON.stringify({
+      agentId,
+      name: "Remote Worker",
+      endpoint: `https://${agentId}.example.com/api/agent-network`,
+      capabilities: ["task-delegation"],
+      status: "available",
+      load: 0.2,
+      trustLevel: "verified",
+      publicKey,
+    }),
+    headers: { "Content-Type": "application/json" },
+  });
+  expect(res.status).toBe(201);
+}
+
+function signedTaskRequest(
+  privateKey: Parameters<typeof signNetworkMessage>[1],
+  overrides: Partial<Parameters<typeof signNetworkMessage>[0]> = {}
+) {
+  return signNetworkMessage(
+    {
+      type: "task_request",
+      from: "agent-003",
+      to: "primary",
+      correlationId: "route-corr-1",
+      timestamp: new Date().toISOString(),
+      payload: { description: "Handle delegated work", payload: { source: "test" } },
+      ...overrides,
+    },
+    privateKey
+  );
+}
+
 describe("network routes", () => {
   let db: InstanceType<typeof Database>;
   let app: Hono;
@@ -67,10 +120,7 @@ describe("network routes", () => {
     db = new Database(":memory:");
     db.pragma("foreign_keys = ON");
     ensureSchema(db);
-    app = new Hono();
-    const deps = buildDeps(db);
-    app.route("/api/network", createNetworkRoutes(deps));
-    app.route("/api/agent-network", createAgentNetworkIngressRoutes(deps));
+    app = buildNetworkApp(db);
   });
 
   afterEach(() => {
@@ -157,20 +207,11 @@ describe("network routes", () => {
 
   it("accepts signed ingress task requests and rejects unsigned ones", async () => {
     const { publicKey, privateKey } = generateKeyPairSync("ed25519");
-    await app.request("/api/network/agents", {
-      method: "POST",
-      body: JSON.stringify({
-        agentId: "agent-003",
-        name: "Remote Worker",
-        endpoint: "https://agent-003.example.com/api/agent-network",
-        capabilities: ["task-delegation"],
-        status: "available",
-        load: 0.2,
-        trustLevel: "verified",
-        publicKey: publicKey.export({ format: "pem", type: "spki" }).toString(),
-      }),
-      headers: { "Content-Type": "application/json" },
-    });
+    await registerSignedAgent(
+      app,
+      "agent-003",
+      publicKey.export({ format: "pem", type: "spki" }).toString()
+    );
     const message = {
       type: "task_request" as const,
       from: "agent-003",
@@ -195,6 +236,71 @@ describe("network routes", () => {
       headers: { "Content-Type": "application/json" },
     });
     expect(unsignedRes.status).toBe(400);
+  });
+
+  it("rejects signed ingress task requests from senders outside the configured allowlist", async () => {
+    const restrictedApp = buildNetworkApp(db, { allowlist: ["different-agent"] });
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    await registerSignedAgent(
+      restrictedApp,
+      "agent-003",
+      publicKey.export({ format: "pem", type: "spki" }).toString()
+    );
+
+    const res = await restrictedApp.request("/api/agent-network", {
+      method: "POST",
+      body: JSON.stringify(signedTaskRequest(privateKey)),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("not allowlisted");
+    expect(getTaskStore(db).listTasks({ createdBy: "network:agent-003" })).toHaveLength(0);
+    expect(getAgentNetworkStore(db).listMessages({ from: "agent-003" })).toHaveLength(0);
+  });
+
+  it("rejects signed ingress task requests from senders on the configured blocklist", async () => {
+    const restrictedApp = buildNetworkApp(db, { blocklist: ["agent-003"] });
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    await registerSignedAgent(
+      restrictedApp,
+      "agent-003",
+      publicKey.export({ format: "pem", type: "spki" }).toString()
+    );
+
+    const res = await restrictedApp.request("/api/agent-network", {
+      method: "POST",
+      body: JSON.stringify(signedTaskRequest(privateKey)),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("is blocked");
+    expect(getTaskStore(db).listTasks({ createdBy: "network:agent-003" })).toHaveLength(0);
+    expect(getAgentNetworkStore(db).listMessages({ from: "agent-003" })).toHaveLength(0);
+  });
+
+  it("rejects signed ingress task requests addressed to a different local agent", async () => {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    await registerSignedAgent(
+      app,
+      "agent-003",
+      publicKey.export({ format: "pem", type: "spki" }).toString()
+    );
+
+    const res = await app.request("/api/agent-network", {
+      method: "POST",
+      body: JSON.stringify(signedTaskRequest(privateKey, { to: "other-local-agent" })),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("not addressed to local agent");
+    expect(getTaskStore(db).listTasks({ createdBy: "network:agent-003" })).toHaveLength(0);
+    expect(getAgentNetworkStore(db).listMessages({ from: "agent-003" })).toHaveLength(0);
   });
 
   it("rejects remote ingress when the network is disabled", async () => {

--- a/src/webui/routes/network.ts
+++ b/src/webui/routes/network.ts
@@ -4,6 +4,7 @@ import { AuditTrailService } from "../../services/audit-trail.js";
 import { NetworkTaskCoordinator } from "../../services/network/coordinator.js";
 import { getAgentNetworkStore } from "../../services/network/discovery.js";
 import { NetworkMessenger } from "../../services/network/messenger.js";
+import { NetworkTrustService } from "../../services/network/trust.js";
 import {
   NETWORK_AGENT_STATUSES,
   NETWORK_TRUST_LEVELS,
@@ -94,6 +95,10 @@ function createMessenger(deps: WebUIServerDeps): NetworkMessenger {
     timeoutMs: deps.networkConfig?.message_timeout_ms,
     maxClockSkewSeconds: deps.networkConfig?.max_clock_skew_seconds,
     auditTrail: new AuditTrailService(deps.memory.db),
+    trustService: new NetworkTrustService({
+      allowlist: deps.networkConfig?.allowlist,
+      blocklist: deps.networkConfig?.blocklist,
+    }),
   });
 }
 


### PR DESCRIPTION
## Description

Fixes the inbound agent-network trust boundary for signed messages. Ingress now uses the configured network allowlist/blocklist, and `NetworkMessenger.receiveMessage()` rejects envelopes whose `to` field does not match the local agent id before logging received messages or creating tasks.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Reproduction and Regression Coverage

Before this fix, a signed `task_request` from a verified peer outside `network.allowlist`, from a configured blocklisted peer, or addressed to a different local agent returned HTTP 202 and could create local tasks.

Added regression coverage in:

- `src/services/network/__tests__/network.test.ts` for wrong-recipient rejection and configured inbound trust denial before message logging
- `src/webui/__tests__/network-routes.test.ts` for allowlist rejection, blocklist rejection, wrong-recipient rejection, and no task/message side effects

## Verification

- [x] `npm run build:sdk`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test`
- [x] `npm run test:coverage`
- [x] `npm run build` (after `npm ci --prefix web`, matching CI setup)
- [x] `npm run audit:ci`

## Screenshots

Not applicable: backend security fix.

## Related Issues

Fixes xlabtg/teleton-agent#400
