### PR TITLE
fix(mtproto): fail over after getMe validation

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
+# Updated: 2026-04-25T05:15:03.231Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
-# Updated: 2026-04-25T05:15:03.231Z

--- a/src/telegram/__tests__/client-proxy.test.ts
+++ b/src/telegram/__tests__/client-proxy.test.ts
@@ -169,6 +169,26 @@ describe("TelegramUserClient — proxy connection", () => {
       expect(client.isConnected()).toBe(true);
     });
 
+    it("falls back to second proxy when first connects but getMe fails", async () => {
+      mockGetMe.mockRejectedValueOnce(new Error("getMe timed out")).mockResolvedValueOnce(MOCK_ME);
+
+      const client = new TelegramUserClient({
+        ...BASE_CONFIG,
+        mtprotoProxies: [
+          { server: "proxy1.example.com", port: 443, secret: "aabbcc" },
+          { server: "proxy2.example.com", port: 443, secret: "ddeeff" },
+        ],
+      });
+
+      await client.connect();
+
+      expect(mockConnect).toHaveBeenCalledTimes(2);
+      expect(mockGetMe).toHaveBeenCalledTimes(2);
+      expect(mockDisconnect).toHaveBeenCalled();
+      expect(client.getActiveProxyIndex()).toBe(1);
+      expect(client.isConnected()).toBe(true);
+    });
+
     it("falls back to direct connection when all proxies fail (session present)", async () => {
       mockConnect
         .mockRejectedValueOnce(new Error("proxy1 unreachable"))

--- a/src/telegram/__tests__/client-proxy.test.ts
+++ b/src/telegram/__tests__/client-proxy.test.ts
@@ -184,7 +184,7 @@ describe("TelegramUserClient — proxy connection", () => {
 
       expect(mockConnect).toHaveBeenCalledTimes(2);
       expect(mockGetMe).toHaveBeenCalledTimes(2);
-      expect(mockDisconnect).toHaveBeenCalled();
+      expect(mockDisconnect).toHaveBeenCalledTimes(1);
       expect(client.getActiveProxyIndex()).toBe(1);
       expect(client.isConnected()).toBe(true);
     });

--- a/src/telegram/client.ts
+++ b/src/telegram/client.ts
@@ -116,7 +116,6 @@ export class TelegramUserClient {
   /** Try connecting via proxy at `index`, rebuilding the client with that proxy.
    *  Races the connect() call against a timeout to avoid indefinite hangs when
    *  a proxy silently drops packets instead of refusing the connection.
-   *  On failure/timeout, disconnects the client to stop background retries.
    */
   private async connectWithProxy(index: number): Promise<void> {
     const proxies = this.config.mtprotoProxies ?? [];
@@ -144,14 +143,48 @@ export class TelegramUserClient {
 
     try {
       await Promise.race([this.client.connect(), timeoutPromise]);
-    } catch (err) {
-      // Disconnect the abandoned client so its internal retry loop stops
-      // and does not leak sockets or interfere with the next attempt.
-      this.client.disconnect().catch(() => {});
-      throw err;
     } finally {
       clearTimeout(timeoutId);
     }
+  }
+
+  private async disconnectCurrentClient(): Promise<void> {
+    await Promise.resolve(this.client.disconnect()).catch(() => {});
+  }
+
+  private async getMeWithTimeout(): Promise<Api.User> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const getMeTimeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () =>
+          reject(
+            new TelegramError(
+              "[Telegram] getMe() timed out — proxy may be unresponsive",
+              "GET_ME_TIMEOUT",
+              { timeoutMs: MTPROTO_PROXY_CONNECT_TIMEOUT_MS }
+            )
+          ),
+        MTPROTO_PROXY_CONNECT_TIMEOUT_MS
+      );
+    });
+
+    try {
+      return (await Promise.race([this.client.getMe(), getMeTimeout])) as Api.User;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private async loadCurrentUser(): Promise<void> {
+    const me = await this.getMeWithTimeout();
+    this.me = {
+      id: BigInt(me.id.toString()),
+      username: me.username,
+      firstName: me.firstName,
+      lastName: me.lastName,
+      phone: me.phone,
+      isBot: me.bot ?? false,
+    };
   }
 
   /** Return the index (0-based) of the currently active proxy, or undefined for direct connection. */
@@ -281,6 +314,7 @@ export class TelegramUserClient {
     try {
       const proxies = this.config.mtprotoProxies ?? [];
       const hasSession = existsSync(this.config.sessionPath);
+      let userLoaded = false;
 
       if (proxies.length > 0) {
         // Try each proxy in order; fall back to direct only if all proxies fail
@@ -288,9 +322,15 @@ export class TelegramUserClient {
         for (let i = 0; i < proxies.length; i++) {
           try {
             await this.connectWithProxy(i);
+            if (hasSession) {
+              await this.loadCurrentUser();
+              userLoaded = true;
+            }
             proxyConnected = true;
             break;
           } catch (err) {
+            await this.disconnectCurrentClient();
+            this.activeProxyIndex = undefined;
             log.warn(
               { err, server: proxies[i].server },
               `[MTProxy] Proxy ${i + 1}/${proxies.length} failed, trying next`
@@ -302,6 +342,10 @@ export class TelegramUserClient {
           this.client = this.buildClient();
           this.activeProxyIndex = undefined;
           await this.client.connect();
+          if (hasSession) {
+            await this.loadCurrentUser();
+            userLoaded = true;
+          }
         }
         // If no session exists, run auth flow now that the TCP connection is established
         if (!hasSession) {
@@ -309,34 +353,16 @@ export class TelegramUserClient {
         }
       } else if (hasSession) {
         await this.client.connect();
+        await this.loadCurrentUser();
+        userLoaded = true;
       } else {
         await this.client.connect();
         await this.runAuthFlow();
       }
 
-      // Race getMe() against a timeout to avoid hanging on a broken proxy
-      const getMeTimeout = new Promise<never>((_, reject) =>
-        setTimeout(
-          () =>
-            reject(
-              new TelegramError(
-                "[Telegram] getMe() timed out — proxy may be unresponsive",
-                "GET_ME_TIMEOUT",
-                { timeoutMs: MTPROTO_PROXY_CONNECT_TIMEOUT_MS }
-              )
-            ),
-          MTPROTO_PROXY_CONNECT_TIMEOUT_MS
-        )
-      );
-      const me = (await Promise.race([this.client.getMe(), getMeTimeout])) as Api.User;
-      this.me = {
-        id: BigInt(me.id.toString()),
-        username: me.username,
-        firstName: me.firstName,
-        lastName: me.lastName,
-        phone: me.phone,
-        isBot: me.bot ?? false,
-      };
+      if (!userLoaded) {
+        await this.loadCurrentUser();
+      }
 
       this.connected = true;
     } catch (error) {


### PR DESCRIPTION
## Summary

Fixes xlabtg/teleton-agent#421.

- Treat MTProto proxy startup as successful only after the authenticated `getMe()` validation succeeds.
- Disconnect a proxy client whose post-connect validation fails, then continue to the next configured proxy before falling back to direct connection.
- Keep the `getMe()` timeout cleanup centralized so successful validation does not leave a pending timer.
- Add a regression test for the reported case where proxy 1 connects but `getMe()` fails and proxy 2 should be used.

## Reproduction

Before this change, `TelegramUserClient.connect()` stopped proxy selection as soon as `client.connect()` resolved. If that proxy later timed out during `getMe()`, startup failed with `GET_ME_TIMEOUT` and the remaining configured MTProto proxies were never tried.

## Verification

- Reproduced with a failing regression test before the implementation change: `npm test -- --run src/telegram/__tests__/client-proxy.test.ts`
- `npm test -- --run src/telegram/__tests__/client-proxy.test.ts src/telegram/__tests__/mtproto-proxy-health.test.ts src/webui/__tests__/mtproto-routes.test.ts src/webui/__tests__/setup-auth-proxy.test.ts src/webui/__tests__/setup-routes.test.ts src/bot/__tests__/gramjs-bot-proxy.test.ts`
- `npm run build -w @teleton-agent/sdk`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run test:coverage` (`3438 passed`)
- `npm run audit:ci`
- `cd web && npm ci`
- `npm run build`
- `node dist/cli/index.js --help`

## Additional double-check (2026-04-25)

After owner review feedback, re-read the proxy failover path and tightened the regression test to assert exactly one cleanup disconnect when proxy 1 connects but `getMe()` validation fails and proxy 2 succeeds.

Additional verification on commit `1373c96`:

- `npm ci`
- `npm test -- --run src/telegram/__tests__/client-proxy.test.ts src/telegram/__tests__/client-auth.test.ts src/bot/__tests__/gramjs-bot-proxy.test.ts src/webui/__tests__/setup-auth-proxy.test.ts` (`32 passed`)
- `npm run build -w @teleton-agent/sdk`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test -- --run` (`3438 passed`)
