### PR TITLE
fix: reject replayed network messages

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-24T11:49:42.118Z for PR creation at branch issue-402-4a28e2320c55 for issue https://github.com/xlabtg/teleton-agent/issues/402

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-24T11:49:42.118Z for PR creation at branch issue-402-4a28e2320c55 for issue https://github.com/xlabtg/teleton-agent/issues/402

--- a/src/memory/__tests__/schema.test.ts
+++ b/src/memory/__tests__/schema.test.ts
@@ -348,12 +348,27 @@ describe("Memory Schema", () => {
           "from_agent_id",
           "to_agent_id",
           "correlation_id",
+          "replay_key",
           "payload",
           "signature",
           "timestamp",
           "status",
         ])
       );
+
+      const messageIndexes = db
+        .prepare(
+          `
+            SELECT name, sql
+            FROM sqlite_master
+            WHERE type='index' AND tbl_name='network_messages'
+          `
+        )
+        .all() as Array<{ name: string; sql: string | null }>;
+      const replayIndex = messageIndexes.find(
+        (index) => index.name === "idx_network_messages_replay_key"
+      );
+      expect(replayIndex?.sql).toMatch(/CREATE UNIQUE INDEX/i);
     });
 
     it("creates memory graph tables with correct schema", () => {
@@ -1326,7 +1341,7 @@ describe("Memory Schema", () => {
     });
 
     it("CURRENT_SCHEMA_VERSION is set to expected value", () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe("1.35.0");
+      expect(CURRENT_SCHEMA_VERSION).toBe("1.36.0");
     });
   });
 

--- a/src/memory/schema.ts
+++ b/src/memory/schema.ts
@@ -424,6 +424,7 @@ export function ensureSchema(db: Database.Database): void {
       from_agent_id TEXT NOT NULL,
       to_agent_id TEXT NOT NULL,
       correlation_id TEXT NOT NULL,
+      replay_key TEXT,
       payload TEXT NOT NULL DEFAULT '{}',
       signature TEXT,
       timestamp TEXT NOT NULL,
@@ -438,6 +439,8 @@ export function ensureSchema(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_network_messages_from ON network_messages(from_agent_id, created_at DESC);
     CREATE INDEX IF NOT EXISTS idx_network_messages_to ON network_messages(to_agent_id, created_at DESC);
     CREATE INDEX IF NOT EXISTS idx_network_messages_correlation ON network_messages(correlation_id);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_network_messages_replay_key
+      ON network_messages(replay_key) WHERE replay_key IS NOT NULL;
     CREATE INDEX IF NOT EXISTS idx_network_messages_status ON network_messages(status, created_at DESC);
 
     -- ============================================
@@ -937,7 +940,7 @@ export function setSchemaVersion(db: Database.Database, version: string): void {
   ).run(version);
 }
 
-export const CURRENT_SCHEMA_VERSION = "1.35.0";
+export const CURRENT_SCHEMA_VERSION = "1.36.0";
 
 export function runMigrations(db: Database.Database): void {
   const currentVersion = getSchemaVersion(db);
@@ -2061,6 +2064,7 @@ export function runMigrations(db: Database.Database): void {
           from_agent_id TEXT NOT NULL,
           to_agent_id TEXT NOT NULL,
           correlation_id TEXT NOT NULL,
+          replay_key TEXT,
           payload TEXT NOT NULL DEFAULT '{}',
           signature TEXT,
           timestamp TEXT NOT NULL,
@@ -2075,11 +2079,33 @@ export function runMigrations(db: Database.Database): void {
         CREATE INDEX IF NOT EXISTS idx_network_messages_from ON network_messages(from_agent_id, created_at DESC);
         CREATE INDEX IF NOT EXISTS idx_network_messages_to ON network_messages(to_agent_id, created_at DESC);
         CREATE INDEX IF NOT EXISTS idx_network_messages_correlation ON network_messages(correlation_id);
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_network_messages_replay_key
+          ON network_messages(replay_key) WHERE replay_key IS NOT NULL;
         CREATE INDEX IF NOT EXISTS idx_network_messages_status ON network_messages(status, created_at DESC);
       `);
       log.info("Migration 1.35.0 complete: agent network tables created");
     } catch (error) {
       log.error({ err: error }, "Migration 1.35.0 failed");
+      throw error;
+    }
+  }
+
+  if (!currentVersion || versionLessThan(currentVersion, "1.36.0")) {
+    log.info("Running migration 1.36.0: Add agent network replay protection");
+    try {
+      const columns = db.prepare("PRAGMA table_info(network_messages)").all() as Array<{
+        name: string;
+      }>;
+      if (!columns.some((column) => column.name === "replay_key")) {
+        db.exec(`ALTER TABLE network_messages ADD COLUMN replay_key TEXT;`);
+      }
+      db.exec(`
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_network_messages_replay_key
+          ON network_messages(replay_key) WHERE replay_key IS NOT NULL;
+      `);
+      log.info("Migration 1.36.0 complete: agent network replay protection added");
+    } catch (error) {
+      log.error({ err: error }, "Migration 1.36.0 failed");
       throw error;
     }
   }

--- a/src/services/network/discovery.ts
+++ b/src/services/network/discovery.ts
@@ -39,6 +39,7 @@ interface NetworkMessageRow {
   from_agent_id: string;
   to_agent_id: string;
   correlation_id: string;
+  replay_key: string | null;
   payload: string;
   signature: string | null;
   timestamp: string;
@@ -139,6 +140,10 @@ function normalizeMessageStatus(value: string): NetworkMessageStatus {
   return NETWORK_MESSAGE_STATUSES.includes(value as NetworkMessageStatus)
     ? (value as NetworkMessageStatus)
     : "queued";
+}
+
+function messageReplayKey(envelope: NetworkMessageEnvelope): string {
+  return JSON.stringify([envelope.from, envelope.to, envelope.correlationId]);
 }
 
 function rowToAgent(row: NetworkAgentRow): NetworkAgentRecord {
@@ -339,15 +344,16 @@ export class AgentNetworkStore {
     const sentAt = options.sentAt === undefined && status === "sent" ? now : options.sentAt;
     const receivedAt =
       options.receivedAt === undefined && status === "received" ? now : options.receivedAt;
+    const replayKey = status === "received" ? messageReplayKey(envelope) : null;
 
     this.db
       .prepare(
         `
           INSERT INTO network_messages (
-            id, type, from_agent_id, to_agent_id, correlation_id, payload,
+            id, type, from_agent_id, to_agent_id, correlation_id, replay_key, payload,
             signature, timestamp, status, error, created_at, sent_at, received_at
           )
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `
       )
       .run(
@@ -356,6 +362,7 @@ export class AgentNetworkStore {
         envelope.from,
         envelope.to,
         envelope.correlationId,
+        replayKey,
         JSON.stringify(envelope.payload ?? {}),
         envelope.signature ?? null,
         envelope.timestamp,
@@ -371,6 +378,24 @@ export class AgentNetworkStore {
       | undefined;
     if (!row) throw new Error(`Network message log failed: ${id}`);
     return rowToMessage(row);
+  }
+
+  findReceivedMessage(envelope: NetworkMessageEnvelope): NetworkMessageRecord | null {
+    const row = this.db
+      .prepare(
+        `
+          SELECT *
+          FROM network_messages
+          WHERE status = 'received'
+            AND from_agent_id = ?
+            AND to_agent_id = ?
+            AND correlation_id = ?
+          ORDER BY created_at ASC, rowid ASC
+          LIMIT 1
+        `
+      )
+      .get(envelope.from, envelope.to, envelope.correlationId) as NetworkMessageRow | undefined;
+    return row ? rowToMessage(row) : null;
   }
 
   listMessages(filter: MessageListFilter = {}): NetworkMessageRecord[] {

--- a/src/services/network/messenger.ts
+++ b/src/services/network/messenger.ts
@@ -89,6 +89,13 @@ export function verifyNetworkMessage(
   }
 }
 
+export class NetworkMessageReplayError extends Error {
+  constructor(readonly existingMessage: NetworkMessageRecord) {
+    super(`Network message replay detected for correlation id ${existingMessage.correlationId}`);
+    this.name = "NetworkMessageReplayError";
+  }
+}
+
 export class NetworkMessenger {
   private readonly store: AgentNetworkStore;
   private readonly localAgentId: string;
@@ -196,7 +203,21 @@ export class NetworkMessenger {
       throw new Error(authorization.reason ?? "Network sender is not authorized");
     }
 
-    const record = this.store.logMessage(message, "received");
+    const existing = this.store.findReceivedMessage(message);
+    if (existing) {
+      throw new NetworkMessageReplayError(existing);
+    }
+
+    let record: NetworkMessageRecord;
+    try {
+      record = this.store.logMessage(message, "received");
+    } catch (error) {
+      const replayed = this.store.findReceivedMessage(message);
+      if (replayed) {
+        throw new NetworkMessageReplayError(replayed);
+      }
+      throw error;
+    }
     this.auditMessage(record);
     return record;
   }

--- a/src/webui/__tests__/network-routes.test.ts
+++ b/src/webui/__tests__/network-routes.test.ts
@@ -2,7 +2,9 @@ import { generateKeyPairSync } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import Database from "better-sqlite3";
+import { getTaskStore } from "../../memory/agent/tasks.js";
 import { ensureSchema } from "../../memory/schema.js";
+import { getAgentNetworkStore } from "../../services/network/discovery.js";
 import { signNetworkMessage } from "../../services/network/messenger.js";
 import { createAgentNetworkIngressRoutes, createNetworkRoutes } from "../routes/network.js";
 import type { WebUIServerDeps } from "../types.js";
@@ -57,6 +59,32 @@ function buildDeps(
       ...networkConfigOverrides,
     },
   };
+}
+
+async function registerSignedPeer(
+  app: Hono,
+  input: {
+    agentId: string;
+    publicKey: string;
+    capabilities?: string[];
+  }
+): Promise<void> {
+  const res = await app.request("/api/network/agents", {
+    method: "POST",
+    body: JSON.stringify({
+      agentId: input.agentId,
+      name: input.agentId,
+      endpoint: `https://${input.agentId}.example.com/api/agent-network`,
+      capabilities: input.capabilities ?? ["task-delegation"],
+      status: "available",
+      load: 0.2,
+      trustLevel: "verified",
+      publicKey: input.publicKey,
+    }),
+    headers: { "Content-Type": "application/json" },
+  });
+
+  expect(res.status).toBe(201);
 }
 
 describe("network routes", () => {
@@ -157,19 +185,9 @@ describe("network routes", () => {
 
   it("accepts signed ingress task requests and rejects unsigned ones", async () => {
     const { publicKey, privateKey } = generateKeyPairSync("ed25519");
-    await app.request("/api/network/agents", {
-      method: "POST",
-      body: JSON.stringify({
-        agentId: "agent-003",
-        name: "Remote Worker",
-        endpoint: "https://agent-003.example.com/api/agent-network",
-        capabilities: ["task-delegation"],
-        status: "available",
-        load: 0.2,
-        trustLevel: "verified",
-        publicKey: publicKey.export({ format: "pem", type: "spki" }).toString(),
-      }),
-      headers: { "Content-Type": "application/json" },
+    await registerSignedPeer(app, {
+      agentId: "agent-003",
+      publicKey: publicKey.export({ format: "pem", type: "spki" }).toString(),
     });
     const message = {
       type: "task_request" as const,
@@ -195,6 +213,117 @@ describe("network routes", () => {
       headers: { "Content-Type": "application/json" },
     });
     expect(unsignedRes.status).toBe(400);
+  });
+
+  it("rejects replayed signed task requests before creating duplicate tasks", async () => {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    await registerSignedPeer(app, {
+      agentId: "agent-004",
+      publicKey: publicKey.export({ format: "pem", type: "spki" }).toString(),
+    });
+    const signed = signNetworkMessage(
+      {
+        type: "task_request",
+        from: "agent-004",
+        to: "primary",
+        correlationId: "route-corr-replay-task",
+        timestamp: new Date().toISOString(),
+        payload: { description: "Handle delegated work", payload: { source: "test" } },
+      },
+      privateKey
+    );
+
+    const firstRes = await app.request("/api/agent-network", {
+      method: "POST",
+      body: JSON.stringify(signed),
+      headers: { "Content-Type": "application/json" },
+    });
+    const replayRes = await app.request("/api/agent-network", {
+      method: "POST",
+      body: JSON.stringify(signed),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(firstRes.status).toBe(202);
+    expect(replayRes.status).toBe(409);
+    const replayBody = await replayRes.json();
+    expect(replayBody.error).toMatch(/replay/i);
+    expect(getTaskStore(db).listTasks({ createdBy: "network:agent-004" })).toHaveLength(1);
+    expect(
+      getAgentNetworkStore(db).listMessages({ from: "agent-004", to: "primary" })
+    ).toHaveLength(1);
+  });
+
+  it("rejects replayed signed heartbeats", async () => {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    await registerSignedPeer(app, {
+      agentId: "agent-005",
+      publicKey: publicKey.export({ format: "pem", type: "spki" }).toString(),
+    });
+    const signed = signNetworkMessage(
+      {
+        type: "heartbeat",
+        from: "agent-005",
+        to: "primary",
+        correlationId: "route-corr-replay-heartbeat",
+        timestamp: new Date().toISOString(),
+        payload: { status: "available", load: 0.1 },
+      },
+      privateKey
+    );
+
+    const firstRes = await app.request("/api/agent-network", {
+      method: "POST",
+      body: JSON.stringify(signed),
+      headers: { "Content-Type": "application/json" },
+    });
+    const replayRes = await app.request("/api/agent-network", {
+      method: "POST",
+      body: JSON.stringify(signed),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(firstRes.status).toBe(200);
+    expect(replayRes.status).toBe(409);
+    expect(
+      getAgentNetworkStore(db).listMessages({ from: "agent-005", to: "primary" })
+    ).toHaveLength(1);
+  });
+
+  it("rejects replayed signed task responses", async () => {
+    const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+    await registerSignedPeer(app, {
+      agentId: "agent-006",
+      publicKey: publicKey.export({ format: "pem", type: "spki" }).toString(),
+    });
+    const signed = signNetworkMessage(
+      {
+        type: "task_response",
+        from: "agent-006",
+        to: "primary",
+        correlationId: "route-corr-replay-response",
+        timestamp: new Date().toISOString(),
+        payload: { status: "done", result: "ok" },
+      },
+      privateKey
+    );
+
+    const firstRes = await app.request("/api/agent-network", {
+      method: "POST",
+      body: JSON.stringify(signed),
+      headers: { "Content-Type": "application/json" },
+    });
+    const replayRes = await app.request("/api/agent-network", {
+      method: "POST",
+      body: JSON.stringify(signed),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    expect(firstRes.status).toBe(200);
+    expect(replayRes.status).toBe(409);
+    expect(
+      getAgentNetworkStore(db).listMessages({ from: "agent-006", to: "primary" })
+    ).toHaveLength(1);
   });
 
   it("rejects remote ingress when the network is disabled", async () => {

--- a/src/webui/routes/network.ts
+++ b/src/webui/routes/network.ts
@@ -3,7 +3,7 @@ import { getTaskStore } from "../../memory/agent/tasks.js";
 import { AuditTrailService } from "../../services/audit-trail.js";
 import { NetworkTaskCoordinator } from "../../services/network/coordinator.js";
 import { getAgentNetworkStore } from "../../services/network/discovery.js";
-import { NetworkMessenger } from "../../services/network/messenger.js";
+import { NetworkMessageReplayError, NetworkMessenger } from "../../services/network/messenger.js";
 import {
   NETWORK_AGENT_STATUSES,
   NETWORK_TRUST_LEVELS,
@@ -290,7 +290,8 @@ export function createAgentNetworkIngressRoutes(deps: WebUIServerDeps) {
 
       return c.json({ success: true, data: { accepted: true, message: record } } as APIResponse);
     } catch (error) {
-      return c.json({ success: false, error: getErrorMessage(error) } as APIResponse, 400);
+      const status = error instanceof NetworkMessageReplayError ? 409 : 400;
+      return c.json({ success: false, error: getErrorMessage(error) } as APIResponse, status);
     }
   });
 


### PR DESCRIPTION
## Summary
- Add a received-message replay key and unique partial index for agent network messages.
- Reject previously received sender/recipient/correlation ids in NetworkMessenger before route side effects run.
- Return HTTP 409 for replayed ingress envelopes and cover task_request, heartbeat, and task_response replays.

## Reproduction
1. Register a verified peer with a public key.
2. POST the same signed /api/agent-network envelope twice with the same correlationId.
3. Before this fix, both requests were accepted and duplicate local task/message rows could be created.
4. After this fix, the second delivery is rejected as a replay and no duplicate task is created.

## Tests
- npm test -- src/webui/__tests__/network-routes.test.ts
- npm test -- src/memory/__tests__/schema.test.ts
- npm run build:sdk
- npm run typecheck
- npm run lint
- npm test
- npm run build:backend

Fixes xlabtg/teleton-agent#402