### PR TITLE
Fix widget generator preview parity for catalog sources

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-24T11:50:11.949Z for PR creation at branch issue-404-bcc72b31d8c0 for issue https://github.com/xlabtg/teleton-agent/issues/404

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-24T11:50:11.949Z for PR creation at branch issue-404-bcc72b31d8c0 for issue https://github.com/xlabtg/teleton-agent/issues/404

--- a/src/webui/__tests__/widget-generator-routes.test.ts
+++ b/src/webui/__tests__/widget-generator-routes.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import Database from "better-sqlite3";
+import { initAnalytics } from "../../services/analytics.js";
+import { BehaviorTracker } from "../../services/behavior-tracker.js";
+import { createDataSourceCatalog } from "../../services/data-source-catalog.js";
 import { initMetrics } from "../../services/metrics.js";
+import type { GeneratedWidgetDefinition } from "../../services/widget-generator.js";
 import { createWidgetGeneratorRoutes } from "../routes/widget-generator.js";
 import type { WebUIServerDeps } from "../types.js";
 
@@ -17,11 +21,110 @@ vi.mock("../../utils/logger.js", () => ({
 function buildApp(db: Database.Database) {
   const deps = {
     memory: { db },
+    agent: {
+      getConfig: () => ({
+        agent: {
+          model: "test-model",
+          provider: "test-provider",
+        },
+        predictions: {
+          enabled: true,
+          confidence_threshold: 0.6,
+          max_suggestions: 5,
+        },
+      }),
+    },
+    toolRegistry: {
+      getAll: () => [{ name: "search" }, { name: "read_file" }],
+    },
   } as unknown as WebUIServerDeps;
 
   const app = new Hono();
   app.route("/widgets", createWidgetGeneratorRoutes(deps));
   return app;
+}
+
+function createDefinition(sourceId: string): GeneratedWidgetDefinition {
+  const source = createDataSourceCatalog().get(sourceId);
+  if (!source) throw new Error(`missing test data source: ${sourceId}`);
+  const now = new Date().toISOString();
+
+  return {
+    id: `generated:test-${sourceId}`,
+    title: source.name,
+    description: source.description,
+    renderer: "table",
+    dataSource: {
+      id: source.id,
+      endpoint: source.endpoint,
+      method: source.method,
+      params: source.params ? { period: "7d" } : undefined,
+      refreshInterval: 30_000,
+    },
+    config: {
+      columns: source.fields.map((field) => field.key),
+    },
+    style: {
+      palette: "default",
+    },
+    defaultSize: {
+      w: 6,
+      h: 5,
+    },
+    generatedFrom: `Preview ${source.name}`,
+    refinementHistory: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function seedPreviewData(db: Database.Database) {
+  const metrics = initMetrics(db);
+  metrics.recordToolCall("search");
+  metrics.recordTokenUsage(1_000, 0.05);
+
+  db.exec(`
+    CREATE TABLE knowledge (id TEXT PRIMARY KEY);
+    CREATE TABLE messages (id TEXT PRIMARY KEY);
+    CREATE TABLE chats (id TEXT PRIMARY KEY);
+    CREATE TABLE sessions (id TEXT PRIMARY KEY);
+    CREATE TABLE tasks (
+      description TEXT NOT NULL,
+      status TEXT NOT NULL,
+      priority INTEGER NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+  `);
+  db.prepare("INSERT INTO knowledge (id) VALUES (?)").run("knowledge-1");
+  db.prepare("INSERT INTO messages (id) VALUES (?)").run("message-1");
+  db.prepare("INSERT INTO chats (id) VALUES (?)").run("chat-1");
+  db.prepare("INSERT INTO sessions (id) VALUES (?)").run("session-1");
+  db.prepare(
+    "INSERT INTO tasks (description, status, priority, created_at) VALUES (?, ?, ?, ?)"
+  ).run("Review preview parity", "pending", 1, Math.floor(Date.now() / 1000));
+
+  initAnalytics(db).recordRequestMetric({
+    toolName: "search",
+    durationMs: 200,
+    success: true,
+  });
+  initAnalytics(db).recordRequestMetric({
+    toolName: "read_file",
+    durationMs: 500,
+    success: false,
+    errorMessage: "failed",
+  });
+
+  const tracker = new BehaviorTracker(db);
+  for (let i = 0; i < 2; i++) {
+    tracker.recordMessage({ sessionId: `prediction-${i}`, chatId: "chat-1", text: "check status" });
+    tracker.recordMessage({ sessionId: `prediction-${i}`, chatId: "chat-1", text: "run tests" });
+  }
+  tracker.recordMessage({
+    sessionId: "prediction-preview",
+    chatId: "chat-1",
+    text: "check status",
+  });
 }
 
 describe("widget generator routes", () => {
@@ -98,5 +201,26 @@ describe("widget generator routes", () => {
       { tool: "search", count: 2 },
       { tool: "read_file", count: 1 },
     ]);
+  });
+
+  it("returns preview rows for every advertised data source", async () => {
+    seedPreviewData(db);
+
+    for (const source of createDataSourceCatalog().list()) {
+      const previewRes = await app.request("/widgets/preview", {
+        method: "POST",
+        body: JSON.stringify({ definition: createDefinition(source.id) }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(previewRes.status, source.id).toBe(200);
+      const preview = await previewRes.json();
+      expect(preview.success, source.id).toBe(true);
+      expect(
+        preview.data.fields.map((field: { key: string }) => field.key),
+        source.id
+      ).toEqual(source.fields.map((field) => field.key));
+      expect(preview.data.data.length, source.id).toBeGreaterThan(0);
+    }
   });
 });

--- a/src/webui/routes/widget-generator.ts
+++ b/src/webui/routes/widget-generator.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import type { WebUIServerDeps, APIResponse } from "../types.js";
 import { getTokenUsage } from "../../agent/token-usage.js";
 import { createDataSourceCatalog } from "../../services/data-source-catalog.js";
+import { initAnalytics } from "../../services/analytics.js";
 import {
   type GeneratedWidgetDefinition,
   type GenerateWidgetInput,
@@ -9,6 +10,7 @@ import {
   WidgetGeneratorService,
 } from "../../services/widget-generator.js";
 import { initMetrics } from "../../services/metrics.js";
+import { initPredictions } from "../../services/predictions.js";
 import { getErrorMessage } from "../../utils/errors.js";
 
 type PreviewRow = Record<string, unknown>;
@@ -60,6 +62,18 @@ function readPreviewData(
       return initMetrics(deps.memory.db).getTokenUsage(periodHours) as unknown as PreviewRow[];
     case "metrics.activity":
       return initMetrics(deps.memory.db).getActivity(periodHours) as unknown as PreviewRow[];
+    case "analytics.performance": {
+      const summary = initAnalytics(deps.memory.db).getPerformanceSummary(periodHours);
+      return [
+        {
+          totalRequests: summary.totalRequests,
+          errorCount: summary.errorCount,
+          successRate: summary.successRate,
+          avgResponseMs: summary.avgResponseMs,
+          p95Ms: summary.p95Ms,
+        },
+      ];
+    }
     case "memory.stats":
       return [
         {
@@ -96,6 +110,11 @@ function readPreviewData(
       } catch {
         return [];
       }
+    case "predictions.next":
+      return initPredictions(deps.memory.db).getNextActions({
+        confidenceThreshold: 0,
+        limit: 5,
+      }) as unknown as PreviewRow[];
     default:
       return [];
   }


### PR DESCRIPTION
## Summary
- Wire `analytics.performance` preview data to the analytics performance summary.
- Wire `predictions.next` preview data to learned next-action predictions.
- Add route coverage that seeds backing data and verifies every advertised catalog source returns preview rows and field metadata.

## Reproduction
1. Generate a widget from `Show error rate and latency performance for the last 7 days`.
2. POST the generated definition to `/api/widgets/preview`.
3. Before this change the response was HTTP 200 with `data: []` for `analytics.performance`; the same preview switch also missed `predictions.next`.

## Verification
- `npx vitest run src/webui/__tests__/widget-generator-routes.test.ts`
- `npm run lint`
- `npm run build:sdk`
- `npm run typecheck`
- `npm test` (193 files, 3406 tests)

Fixes xlabtg/teleton-agent#404