### PR TITLE
fix(setup): allow QR auth before config save

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-24T17:58:20.869Z for PR creation at branch issue-413-6a4f4ef245c8 for issue https://github.com/xlabtg/teleton-agent/issues/413

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-24T17:58:20.869Z for PR creation at branch issue-413-6a4f4ef245c8 for issue https://github.com/xlabtg/teleton-agent/issues/413

--- a/src/webui/__tests__/setup-auth-fragment.test.ts
+++ b/src/webui/__tests__/setup-auth-fragment.test.ts
@@ -134,6 +134,7 @@ vi.mock("../../utils/logger.js", () => ({
 import { TelegramAuthManager } from "../setup-auth.js";
 import { Api } from "telegram";
 import { readRawConfig, writeRawConfig } from "../../config/configurable-keys.js";
+import { writeFileSync } from "fs";
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -243,6 +244,33 @@ describe("TelegramAuthManager — Fragment support", () => {
       expect(result.user).toBeDefined();
       expect(result.user!.firstName).toBe("Fragment");
       expect(result.user!.username).toBe("fraguser");
+    });
+
+    it("authenticates during initial setup before config.yaml exists", async () => {
+      vi.mocked(readRawConfig).mockImplementationOnce(() => {
+        throw new Error(
+          "Config file not found: /tmp/teleton-test/config.yaml\nRun 'teleton setup' to create one."
+        );
+      });
+      const smsType = new Api.auth.SentCodeTypeSms({ length: 5 });
+      mockInvoke.mockResolvedValueOnce(makeSentCode(smsType));
+      const sendResult = await manager.sendCode(12345, "abcdef", "+1234567890");
+      const mockUser = new Api.User({
+        id: BigInt(123),
+        firstName: "Setup",
+        username: "setupuser",
+      });
+      mockInvoke.mockResolvedValueOnce(new Api.auth.Authorization({ user: mockUser }));
+
+      const result = await manager.verifyCode(sendResult.authSessionId, "12345");
+
+      expect(result.status).toBe("authenticated");
+      expect(writeFileSync).toHaveBeenCalledWith(
+        "/tmp/teleton-test/telegram_session.txt",
+        "session-string",
+        { mode: 0o600 }
+      );
+      expect(writeRawConfig).not.toHaveBeenCalled();
     });
 
     it("overwrites cloned owner and admin metadata for managed-agent auth targets", async () => {

--- a/src/webui/__tests__/setup-auth-proxy.test.ts
+++ b/src/webui/__tests__/setup-auth-proxy.test.ts
@@ -69,6 +69,28 @@ vi.mock("telegram", () => {
           this.expires = args.expires;
         }
       },
+      LoginTokenSuccess: class LoginTokenSuccess {
+        authorization: unknown;
+        constructor(args: { authorization: unknown }) {
+          this.authorization = args.authorization;
+        }
+      },
+      Authorization: class Authorization {
+        user: unknown;
+        constructor(args: { user: unknown }) {
+          this.user = args.user;
+        }
+      },
+    },
+    User: class User {
+      id: bigint;
+      firstName: string;
+      username?: string;
+      constructor(args: { id: bigint; firstName: string; username?: string }) {
+        this.id = args.id;
+        this.firstName = args.firstName;
+        this.username = args.username;
+      }
     },
     CodeSettings: class {
       constructor(_args?: unknown) {}
@@ -122,6 +144,8 @@ vi.mock("../../utils/logger.js", () => ({
 import { Api } from "telegram";
 import { TelegramAuthManager } from "../setup-auth.js";
 import type { MtprotoProxyEntry } from "../../config/schema.js";
+import { readRawConfig, writeRawConfig } from "../../config/configurable-keys.js";
+import { writeFileSync } from "fs";
 
 function makeSentCode() {
   return new Api.auth.SentCode({
@@ -207,5 +231,38 @@ describe("TelegramAuthManager — MTProto proxy support", () => {
         MTProxy: true,
       },
     });
+  });
+
+  it("returns authenticated from QR refresh when setup config has not been saved yet", async () => {
+    mockInvoke.mockResolvedValueOnce(
+      new Api.auth.LoginToken({
+        token: Buffer.from("qr-token"),
+        expires: 1_800_000_000,
+      })
+    );
+    const start = await manager.startQrSession(12345, "abcdef");
+    vi.mocked(readRawConfig).mockImplementationOnce(() => {
+      throw new Error(
+        "Config file not found: /tmp/teleton-test/config.yaml\nRun 'teleton setup' to create one."
+      );
+    });
+    mockInvoke.mockResolvedValueOnce(
+      new Api.auth.LoginTokenSuccess({
+        authorization: new Api.auth.Authorization({
+          user: new Api.User({ id: BigInt(123), firstName: "Setup", username: "setupuser" }),
+        }),
+      })
+    );
+
+    const result = await manager.refreshQrToken(start.authSessionId);
+
+    expect(result.status).toBe("authenticated");
+    expect(result.user).toEqual({ id: 123, firstName: "Setup", username: "setupuser" });
+    expect(writeFileSync).toHaveBeenCalledWith(
+      "/tmp/teleton-test/telegram_session.txt",
+      "session-string",
+      { mode: 0o600 }
+    );
+    expect(writeRawConfig).not.toHaveBeenCalled();
   });
 });

--- a/src/webui/__tests__/setup-routes.test.ts
+++ b/src/webui/__tests__/setup-routes.test.ts
@@ -30,6 +30,7 @@ const mockAuthManager = {
   verifyPassword: vi.fn(),
   resendCode: vi.fn(),
   startQrSession: vi.fn(),
+  refreshQrToken: vi.fn(),
   cancelSession: vi.fn(),
 };
 
@@ -40,6 +41,7 @@ vi.mock("../setup-auth.js", () => ({
     verifyPassword = mockAuthManager.verifyPassword;
     resendCode = mockAuthManager.resendCode;
     startQrSession = mockAuthManager.startQrSession;
+    refreshQrToken = mockAuthManager.refreshQrToken;
     cancelSession = mockAuthManager.cancelSession;
   },
 }));
@@ -206,6 +208,7 @@ describe("Setup API Routes", () => {
     mockAuthManager.verifyPassword.mockReset();
     mockAuthManager.resendCode.mockReset();
     mockAuthManager.startQrSession.mockReset();
+    mockAuthManager.refreshQrToken.mockReset();
     mockAuthManager.cancelSession.mockReset();
     // Reset env vars
     delete process.env.TELETON_API_KEY;
@@ -853,6 +856,70 @@ mtproto:
       expect(data.success).toBe(true);
       expect(data.data.codeDelivery).toBe("fragment");
       expect(data.data.fragmentUrl).toBe("https://fragment.com/number/88812345678");
+    });
+  });
+
+  // ── POST /telegram/qr-refresh ─────────────────────────────────────────────
+
+  describe("POST /telegram/qr-refresh", () => {
+    it("refreshes QR auth status successfully", async () => {
+      mockAuthManager.refreshQrToken.mockResolvedValue({
+        status: "waiting",
+        token: "fresh-token",
+        expires: 1_714_000_000,
+      });
+
+      const res = await post(app, "/telegram/qr-refresh", {
+        authSessionId: "qr-sess-123",
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.success).toBe(true);
+      expect(data.data).toEqual({
+        status: "waiting",
+        token: "fresh-token",
+        expires: 1_714_000_000,
+      });
+      expect(mockAuthManager.refreshQrToken).toHaveBeenCalledWith("qr-sess-123");
+    });
+
+    it("returns authenticated QR status without treating it as an error", async () => {
+      mockAuthManager.refreshQrToken.mockResolvedValue({
+        status: "authenticated",
+        user: { id: 123, firstName: "Setup", username: "setupuser" },
+      });
+
+      const res = await post(app, "/telegram/qr-refresh", {
+        authSessionId: "qr-sess-123",
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.success).toBe(true);
+      expect(data.data.status).toBe("authenticated");
+      expect(data.data.user.id).toBe(123);
+    });
+
+    it("returns 400 when missing authSessionId", async () => {
+      const res = await post(app, "/telegram/qr-refresh", {});
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.success).toBe(false);
+      expect(data.error).toContain("Missing");
+    });
+
+    it("returns 429 on rate limit", async () => {
+      mockAuthManager.refreshQrToken.mockRejectedValue({ seconds: 30 });
+
+      const res = await post(app, "/telegram/qr-refresh", {
+        authSessionId: "qr-sess-123",
+      });
+
+      expect(res.status).toBe(429);
+      const data = await res.json();
+      expect(data.error).toContain("30 seconds");
     });
   });
 

--- a/src/webui/setup-auth.ts
+++ b/src/webui/setup-auth.ts
@@ -25,6 +25,10 @@ const SESSION_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_CODE_ATTEMPTS = 5;
 const MAX_PASSWORD_ATTEMPTS = 3;
 
+function isConfigNotFoundError(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith("Config file not found:");
+}
+
 export interface TelegramAuthSaveTarget {
   rootDir?: string;
   configPath?: string;
@@ -577,36 +581,50 @@ export class TelegramAuthManager {
 
     writeFileSync(sessionPath, sessionString, { mode: 0o600 });
 
-    // Persist telegram credentials to config.yaml
+    // Persist telegram credentials to config.yaml when it already exists. During
+    // the primary setup wizard, authentication happens before /config/save.
     const configPath = session.saveTarget?.configPath ?? join(rootDir, "config.yaml");
-    const raw = readRawConfig(configPath);
-    raw.telegram = raw.telegram ?? {};
-    raw.telegram.api_id = session.apiId;
-    raw.telegram.api_hash = session.apiHash;
-    raw.telegram.session_path = sessionPath;
-    if (session.type === "phone") {
-      raw.telegram.phone = session.phone;
-    }
-    if (user) {
-      if (session.saveTarget?.replaceTelegramIdentity) {
-        raw.telegram.owner_id = user.id;
-        raw.telegram.owner_name = user.firstName;
-        if (user.username) {
-          raw.telegram.owner_username = user.username;
-        } else {
-          delete raw.telegram.owner_username;
-        }
-        raw.telegram.admin_ids = [user.id];
-      } else {
-        raw.telegram.owner_id = raw.telegram.owner_id ?? user.id;
-        raw.telegram.owner_name = raw.telegram.owner_name ?? user.firstName;
-        raw.telegram.owner_username = raw.telegram.owner_username ?? user.username;
-        const adminIds = Array.isArray(raw.telegram.admin_ids) ? raw.telegram.admin_ids : [];
-        raw.telegram.admin_ids = [...new Set([...adminIds, user.id])];
+    let configSaved = false;
+    try {
+      const raw = readRawConfig(configPath);
+      raw.telegram = raw.telegram ?? {};
+      raw.telegram.api_id = session.apiId;
+      raw.telegram.api_hash = session.apiHash;
+      raw.telegram.session_path = sessionPath;
+      if (session.type === "phone") {
+        raw.telegram.phone = session.phone;
       }
+      if (user) {
+        if (session.saveTarget?.replaceTelegramIdentity) {
+          raw.telegram.owner_id = user.id;
+          raw.telegram.owner_name = user.firstName;
+          if (user.username) {
+            raw.telegram.owner_username = user.username;
+          } else {
+            delete raw.telegram.owner_username;
+          }
+          raw.telegram.admin_ids = [user.id];
+        } else {
+          raw.telegram.owner_id = raw.telegram.owner_id ?? user.id;
+          raw.telegram.owner_name = raw.telegram.owner_name ?? user.firstName;
+          raw.telegram.owner_username = raw.telegram.owner_username ?? user.username;
+          const adminIds = Array.isArray(raw.telegram.admin_ids) ? raw.telegram.admin_ids : [];
+          raw.telegram.admin_ids = [...new Set([...adminIds, user.id])];
+        }
+      }
+      writeRawConfig(raw, configPath);
+      configSaved = true;
+    } catch (err) {
+      if (session.saveTarget?.configPath || !isConfigNotFoundError(err)) {
+        throw err;
+      }
+      log.info({ configPath }, "Config file not created yet; setup will save it later");
     }
-    writeRawConfig(raw, configPath);
 
-    log.info("Telegram session and credentials saved");
+    log.info(
+      configSaved
+        ? "Telegram session and credentials saved"
+        : "Telegram session saved; credentials pending setup config save"
+    );
   }
 }


### PR DESCRIPTION
## Summary

Fixes xlabtg/teleton-agent#413.

- Allow the setup Telegram auth manager to complete phone-code and QR authentication before `config.yaml` exists.
- Continue writing the Telegram session file immediately, but defer config mutation to the setup wizard's later `/config/save` step when this is the primary setup flow.
- Preserve strict behavior for explicit managed-agent auth targets: missing managed config still fails instead of being silently skipped.
- Add regression coverage for the QR `/telegram/qr-refresh` success path and for initial setup auth before config save.

## Reproduction

Before this change, step 6 of the setup wizard could successfully scan the Telegram QR code, then `/setup/telegram/qr-refresh` returned HTTP 500 because `saveSession()` tried to read `~/.teleton/config.yaml` before the setup wizard had saved it. The frontend then kept polling, producing repeated `qr-refresh: 500` browser console errors.

## Verification

- `npm test -- --run src/webui/__tests__/setup-auth-fragment.test.ts src/webui/__tests__/setup-auth-proxy.test.ts src/webui/__tests__/setup-routes.test.ts`
- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`
- `npm test` (`197 passed`, `3434 passed`)
- `npm run build:backend`
- `cd web && npm ci`
- `npm run build:web`
