### PR TITLE
[WORK3-H3] Expose V2 WebUI routes through Management API

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-24T11:49:57.482Z for PR creation at branch issue-403-226344248641 for issue https://github.com/xlabtg/teleton-agent/issues/403

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-24T11:49:57.482Z for PR creation at branch issue-403-226344248641 for issue https://github.com/xlabtg/teleton-agent/issues/403

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -272,7 +272,7 @@ Useful for testing connectivity and key validity without side effects.
 
 ### Reused WebUI Routes
 
-The API mounts all existing WebUI route factories under `/v1/`, giving you full access to every dashboard feature via HTTP:
+The API mounts stable WebUI route factories under `/v1/`, giving remote management clients access to dashboard features via HTTP:
 
 | Prefix | Description |
 |--------|-------------|
@@ -289,7 +289,35 @@ The API mounts all existing WebUI route factories under `/v1/`, giving you full 
 | `/v1/marketplace` | Plugin marketplace |
 | `/v1/hooks` | Hook management |
 | `/v1/ton-proxy` | TON Proxy control |
+| `/v1/notifications` | In-app notifications and unread counts |
+| `/v1/cache` | Predictive cache inspection and controls |
+| `/v1/metrics` | Operational metrics |
+| `/v1/sessions` | Chat session search and inspection |
+| `/v1/analytics` | Usage analytics |
+| `/v1/anomalies` | Anomaly detection data |
+| `/v1/security` | Security status and zero-trust policy data |
+| `/v1/audit` | Audit trail search and stream |
+| `/v1/health-check` | Composite application health checks |
+| `/v1/export` | Safe configuration and prompt export/import |
+| `/v1/workflows` | Workflow definitions and scheduling |
+| `/v1/pipelines` | Pipeline definitions and execution |
+| `/v1/self-improvement` | Self-improvement run history and controls |
+| `/v1/autonomous` | Autonomous task queue and policy routes |
+| `/v1/predictions` | Prediction service data |
+| `/v1/context` | Temporal context analytics |
+| `/v1/dashboards` | Dynamic dashboard layout and widgets |
+| `/v1/widgets` | Widget generator routes |
+| `/v1/network` | Agent network registry and delegation routes |
 | `/v1/setup` | Setup wizard (works without agent) |
+
+WebUI route groups intentionally not mirrored in the Management API:
+
+| WebUI Prefix | Reason |
+|--------------|--------|
+| `/api/agent-network` | Signed inter-agent ingress with protocol authentication, not API key authentication |
+| `/api/agent-actions` | Browser-specific control helper; management clients use `/v1/agent` |
+| `/api/groq` | WebUI provider configuration helper |
+| `/api/mtproto` | WebUI setup/configuration helper |
 
 > Routes that require agent subsystems (memory, bridge, etc.) return `503` with an RFC 9457 error if the agent is not running.
 

--- a/src/api/__tests__/api-route-parity.test.ts
+++ b/src/api/__tests__/api-route-parity.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const STABLE_V2_WEBUI_GROUPS = [
+  "analytics",
+  "anomalies",
+  "audit",
+  "autonomous",
+  "cache",
+  "context",
+  "dashboards",
+  "export",
+  "health-check",
+  "metrics",
+  "network",
+  "notifications",
+  "pipelines",
+  "predictions",
+  "security",
+  "self-improvement",
+  "sessions",
+  "widgets",
+  "workflows",
+];
+
+const WEBUI_ONLY_GROUPS = new Map<string, string>([
+  [
+    "agent-actions",
+    "WebUI-only action surface for browser-driven agent controls; management clients use /v1/agent.",
+  ],
+  [
+    "agent-network",
+    "Signed inter-agent ingress with protocol authentication, not management API bearer authentication.",
+  ],
+  ["groq", "WebUI provider configuration helper, not a stable management API surface."],
+  ["mtproto", "WebUI setup/configuration helper, not a stable management API surface."],
+]);
+
+function readServerSource(relativePath: string): string {
+  return readFileSync(resolve(__dirname, relativePath), "utf8");
+}
+
+function mountedGroups(source: string, prefix: "api" | "v1"): Set<string> {
+  const groups = new Set<string>();
+  const pattern = new RegExp(`this\\.app\\.route\\("/${prefix}/([^"]+)"`, "g");
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(source))) {
+    groups.add(match[1]);
+  }
+
+  return groups;
+}
+
+describe("Management API route parity", () => {
+  const webuiGroups = mountedGroups(readServerSource("../../webui/server.ts"), "api");
+  const managementGroups = mountedGroups(readServerSource("../server.ts"), "v1");
+
+  it("mounts stable V2 WebUI route groups under /v1", () => {
+    const missing = STABLE_V2_WEBUI_GROUPS.filter((group) => !managementGroups.has(group));
+
+    for (const group of STABLE_V2_WEBUI_GROUPS) {
+      expect(webuiGroups.has(group), `${group} should be a WebUI route group`).toBe(true);
+    }
+
+    expect(missing).toEqual([]);
+  });
+
+  it("keeps every non-management WebUI group explicitly documented", () => {
+    const undocumented = [...webuiGroups].filter(
+      (group) => !managementGroups.has(group) && !WEBUI_ONLY_GROUPS.has(group)
+    );
+    const staleExemptions = [...WEBUI_ONLY_GROUPS.keys()].filter(
+      (group) => !webuiGroups.has(group)
+    );
+
+    expect(undocumented).toEqual([]);
+    expect(staleExemptions).toEqual([]);
+  });
+});

--- a/src/api/bootstrap.ts
+++ b/src/api/bootstrap.ts
@@ -73,6 +73,7 @@ export async function startApiOnly(options: { config?: string; apiPort?: string 
         toolRegistry: appInstance.getToolRegistry(),
         plugins: appInstance.getPlugins(),
         config: appInstance.getWebuiConfig(),
+        networkConfig: appInstance.getNetworkConfig(),
       });
     },
     // stopFn — called when POST /v1/agent/stop fires
@@ -88,6 +89,7 @@ export async function startApiOnly(options: { config?: string; apiPort?: string 
           memory: null,
           toolRegistry: null,
           plugins: null,
+          networkConfig: undefined,
         });
       }
     }

--- a/src/api/deps.ts
+++ b/src/api/deps.ts
@@ -3,7 +3,7 @@ import type { TelegramBridge } from "../telegram/bridge.js";
 import type { MemorySystem } from "../memory/index.js";
 import type { ToolRegistry } from "../agent/tools/registry.js";
 import type { WebUIServerDeps, LoadedPlugin, McpServerInfo } from "../webui/types.js";
-import type { WebUIConfig } from "../config/schema.js";
+import type { NetworkConfig, WebUIConfig } from "../config/schema.js";
 import type { Database } from "better-sqlite3";
 import type { AgentLifecycle } from "../agent/lifecycle.js";
 import type { UserHookEvaluator } from "../agent/hooks/user-hook-evaluator.js";
@@ -28,6 +28,7 @@ export interface ApiServerDeps {
   plugins?: LoadedPlugin[] | null;
   mcpServers?: McpServerInfo[] | (() => McpServerInfo[]) | null;
   config: WebUIConfig;
+  networkConfig?: NetworkConfig;
   configPath: string;
   lifecycle?: AgentLifecycle | null;
   marketplace?: MarketplaceDeps | null;
@@ -50,6 +51,7 @@ export function createDepsAdapter(apiDeps: ApiServerDeps): WebUIServerDeps {
       // These are always available
       if (
         prop === "config" ||
+        prop === "networkConfig" ||
         prop === "configPath" ||
         prop === "lifecycle" ||
         prop === "userHookEvaluator" ||

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -47,6 +47,25 @@ import { createWebhooksRoutes } from "../webui/routes/webhooks.js";
 import { createIntegrationsRoutes } from "../webui/routes/integrations.js";
 import { createFeedbackRoutes } from "../webui/routes/feedback.js";
 import { createPromptRoutes } from "../webui/routes/prompts.js";
+import { createNotificationsRoutes } from "../webui/routes/notifications.js";
+import { createCacheRoutes } from "../webui/routes/cache.js";
+import { createMetricsRoutes } from "../webui/routes/metrics.js";
+import { createSessionsRoutes } from "../webui/routes/sessions.js";
+import { createAnalyticsRoutes } from "../webui/routes/analytics.js";
+import { createAnomaliesRoutes } from "../webui/routes/anomalies.js";
+import { createSecurityRoutes } from "../webui/routes/security.js";
+import { createAuditRoutes } from "../webui/routes/audit.js";
+import { createHealthRoutes } from "../webui/routes/health.js";
+import { createExportImportRoutes } from "../webui/routes/export-import.js";
+import { createWorkflowsRoutes } from "../webui/routes/workflows.js";
+import { createPipelinesRoutes } from "../webui/routes/pipelines.js";
+import { createSelfImprovementRoutes } from "../webui/routes/self-improvement.js";
+import { createAutonomousRoutes } from "../webui/routes/autonomous.js";
+import { createPredictionsRoutes } from "../webui/routes/predictions.js";
+import { createTemporalRoutes } from "../webui/routes/temporal.js";
+import { createDashboardsRoutes } from "../webui/routes/dashboards.js";
+import { createWidgetGeneratorRoutes } from "../webui/routes/widget-generator.js";
+import { createNetworkRoutes } from "../webui/routes/network.js";
 
 // New API routes
 import { createAgentRoutes } from "./routes/agent.js";
@@ -91,7 +110,14 @@ function getSetupStatus(): Record<string, boolean> {
 }
 
 /** SSE path patterns that must be excluded from timeout middleware */
-const SSE_PATHS = ["/v1/agent/events", "/v1/logs/stream", "/v1/events/stream"];
+const SSE_PATHS = [
+  "/v1/agent/events",
+  "/v1/api-logs/stream",
+  "/v1/audit/stream",
+  "/v1/events/stream",
+  "/v1/logs/stream",
+  "/v1/notifications/stream",
+];
 
 export interface ApiCredentials {
   apiKey: string;
@@ -250,6 +276,29 @@ export class ApiServer {
     this.app.route("/v1/prompts", createPromptRoutes(adaptedDeps));
     this.app.route("/v1/events", createEventsRoutes(adaptedDeps));
     this.app.route("/v1/webhooks", createWebhooksRoutes(adaptedDeps));
+    this.app.route("/v1/notifications", createNotificationsRoutes(adaptedDeps));
+    this.app.route("/v1/cache", createCacheRoutes(adaptedDeps));
+    this.app.route("/v1/metrics", createMetricsRoutes(adaptedDeps));
+    this.app.route("/v1/sessions", createSessionsRoutes(adaptedDeps));
+    this.app.route("/v1/analytics", createAnalyticsRoutes(adaptedDeps));
+    this.app.route("/v1/anomalies", createAnomaliesRoutes(adaptedDeps));
+    this.app.route("/v1/security", createSecurityRoutes(adaptedDeps));
+    this.app.route("/v1/audit", createAuditRoutes(adaptedDeps));
+    this.app.route("/v1/health-check", createHealthRoutes(adaptedDeps));
+    this.app.route("/v1/export", createExportImportRoutes(adaptedDeps));
+    this.app.route("/v1/workflows", createWorkflowsRoutes(adaptedDeps));
+    this.app.route("/v1/pipelines", createPipelinesRoutes(adaptedDeps));
+    this.app.route("/v1/self-improvement", createSelfImprovementRoutes(adaptedDeps));
+    this.app.route("/v1/autonomous", createAutonomousRoutes(adaptedDeps));
+    this.app.route("/v1/predictions", createPredictionsRoutes(adaptedDeps));
+    this.app.route("/v1/context", createTemporalRoutes(adaptedDeps));
+    this.app.route("/v1/dashboards", createDashboardsRoutes(adaptedDeps));
+    this.app.route("/v1/widgets", createWidgetGeneratorRoutes(adaptedDeps));
+    this.app.route("/v1/network", createNetworkRoutes(adaptedDeps));
+
+    // WebUI-only groups not mirrored here:
+    // - agent-network uses signed inter-agent protocol auth instead of API keys.
+    // - agent-actions, groq, and mtproto are browser setup/control helpers.
 
     // Setup routes (no agent deps needed, keyHash for config persistence)
     this.app.route("/v1/setup", createSetupRoutes({ keyHash: this.keyHash }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,6 +300,10 @@ export class TeletonApp {
     return this.config.webui;
   }
 
+  getNetworkConfig() {
+    return this.config.network;
+  }
+
   getConfigPath(): string {
     return this.configPath;
   }
@@ -475,6 +479,7 @@ ${blue}  ┌──────────────────────�
             plugins: this.getPlugins(),
             mcpServers,
             config: this.config.webui,
+            networkConfig: this.config.network,
             configPath: this.configPath,
             lifecycle: this.lifecycle,
             marketplace: {


### PR DESCRIPTION
## Summary
- Mount stable V2 WebUI route groups under /v1 in the Management API, including analytics, audit, autonomous, cache, dashboards, export, health-check, metrics, network, notifications, pipelines, predictions, security, sessions, widgets, and workflows.
- Pass networkConfig through ApiServerDeps/API-only bootstrap so /v1/network uses the same runtime config as WebUI.
- Document WebUI-only route exceptions and add a regression test that compares WebUI /api groups with Management API /v1 groups.

Fixes xlabtg/teleton-agent#403

## Reproduction
Before this change, comparing route mounts in src/webui/server.ts and src/api/server.ts showed stable WebUI /api groups missing from /v1. The new api-route-parity test reproduces that gap by failing when a stable WebUI group lacks a /v1 mount and is not explicitly documented as WebUI-only.

## Verification
- npm run build:sdk
- npm run typecheck
- npm run lint
- npm run format:check
- npx vitest run src/api/__tests__/api-route-parity.test.ts src/api/__tests__/api-server.test.ts
- npm test
- git diff --check