### PR TITLE
fix: dispatch agent network ingress tasks

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-24T11:49:29.730Z for PR creation at branch issue-401-bde3b331f288 for issue https://github.com/xlabtg/teleton-agent/issues/401

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-24T11:49:29.730Z for PR creation at branch issue-401-bde3b331f288 for issue https://github.com/xlabtg/teleton-agent/issues/401

--- a/docs/agent-network.md
+++ b/docs/agent-network.md
@@ -69,4 +69,6 @@ Signed remote ingress:
 
 - `POST /api/agent-network`
 
-Inbound `task_request` messages create a local pending task with `created_by` set to `network:<agentId>`. Network messages are recorded in `network_messages` and mirrored into the tamper-evident audit trail as `network.message` events.
+Inbound `task_request` messages are submitted to the autonomous task manager when it is available, and the ingress response includes `taskRuntime: "autonomous"` plus an `execution` state of `dispatched` or `queued`. The autonomous task context stores the source agent, network message id, correlation id, requested capabilities, and nested task payload.
+
+If the autonomous manager is not configured, ingress still records the request as an explicit manual inbox item in the scheduled-task table with `created_by` set to `network:<agentId>`. In that fallback case the response includes `taskRuntime: "manual_inbox"` and `execution.state: "queued"` so callers can distinguish accepted-but-manual work from dispatched work. Network messages are recorded in `network_messages` and mirrored into the tamper-evident audit trail as `network.message` events.

--- a/src/webui/__tests__/network-routes.test.ts
+++ b/src/webui/__tests__/network-routes.test.ts
@@ -2,6 +2,10 @@ import { generateKeyPairSync } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import Database from "better-sqlite3";
+import { AutonomousTaskManager } from "../../autonomous/manager.js";
+import type { LoopDependencies } from "../../autonomous/loop.js";
+import { getAutonomousTaskStore } from "../../memory/agent/autonomous-tasks.js";
+import { getTaskStore } from "../../memory/agent/tasks.js";
 import { ensureSchema } from "../../memory/schema.js";
 import { signNetworkMessage } from "../../services/network/messenger.js";
 import { createAgentNetworkIngressRoutes, createNetworkRoutes } from "../routes/network.js";
@@ -9,12 +13,14 @@ import type { WebUIServerDeps } from "../types.js";
 
 const { privateKey: localPrivateKey } = generateKeyPairSync("ed25519");
 const LOCAL_PRIVATE_KEY = localPrivateKey.export({ format: "pem", type: "pkcs8" }).toString();
+type SigningKey = Parameters<typeof signNetworkMessage>[1];
 
 function buildDeps(
   db: InstanceType<typeof Database>,
-  networkConfigOverrides: Partial<NonNullable<WebUIServerDeps["networkConfig"]>> = {}
+  networkConfigOverrides: Partial<NonNullable<WebUIServerDeps["networkConfig"]>> = {},
+  depsOverrides: Partial<WebUIServerDeps> = {}
 ): WebUIServerDeps {
-  return {
+  const deps: WebUIServerDeps = {
     configPath: "/tmp/teleton/config.yaml",
     config: {
       auth_token: "test",
@@ -57,11 +63,40 @@ function buildDeps(
       ...networkConfigOverrides,
     },
   };
+  return { ...deps, ...depsOverrides };
+}
+
+function hangingLoopDeps(): LoopDependencies {
+  return {
+    planNextAction: vi.fn().mockImplementation(() => new Promise(() => {})),
+    executeTool: vi.fn().mockResolvedValue({ success: true, durationMs: 1 }),
+    evaluateSuccess: vi.fn().mockResolvedValue(false),
+    selfReflect: vi.fn().mockResolvedValue({ progressSummary: "", isStuck: false }),
+    escalate: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+async function signedTaskRequest(app: Hono, privateKey: SigningKey, from = "agent-003") {
+  const message = {
+    type: "task_request" as const,
+    from,
+    to: "primary",
+    correlationId: "route-corr-1",
+    timestamp: new Date().toISOString(),
+    payload: { description: "Handle delegated work", payload: { source: "test" } },
+  };
+
+  return app.request("/api/agent-network", {
+    method: "POST",
+    body: JSON.stringify(signNetworkMessage(message, privateKey)),
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 describe("network routes", () => {
   let db: InstanceType<typeof Database>;
   let app: Hono;
+  let managers: AutonomousTaskManager[] = [];
 
   beforeEach(() => {
     db = new Database(":memory:");
@@ -74,6 +109,8 @@ describe("network routes", () => {
   });
 
   afterEach(() => {
+    for (const manager of managers) manager.stopAll();
+    managers = [];
     vi.unstubAllGlobals();
     db.close();
   });
@@ -188,6 +225,18 @@ describe("network routes", () => {
     expect(acceptedRes.status).toBe(202);
     const acceptedBody = await acceptedRes.json();
     expect(acceptedBody.data.taskId).toEqual(expect.any(String));
+    expect(acceptedBody.data).toMatchObject({
+      taskRuntime: "manual_inbox",
+      taskStatus: "pending",
+      execution: {
+        mode: "manual_inbox",
+        state: "queued",
+      },
+    });
+    expect(getTaskStore(db).getTask(acceptedBody.data.taskId)).toMatchObject({
+      status: "pending",
+      createdBy: "network:agent-003",
+    });
 
     const unsignedRes = await app.request("/api/agent-network", {
       method: "POST",
@@ -195,6 +244,58 @@ describe("network routes", () => {
       headers: { "Content-Type": "application/json" },
     });
     expect(unsignedRes.status).toBe(400);
+  });
+
+  it("dispatches signed ingress task requests to the autonomous manager when available", async () => {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    await app.request("/api/network/agents", {
+      method: "POST",
+      body: JSON.stringify({
+        agentId: "agent-004",
+        name: "Remote Autonomous Worker",
+        endpoint: "https://agent-004.example.com/api/agent-network",
+        capabilities: ["task-delegation"],
+        status: "available",
+        load: 0.2,
+        trustLevel: "verified",
+        publicKey: publicKey.export({ format: "pem", type: "spki" }).toString(),
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const manager = new AutonomousTaskManager(db, hangingLoopDeps());
+    managers.push(manager);
+    const ingressApp = new Hono();
+    ingressApp.route(
+      "/api/agent-network",
+      createAgentNetworkIngressRoutes(buildDeps(db, {}, { autonomousManager: manager }))
+    );
+
+    const acceptedRes = await signedTaskRequest(ingressApp, privateKey, "agent-004");
+    expect(acceptedRes.status).toBe(202);
+    const acceptedBody = await acceptedRes.json();
+    expect(acceptedBody.data).toMatchObject({
+      accepted: true,
+      taskRuntime: "autonomous",
+      taskStatus: "running",
+      execution: { mode: "autonomous", state: "dispatched" },
+    });
+
+    const task = getAutonomousTaskStore(db).getTask(acceptedBody.data.taskId);
+    expect(task).toMatchObject({
+      goal: "Handle delegated work",
+      context: {
+        network: {
+          from: "agent-004",
+          correlationId: "route-corr-1",
+        },
+        payload: { source: "test" },
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(getAutonomousTaskStore(db).getTask(acceptedBody.data.taskId)?.status).toBe("running");
+    expect(manager.isTaskRunning(acceptedBody.data.taskId)).toBe(true);
   });
 
   it("rejects remote ingress when the network is disabled", async () => {

--- a/src/webui/routes/network.ts
+++ b/src/webui/routes/network.ts
@@ -256,10 +256,49 @@ export function createAgentNetworkIngressRoutes(deps: WebUIServerDeps) {
           typeof payload.description === "string" && payload.description.trim()
             ? payload.description.trim()
             : `Network task from ${message.from}`;
+        const taskPayload = normalizePayload(payload.payload);
+        const requiredCapabilities = normalizeStringArray(payload.requiredCapabilities);
+        const networkContext = {
+          network: {
+            messageId: record.id,
+            from: message.from,
+            to: message.to,
+            correlationId: message.correlationId,
+            requiredCapabilities,
+            receivedAt: record.receivedAt,
+          },
+          payload: taskPayload,
+        };
+
+        if (deps.autonomousManager) {
+          const task = await deps.autonomousManager.startTask({
+            goal: description,
+            context: networkContext,
+          });
+          const currentTask = deps.autonomousManager.getStore().getTask(task.id) ?? task;
+          return c.json(
+            {
+              success: true,
+              data: {
+                accepted: true,
+                message: record,
+                taskId: task.id,
+                taskRuntime: "autonomous",
+                taskStatus: currentTask.status,
+                execution: {
+                  mode: "autonomous",
+                  state: currentTask.status === "queued" ? "queued" : "dispatched",
+                },
+              },
+            } as APIResponse,
+            202
+          );
+        }
+
         const task = getTaskStore(deps.memory.db).createTask({
           description,
           createdBy: `network:${message.from}`,
-          payload: JSON.stringify(payload.payload ?? {}),
+          payload: JSON.stringify(taskPayload),
           reason: `Remote network task ${message.correlationId}`,
         });
         return c.json(
@@ -269,6 +308,14 @@ export function createAgentNetworkIngressRoutes(deps: WebUIServerDeps) {
               accepted: true,
               message: record,
               taskId: task.id,
+              taskRuntime: "manual_inbox",
+              taskStatus: task.status,
+              execution: {
+                mode: "manual_inbox",
+                state: "queued",
+                reason:
+                  "Autonomous manager is unavailable; operator action is required to run this task.",
+              },
             },
           } as APIResponse,
           202


### PR DESCRIPTION
## Summary

Fixes xlabtg/teleton-agent#401.

Remote signed `task_request` ingress no longer accepts work into an inert generic pending task without a runtime path:

- When `AutonomousTaskManager` is wired into WebUI/API deps, `/api/agent-network` submits the request with `startTask()` and returns `taskRuntime: "autonomous"` with dispatch state and refreshed task status.
- The autonomous task context preserves the network message id, source/target agents, correlation id, requested capabilities, and nested task payload.
- When the autonomous manager is unavailable, the route keeps the durable scheduled-task fallback but now labels it explicitly as `taskRuntime: "manual_inbox"` with `execution.state: "queued"`, so callers can distinguish accepted manual inbox work from dispatched work.
- `docs/agent-network.md` documents the dispatch and fallback contract.

## Reproduction

Before this change, a signed `task_request` POST to `/api/agent-network` returned HTTP 202 and a `taskId`, but the id pointed at a generic `tasks` row with `status = pending` and no Telegram scheduling metadata, so nothing executed it.

## Merge Update

Merged latest `upstream/main` into `issue-401-bde3b331f288` and resolved the test conflict in `src/webui/__tests__/network-routes.test.ts` by keeping both the issue-401 autonomous dispatch regression and the new upstream allowlist/blocklist/addressing ingress coverage.

## Verification

- Added a regression test that wires an `AutonomousTaskManager` into network ingress and verifies the signed request creates an autonomous task, preserves network context, and transitions to `running`.
- Tightened the existing no-manager ingress test to verify the explicit `manual_inbox` queued fallback.
- Preserved upstream ingress rejection tests for allowlist, blocklist, and wrong recipient cases during the merge resolution.

## Tests

Latest local verification after resolving conflicts:

- `npm ci`
- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npx vitest run src/webui/__tests__/network-routes.test.ts` - 8 tests passed

Prior full-suite verification on this PR:

- `npm test` - 193 files / 3406 tests passed

Note: one earlier full-suite run hit an unrelated managed-agent timing assertion in `src/agents/__tests__/service.test.ts`; the test passed when rerun in isolation, and the subsequent full-suite run passed.
