### PR TITLE
fix: validate MTProto proxy status with saved session

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
-# Updated: 2026-04-25T06:41:15.168Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
+# Updated: 2026-04-25T06:41:15.168Z

--- a/src/telegram/__tests__/mtproto-proxy-health.test.ts
+++ b/src/telegram/__tests__/mtproto-proxy-health.test.ts
@@ -44,7 +44,7 @@ vi.mock("../../constants/timeouts.js", () => ({
   MTPROTO_PROXY_STATUS_TIMEOUT_MS: 100,
 }));
 
-import { checkMtprotoProxy } from "../mtproto-proxy-health.js";
+import { checkMtprotoProxies, checkMtprotoProxy } from "../mtproto-proxy-health.js";
 
 const PROXY = { server: "proxy.example.com", port: 443, secret: "a".repeat(32) };
 
@@ -91,6 +91,21 @@ describe("MTProto proxy health checks", () => {
     expect(constructedSessions[0]).toBe("saved-session");
     expect(mockGetMe).toHaveBeenCalledTimes(1);
     expect(mockDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the saved session to every bulk proxy health check", async () => {
+    const statuses = await checkMtprotoProxies({
+      apiId: 12345,
+      apiHash: "hash",
+      proxies: [PROXY, { server: "proxy2.example.com", port: 8443, secret: "b".repeat(32) }],
+      activeProxyIndex: 1,
+      sessionString: "saved-session",
+    });
+
+    expect(statuses).toHaveLength(2);
+    expect(statuses.every((status) => status.status === "available")).toBe(true);
+    expect(constructedSessions).toEqual(["saved-session", "saved-session"]);
+    expect(mockGetMe).toHaveBeenCalledTimes(2);
   });
 
   it("reports an unavailable proxy when connection succeeds but authenticated validation fails", async () => {

--- a/src/telegram/mtproto-proxy-health.ts
+++ b/src/telegram/mtproto-proxy-health.ts
@@ -141,10 +141,14 @@ export async function checkMtprotoProxy(
 }
 
 export async function checkMtprotoProxies(options: CheckAllOptions): Promise<MtprotoProxyHealth[]> {
-  const { apiId, apiHash, proxies, activeProxyIndex, timeoutMs } = options;
+  const { apiId, apiHash, proxies, activeProxyIndex, timeoutMs, sessionString } = options;
   return Promise.all(
     proxies.map((entry, index) =>
-      checkMtprotoProxy(apiId, apiHash, entry, index, { activeProxyIndex, timeoutMs })
+      checkMtprotoProxy(apiId, apiHash, entry, index, {
+        activeProxyIndex,
+        timeoutMs,
+        sessionString,
+      })
     )
   );
 }


### PR DESCRIPTION
## Summary
- Pass the saved Telegram session through bulk MTProto proxy health checks.
- Add a regression test proving each configured proxy is validated with the saved session during status checks.

Fixes xlabtg/teleton-agent#425

## Reproduction
The WebUI `/api/mtproto/status` route already reads the saved Telegram session and sends it to `checkMtprotoProxies`, but the helper dropped `sessionString` before calling `checkMtprotoProxy`. That meant the UI proxy status path could run unauthenticated checks instead of the same authenticated validation used for the active Telegram connection.

## Tests
- `npx vitest run src/telegram/__tests__/mtproto-proxy-health.test.ts`
- `npx vitest run src/webui/__tests__/mtproto-routes.test.ts src/telegram/__tests__/client-proxy.test.ts`
- `npm test -- --run src/telegram/__tests__/mtproto-proxy-health.test.ts src/webui/__tests__/mtproto-routes.test.ts src/telegram/__tests__/client-proxy.test.ts`
- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`