### PR TITLE
fix(mtproto): validate proxy status with session

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
-# Updated: 2026-04-25T05:59:54.061Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
+# Updated: 2026-04-25T05:59:54.061Z

--- a/src/telegram/__tests__/mtproto-proxy-health.test.ts
+++ b/src/telegram/__tests__/mtproto-proxy-health.test.ts
@@ -1,15 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const constructedOptions: Array<Record<string, unknown>> = [];
-const { mockConnect, mockDisconnect } = vi.hoisted(() => ({
+const constructedSessions: string[] = [];
+const { mockConnect, mockDisconnect, mockGetMe } = vi.hoisted(() => ({
   mockConnect: vi.fn(),
   mockDisconnect: vi.fn().mockResolvedValue(undefined),
+  mockGetMe: vi.fn(),
 }));
 
 vi.mock("telegram", () => {
   class TelegramClient {
     connect = mockConnect;
     disconnect = mockDisconnect;
+    getMe = mockGetMe;
 
     constructor(
       _session: unknown,
@@ -31,7 +34,9 @@ vi.mock("telegram/extensions/Logger.js", () => ({
 
 vi.mock("telegram/sessions/index.js", () => ({
   StringSession: class {
-    constructor(_value?: string) {}
+    constructor(value?: string) {
+      constructedSessions.push(value ?? "");
+    }
   },
 }));
 
@@ -46,8 +51,10 @@ const PROXY = { server: "proxy.example.com", port: 443, secret: "a".repeat(32) }
 describe("MTProto proxy health checks", () => {
   beforeEach(() => {
     constructedOptions.length = 0;
+    constructedSessions.length = 0;
     vi.clearAllMocks();
     mockConnect.mockResolvedValue(undefined);
+    mockGetMe.mockResolvedValue({ id: 12345 });
   });
 
   afterEach(() => {
@@ -70,6 +77,34 @@ describe("MTProto proxy health checks", () => {
       secret: PROXY.secret,
       MTProxy: true,
     });
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an authenticated proxy as available when getMe succeeds through the saved session", async () => {
+    const status = await checkMtprotoProxy(12345, "hash", PROXY, 0, {
+      activeProxyIndex: 0,
+      sessionString: "saved-session",
+    });
+
+    expect(status.status).toBe("available");
+    expect(status.available).toBe(true);
+    expect(constructedSessions[0]).toBe("saved-session");
+    expect(mockGetMe).toHaveBeenCalledTimes(1);
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an unavailable proxy when connection succeeds but authenticated validation fails", async () => {
+    mockGetMe.mockRejectedValueOnce(new Error("getMe timed out"));
+
+    const status = await checkMtprotoProxy(12345, "hash", PROXY, 0, {
+      sessionString: "saved-session",
+    });
+
+    expect(status.status).toBe("unavailable");
+    expect(status.available).toBe(false);
+    expect(status.error).toContain("getMe timed out");
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+    expect(mockGetMe).toHaveBeenCalledTimes(1);
     expect(mockDisconnect).toHaveBeenCalledTimes(1);
   });
 

--- a/src/telegram/mtproto-proxy-health.ts
+++ b/src/telegram/mtproto-proxy-health.ts
@@ -23,6 +23,7 @@ export interface MtprotoProxyHealth {
 interface CheckOptions {
   activeProxyIndex?: number;
   timeoutMs?: number;
+  sessionString?: string;
 }
 
 interface CheckAllOptions extends CheckOptions {
@@ -79,28 +80,44 @@ export async function checkMtprotoProxy(
   const checkedAt = new Date().toISOString();
   const startedAt = Date.now();
   const logger = new Logger(LogLevel.NONE);
-  const client = new TelegramClient(new StringSession(""), apiId, apiHash, {
-    connectionRetries: 1,
-    retryDelay: 250,
-    autoReconnect: false,
-    floodSleepThreshold: 0,
-    baseLogger: logger,
-    proxy: buildProxy(entry),
-  });
+  const client = new TelegramClient(
+    new StringSession(options.sessionString ?? ""),
+    apiId,
+    apiHash,
+    {
+      connectionRetries: 1,
+      retryDelay: 250,
+      autoReconnect: false,
+      floodSleepThreshold: 0,
+      baseLogger: logger,
+      proxy: buildProxy(entry),
+    }
+  );
 
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeoutId = setTimeout(
-      () =>
-        reject(
-          new Error(`MTProto proxy status check timed out after ${Math.round(timeoutMs / 1000)}s`)
-        ),
-      timeoutMs
-    );
-  });
+  const withStatusTimeout = async <T>(operation: Promise<T>, action: string): Promise<T> => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () =>
+          reject(
+            new Error(`MTProto proxy ${action} timed out after ${Math.round(timeoutMs / 1000)}s`)
+          ),
+        timeoutMs
+      );
+    });
+
+    try {
+      return await Promise.race([operation, timeoutPromise]);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  };
 
   try {
-    await Promise.race([client.connect(), timeoutPromise]);
+    await withStatusTimeout(client.connect(), "connection check");
+    if (options.sessionString) {
+      await withStatusTimeout(client.getMe(), "authenticated check");
+    }
     return {
       ...createStatusBase(entry, index, options.activeProxyIndex),
       status: "available",
@@ -119,7 +136,6 @@ export async function checkMtprotoProxy(
       checkedAt,
     };
   } finally {
-    clearTimeout(timeoutId);
     await Promise.resolve(client.disconnect()).catch(() => {});
   }
 }

--- a/src/webui/__tests__/mtproto-routes.test.ts
+++ b/src/webui/__tests__/mtproto-routes.test.ts
@@ -2,6 +2,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import type { WebUIServerDeps } from "../types.js";
 
+const { mockExistsSync, mockReadFileSync, mockStatSync, mockWriteFileSync } = vi.hoisted(() => ({
+  mockExistsSync: vi.fn(),
+  mockReadFileSync: vi.fn(),
+  mockStatSync: vi.fn(),
+  mockWriteFileSync: vi.fn(),
+}));
+
+vi.mock("fs", () => ({
+  existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
+  statSync: (...args: unknown[]) => mockStatSync(...args),
+  writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+}));
+
 vi.mock("../../telegram/mtproto-proxy-health.js", () => ({
   checkMtprotoProxies: vi.fn(),
   uncheckedMtprotoProxyStatuses: vi.fn((proxies, reason, activeProxyIndex) =>
@@ -49,6 +63,9 @@ function buildApp(config: Record<string, unknown>, bridgeOverrides: Record<strin
 describe("MTProto routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockExistsSync.mockReturnValue(false);
+    mockReadFileSync.mockReturnValue("");
+    mockStatSync.mockReturnValue({ isDirectory: () => false });
     vi.mocked(checkMtprotoProxies).mockResolvedValue([
       {
         index: 0,
@@ -106,6 +123,30 @@ describe("MTProto routes", () => {
       apiHash: "hash",
       proxies,
       activeProxyIndex: 1,
+    });
+  });
+
+  it("passes the saved Telegram session to proxy health checks for authenticated validation", async () => {
+    mockExistsSync.mockImplementation((path) => path === "/tmp/teleton-session.txt");
+    mockReadFileSync.mockReturnValue(" saved-session \n");
+    const app = buildApp({
+      telegram: {
+        api_id: 12345,
+        api_hash: "hash",
+        session_path: "/tmp/teleton-session.txt",
+      },
+      mtproto: { enabled: true, proxies },
+    });
+
+    const res = await app.request("/mtproto/status");
+
+    expect(res.status).toBe(200);
+    expect(checkMtprotoProxies).toHaveBeenCalledWith({
+      apiId: 12345,
+      apiHash: "hash",
+      proxies,
+      activeProxyIndex: 1,
+      sessionString: "saved-session",
     });
   });
 

--- a/src/webui/routes/mtproto.ts
+++ b/src/webui/routes/mtproto.ts
@@ -1,4 +1,6 @@
 import { Hono } from "hono";
+import { existsSync, readFileSync, statSync } from "fs";
+import { join } from "path";
 import type { WebUIServerDeps, APIResponse } from "../types.js";
 import { readRawConfig, writeRawConfig, setNestedValue } from "../../config/configurable-keys.js";
 import type { MtprotoProxyEntry } from "../../config/schema.js";
@@ -6,6 +8,67 @@ import {
   checkMtprotoProxies,
   uncheckedMtprotoProxyStatuses,
 } from "../../telegram/mtproto-proxy-health.js";
+import { TELETON_ROOT } from "../../workspace/paths.js";
+
+function unique(values: Array<string | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => !!value))];
+}
+
+function readSessionCandidate(path: string): string | undefined {
+  try {
+    if (!existsSync(path) || statSync(path).isDirectory()) {
+      return undefined;
+    }
+    const sessionString = readFileSync(path, "utf-8").trim();
+    return sessionString || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readTelegramSessionString(config: Record<string, unknown>): string | undefined {
+  const telegram = config.telegram as
+    | { session_path?: unknown; session_name?: unknown }
+    | undefined;
+  const configuredSessionPath =
+    typeof telegram?.session_path === "string" && telegram.session_path.trim()
+      ? telegram.session_path.trim()
+      : undefined;
+  const sessionName =
+    typeof telegram?.session_name === "string" && telegram.session_name.trim()
+      ? telegram.session_name.trim()
+      : "teleton_session";
+
+  const directCandidates = unique([
+    configuredSessionPath,
+    join(TELETON_ROOT, "telegram_session.txt"),
+  ]);
+  for (const candidate of directCandidates) {
+    const sessionString = readSessionCandidate(candidate);
+    if (sessionString) return sessionString;
+  }
+
+  const directoryCandidates = unique([configuredSessionPath, TELETON_ROOT]);
+  for (const candidate of directoryCandidates) {
+    try {
+      if (!existsSync(candidate) || !statSync(candidate).isDirectory()) {
+        continue;
+      }
+      for (const nested of [
+        join(candidate, "telegram_session.txt"),
+        join(candidate, sessionName),
+        join(candidate, `${sessionName}.session`),
+      ]) {
+        const sessionString = readSessionCandidate(nested);
+        if (sessionString) return sessionString;
+      }
+    } catch {
+      // Ignore unreadable legacy session locations and fall back to a transport-only check.
+    }
+  }
+
+  return undefined;
+}
 
 export function createMtprotoRoutes(deps: WebUIServerDeps) {
   const app = new Hono();
@@ -36,11 +99,18 @@ export function createMtprotoRoutes(deps: WebUIServerDeps) {
         : null;
     const apiId = Number(config.telegram?.api_id);
     const apiHash = typeof config.telegram?.api_hash === "string" ? config.telegram.api_hash : "";
+    const sessionString = readTelegramSessionString(config);
     const proxyStatuses =
       proxies.length === 0
         ? []
         : Number.isFinite(apiId) && apiId > 0 && apiHash
-          ? await checkMtprotoProxies({ apiId, apiHash, proxies, activeProxyIndex })
+          ? await checkMtprotoProxies({
+              apiId,
+              apiHash,
+              proxies,
+              activeProxyIndex,
+              ...(sessionString ? { sessionString } : {}),
+            })
           : uncheckedMtprotoProxyStatuses(
               proxies,
               "Telegram API ID and hash are required before proxy checks can run",


### PR DESCRIPTION
## Summary

Fixes xlabtg/teleton-agent#423.

- Validate MTProto proxy WebUI status with the saved Telegram session when one is available, so a proxy is only reported as `Available` after authenticated `getMe()` succeeds through it.
- Keep transport-only checks for pre-auth/setup cases where no saved session exists.
- Resolve configured, default, and legacy session locations before running `/api/mtproto/status` checks.
- Add regression coverage for proxies that connect successfully but fail authenticated validation.

## Reproduction

Before this change, `checkMtprotoProxy()` reported a proxy as `available` immediately after `client.connect()` resolved. After #422, startup correctly treats the proxy as failed if `getMe()` times out through that same proxy, which produced the issue-423 mismatch: WebUI showed available proxy servers while the aggregate MTProto connection stayed red/not connected.

The new regression test reproduces that mismatch by making `connect()` succeed and `getMe()` fail through a saved session; before the implementation change, the health check still returned `available`.

## Verification

- `npm ci`
- `npm test -- --run src/telegram/__tests__/mtproto-proxy-health.test.ts` (failed before fix with the new reproducer)
- `npm test -- --run src/telegram/__tests__/client-proxy.test.ts src/telegram/__tests__/mtproto-proxy-health.test.ts src/webui/__tests__/mtproto-routes.test.ts`
- `npm run build -w @teleton-agent/sdk`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test -- --run` (`3441 passed`)
- `npm run build:backend`
