### PR TITLE
fix: send CSRF token for agent controls

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: [
       "src/**/__tests__/**/*.test.ts",
+      "web/src/**/__tests__/**/*.test.ts",
       "packages/sdk/src/**/__tests__/**/*.test.ts",
     ],
     coverage: {

--- a/web/src/components/AgentControl.tsx
+++ b/web/src/components/AgentControl.tsx
@@ -1,9 +1,9 @@
 import { useState, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { useAgentStatus, AgentState } from '../hooks/useAgentStatus';
+import { api } from '../lib/api';
 import { toast } from '../lib/toast-store';
 
-const API_BASE = '/api';
 const MAX_START_RETRIES = 3;
 const RETRY_DELAYS = [1000, 2000, 4000];
 
@@ -45,16 +45,7 @@ export function AgentControl() {
     abortRef.current = new AbortController();
 
     try {
-      const res = await fetch(`${API_BASE}/agent/start`, {
-        method: 'POST',
-        credentials: 'include',
-        signal: AbortSignal.timeout(10_000),
-      });
-      const json = await res.json();
-
-      if (!res.ok && json.error) {
-        throw new Error(json.error);
-      }
+      await api.agentStart({ signal: AbortSignal.timeout(10_000) });
       toast.success('Agent started');
     } catch (err) {
       if (!retryTimerRef.current && attempt < MAX_START_RETRIES) {
@@ -84,16 +75,7 @@ export function AgentControl() {
     clearRetry();
 
     try {
-      const res = await fetch(`${API_BASE}/agent/stop`, {
-        method: 'POST',
-        credentials: 'include',
-        signal: AbortSignal.timeout(10_000),
-      });
-      const json = await res.json();
-
-      if (!res.ok && json.error) {
-        throw new Error(json.error);
-      }
+      await api.agentStop({ signal: AbortSignal.timeout(10_000) });
       toast.success('Agent stopped');
     } catch (err) {
       toast.error(`Failed to stop agent: ${err instanceof Error ? err.message : String(err)}`);

--- a/web/src/lib/__tests__/api.test.ts
+++ b/web/src/lib/__tests__/api.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "../api";
+
+describe("web API client CSRF handling", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("sends the CSRF cookie value when stopping the agent", async () => {
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: { cookie: "teleton_csrf=csrf-token-123; theme=dark" },
+    });
+
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ state: "stopping" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(api.agentStop()).resolves.toEqual({ state: "stopping" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/agent/stop",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "X-CSRF-Token": "csrf-token-123",
+        }),
+      })
+    );
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2196,7 +2196,7 @@ function getCookieValue(name: string): string | null {
 
 const MUTATION_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
-async function fetchAPI<T>(endpoint: string, options?: RequestInit): Promise<T> {
+export async function fetchAPI<T>(endpoint: string, options?: RequestInit): Promise<T> {
   const method = options?.method?.toUpperCase() ?? "GET";
   const csrfToken = MUTATION_METHODS.has(method) ? getCookieValue("teleton_csrf") : null;
 
@@ -4142,12 +4142,12 @@ export const api = {
     });
   },
 
-  async agentStart() {
-    return fetchAPI<{ state: string }>("/agent/start", { method: "POST" });
+  async agentStart(options?: Pick<RequestInit, "signal">) {
+    return fetchAPI<{ state: string }>("/agent/start", { method: "POST", ...options });
   },
 
-  async agentStop() {
-    return fetchAPI<{ state: string }>("/agent/stop", { method: "POST" });
+  async agentStop(options?: Pick<RequestInit, "signal">) {
+    return fetchAPI<{ state: string }>("/agent/stop", { method: "POST", ...options });
   },
 
   async agentStatus() {


### PR DESCRIPTION
## Summary
- Route the sidebar Start Agent and Stop Agent actions through the shared WebUI API client.
- Preserve the existing 10s abort behavior while letting the shared client attach credentials, JSON headers, and the `X-CSRF-Token` header for mutating requests.
- Add a regression test proving `api.agentStop()` reads `teleton_csrf` from `document.cookie` and sends it as `X-CSRF-Token`.

## Reproduction
Before this change, the Stop Agent button used a raw `fetch('/api/agent/stop', { method: 'POST' })`, bypassing the shared API client. The WebUI CSRF middleware requires the value of the `teleton_csrf` cookie in the `X-CSRF-Token` header for POST requests, so the stop request was rejected with:

`CSRF token missing or invalid. Include the value of the 'teleton_csrf' cookie in the 'X-CSRF-Token' request header.`

## Verification
- `npx vitest run web/src/lib/__tests__/api.test.ts`
- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm test`

Fixes xlabtg/teleton-agent#419
