### PR TITLE
fix(cli): bind runtime home to explicit config

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-25T03:16:32.135Z for PR creation at branch issue-415-c00d5022b70c for issue https://github.com/xlabtg/teleton-agent/issues/415

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-25T03:16:32.135Z for PR creation at branch issue-415-c00d5022b70c for issue https://github.com/xlabtg/teleton-agent/issues/415

--- a/src/cli/__tests__/start-config-missing.test.ts
+++ b/src/cli/__tests__/start-config-missing.test.ts
@@ -4,6 +4,9 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, describe, expect, it } from "vitest";
 
+process.env.TELETON_CLI_SKIP_PARSE = "true";
+const { bindTeletonHomeToConfig } = await import("../index.js");
+
 const repoRoot = process.cwd();
 const cliEntry = join(repoRoot, "src", "cli", "index.ts");
 const tsxBin = join(
@@ -51,6 +54,7 @@ describe("teleton start missing config diagnostics", () => {
         HOME: normalHome,
         USERPROFILE: normalHome,
         TELETON_HOME: overrideHome,
+        TELETON_CLI_SKIP_PARSE: undefined,
       },
     });
 
@@ -64,5 +68,18 @@ describe("teleton start missing config diagnostics", () => {
     expect(result.stderr).toContain("temporary workaround for #364");
     expect(result.stderr).toContain("set TELETON_HOME=");
     expect(result.stderr).toContain("$env:TELETON_HOME=$null");
+  });
+
+  it("binds runtime home to an explicit config path before loading the app", () => {
+    const wrongHome = makeTempDir("teleton-wrong-home");
+    const agentHome = makeTempDir("teleton-agent-home");
+    const configPath = join(agentHome, "config.yaml");
+    const originalHome = process.env.TELETON_HOME;
+
+    process.env.TELETON_HOME = wrongHome;
+    bindTeletonHomeToConfig(configPath, ["node", "teleton", "start", "-c", configPath]);
+
+    expect(process.env.TELETON_HOME).toBe(agentHome);
+    process.env.TELETON_HOME = originalHome;
   });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,7 +11,7 @@ import {
   getNormalDefaultConfigPath,
 } from "../config/loader.js";
 import { readFileSync, existsSync } from "fs";
-import { dirname, join } from "path";
+import { dirname, isAbsolute, join, resolve } from "path";
 import { fileURLToPath } from "url";
 import { getErrorMessage } from "../utils/errors.js";
 
@@ -70,6 +70,24 @@ function printConfigNotFoundError(configPath: string): void {
   console.error("   PowerShell: $env:TELETON_HOME=$null");
   console.error("   macOS/Linux: unset TELETON_HOME");
   console.error("\n   Or use: teleton start --api (for API-only bootstrap)");
+}
+
+export function bindTeletonHomeToConfig(configPath: string, argv = process.argv): void {
+  const explicitConfigArg =
+    argv.includes("-c") ||
+    argv.includes("--config") ||
+    argv.some((arg) => arg.startsWith("--config="));
+
+  if (!explicitConfigArg) return;
+
+  const expandedConfigPath = configPath.startsWith("~")
+    ? join(process.env.HOME || process.env.USERPROFILE || "", configPath.slice(1))
+    : configPath;
+  const absoluteConfigPath = isAbsolute(expandedConfigPath)
+    ? expandedConfigPath
+    : resolve(process.cwd(), expandedConfigPath);
+
+  process.env.TELETON_HOME = dirname(absoluteConfigPath);
 }
 
 program
@@ -141,6 +159,8 @@ program
   .option("--json-credentials", "Output API credentials as JSON to stdout on start")
   .action(async (options) => {
     try {
+      bindTeletonHomeToConfig(options.config);
+
       // If --api flag and no config: start API-only bootstrap mode
       if (options.api && !configExists(options.config)) {
         if (options.apiPort) {
@@ -431,4 +451,6 @@ program.action(() => {
   program.help();
 });
 
-program.parse(process.argv);
+if (process.env.TELETON_CLI_SKIP_PARSE !== "true") {
+  program.parse(process.argv);
+}


### PR DESCRIPTION
Fixes xlabtg/teleton-agent#415

## Summary
- Bind `TELETON_HOME` to the directory of an explicit `teleton start -c/--config <path>` before lazy-loading the runtime.
- This makes workspace, session, memory, plugin, and other `TELETON_ROOT`-derived paths follow the launched agent folder instead of a stale globally configured home.
- Keep the existing missing-config diagnostic for default startup and add a small import guard so the CLI helper can be tested without Commander parsing the test process argv.

## Reproduction
Before this change, running a second local agent with `teleton start -c C:\Users\User\T2\teleton-agent\config.yaml` while `TELETON_HOME` still pointed at `C:\Users\User\teleton-agent` could load the explicit config but keep runtime paths bound to the first folder.

The new regression test sets `TELETON_HOME` to a wrong directory, calls the same binding path used by `teleton start -c`, and verifies the runtime home is rebound to the explicit config directory before app modules are imported.

## Verification
- `npm test -- src/cli/__tests__/start-config-missing.test.ts`
- `npm run build -w @teleton-agent/sdk`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
