### PR TITLE
Fix MTProto proxy auth recovery and prefixed secrets

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
+# Updated: 2026-04-26T15:08:27.505Z

--- a/src/bot/__tests__/gramjs-bot-proxy.test.ts
+++ b/src/bot/__tests__/gramjs-bot-proxy.test.ts
@@ -109,7 +109,7 @@ describe("GramJSBotClient — proxy timeout and cleanup", () => {
 
   it("connects via first proxy on success", async () => {
     const client = new GramJSBotClient(12345, "hash", "/tmp/session", [
-      { server: "proxy1.example.com", port: 443, secret: "aabbcc" },
+      { server: "proxy1.example.com", port: 443, secret: "a".repeat(32) },
     ]);
 
     await client.connect(BOT_TOKEN);
@@ -131,8 +131,8 @@ describe("GramJSBotClient — proxy timeout and cleanup", () => {
     vi.useFakeTimers();
 
     const client = new GramJSBotClient(12345, "hash", "/tmp/session", [
-      { server: "hanging.example.com", port: 443, secret: "aabbcc" },
-      { server: "good.example.com", port: 443, secret: "ddeeff" },
+      { server: "hanging.example.com", port: 443, secret: "a".repeat(32) },
+      { server: "good.example.com", port: 443, secret: "b".repeat(32) },
     ]);
 
     const connectPromise = client.connect(BOT_TOKEN);
@@ -164,8 +164,8 @@ describe("GramJSBotClient — proxy timeout and cleanup", () => {
     vi.useFakeTimers();
 
     const client = new GramJSBotClient(12345, "hash", "/tmp/session", [
-      { server: "hang1.example.com", port: 443, secret: "aabbcc" },
-      { server: "hang2.example.com", port: 443, secret: "ddeeff" },
+      { server: "hang1.example.com", port: 443, secret: "a".repeat(32) },
+      { server: "hang2.example.com", port: 443, secret: "b".repeat(32) },
     ]);
 
     const connectPromise = client.connect(BOT_TOKEN);
@@ -185,8 +185,8 @@ describe("GramJSBotClient — proxy timeout and cleanup", () => {
       .mockResolvedValueOnce(undefined);
 
     const client = new GramJSBotClient(12345, "hash", "/tmp/session", [
-      { server: "bad.example.com", port: 443, secret: "aabbcc" },
-      { server: "good.example.com", port: 443, secret: "ddeeff" },
+      { server: "bad.example.com", port: 443, secret: "a".repeat(32) },
+      { server: "good.example.com", port: 443, secret: "b".repeat(32) },
     ]);
 
     await client.connect(BOT_TOKEN);

--- a/src/bot/gramjs-bot.ts
+++ b/src/bot/gramjs-bot.ts
@@ -11,7 +11,6 @@
  */
 
 import { TelegramClient, Api } from "telegram";
-import type { ProxyInterface } from "telegram/network/connection/TCPMTProxy.js";
 import { toLong } from "../utils/gramjs-bigint.js";
 import { StringSession } from "telegram/sessions/index.js";
 import { Logger, LogLevel } from "telegram/extensions/Logger.js";
@@ -26,6 +25,10 @@ import { TELEGRAM_CONNECTION_RETRIES } from "../constants/limits.js";
 import { withFloodRetry } from "../telegram/flood-retry.js";
 import { createLogger } from "../utils/logger.js";
 import type { MtprotoProxyEntry } from "../config/schema.js";
+import {
+  buildMtprotoProxyClientOptions,
+  type MtprotoProxyClientOptions,
+} from "../telegram/mtproto-proxy.js";
 
 const log = createLogger("Bot");
 
@@ -79,24 +82,18 @@ export class GramJSBotClient {
     this.client = this.buildClient(sessionString);
   }
 
-  private buildClient(sessionString: string, proxy?: ProxyInterface): TelegramClient {
+  private buildClient(
+    sessionString: string,
+    proxyOptions: Partial<MtprotoProxyClientOptions> = {}
+  ): TelegramClient {
     const logger = new Logger(LogLevel.NONE);
     return new TelegramClient(new StringSession(sessionString), this.apiId, this.apiHash, {
       connectionRetries: 3,
       retryDelay: GRAMJS_RETRY_DELAY_MS,
       autoReconnect: true,
       baseLogger: logger,
-      proxy,
+      ...proxyOptions,
     });
-  }
-
-  private buildProxy(entry: MtprotoProxyEntry): ProxyInterface {
-    return {
-      ip: entry.server,
-      port: entry.port,
-      secret: entry.secret,
-      MTProxy: true,
-    } as ProxyInterface;
   }
 
   private loadSession(): string {
@@ -146,7 +143,7 @@ export class GramJSBotClient {
           `[GramJS Bot] [MTProxy] Trying proxy ${i + 1}/${this.mtprotoProxies.length}`
         );
         try {
-          this.client = this.buildClient(sessionString, this.buildProxy(entry));
+          this.client = this.buildClient(sessionString, buildMtprotoProxyClientOptions(entry));
 
           let timeoutId: ReturnType<typeof setTimeout> | undefined;
           const timeoutPromise = new Promise<never>((_, reject) => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -782,7 +782,7 @@ const _MtprotoProxyObject = z.object({
   port: z.number().min(1).max(65535).describe("Proxy server port"),
   secret: z
     .string()
-    .describe("MTProto proxy secret (hex string, 32 chars or dd-prefixed 34 chars)"),
+    .describe("MTProto proxy secret (16-byte hex, or 17-byte transport-prefixed hex)"),
 });
 export type MtprotoProxyEntry = z.infer<typeof _MtprotoProxyObject>;
 

--- a/src/telegram/__tests__/client-proxy.test.ts
+++ b/src/telegram/__tests__/client-proxy.test.ts
@@ -25,20 +25,50 @@ vi.mock("../flood-retry.js", () => ({
 }));
 
 // Use vi.hoisted so variables are available inside vi.mock factories
-const { mockConnect, mockDisconnect, mockGetMe, mockInvoke, mockExistsSync } = vi.hoisted(() => {
+const {
+  mockConnect,
+  mockDisconnect,
+  mockGetMe,
+  mockInvoke,
+  mockExistsSync,
+  mockReadFileSync,
+  mockUnlinkSync,
+  constructedOptions,
+  constructedSessions,
+} = vi.hoisted(() => {
   const mockConnect = vi.fn();
   const mockDisconnect = vi.fn().mockResolvedValue(undefined);
   const mockGetMe = vi.fn();
   const mockInvoke = vi.fn();
   const mockExistsSync = vi.fn();
-  return { mockConnect, mockDisconnect, mockGetMe, mockInvoke, mockExistsSync };
+  const mockReadFileSync = vi.fn();
+  const mockUnlinkSync = vi.fn();
+  const constructedOptions: Array<Record<string, unknown>> = [];
+  const constructedSessions: string[] = [];
+  return {
+    mockConnect,
+    mockDisconnect,
+    mockGetMe,
+    mockInvoke,
+    mockExistsSync,
+    mockReadFileSync,
+    mockUnlinkSync,
+    constructedOptions,
+    constructedSessions,
+  };
 });
 
 vi.mock("telegram", () => {
   class MockTelegramClient {
     session: { save: () => string };
-    constructor(_session: unknown, _apiId: number, _apiHash: string) {
-      this.session = { save: () => "" };
+    constructor(
+      session: { value?: string },
+      _apiId: number,
+      _apiHash: string,
+      options: Record<string, unknown> = {}
+    ) {
+      constructedOptions.push(options);
+      this.session = { save: () => session.value ?? "" };
     }
     connect = mockConnect;
     disconnect = mockDisconnect;
@@ -81,7 +111,9 @@ vi.mock("telegram/extensions/Logger.js", () => ({
 
 vi.mock("telegram/sessions/index.js", () => ({
   StringSession: class {
-    constructor(public value: string = "") {}
+    constructor(public value: string = "") {
+      constructedSessions.push(value);
+    }
     save() {
       return this.value;
     }
@@ -94,9 +126,10 @@ vi.mock("telegram/events/index.js", () => ({
 
 vi.mock("fs", () => ({
   existsSync: (...args: unknown[]) => mockExistsSync(...args),
-  readFileSync: vi.fn().mockReturnValue(""),
+  readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
   writeFileSync: vi.fn(),
   mkdirSync: vi.fn(),
+  unlinkSync: (...args: unknown[]) => mockUnlinkSync(...args),
 }));
 
 vi.mock("path", () => ({
@@ -129,8 +162,11 @@ const MOCK_ME = {
 describe("TelegramUserClient — proxy connection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    constructedOptions.length = 0;
+    constructedSessions.length = 0;
     mockConnect.mockResolvedValue(undefined);
     mockGetMe.mockResolvedValue(MOCK_ME);
+    mockReadFileSync.mockReturnValue("");
   });
 
   describe("with existing session", () => {
@@ -141,7 +177,7 @@ describe("TelegramUserClient — proxy connection", () => {
     it("connects via first proxy when session exists", async () => {
       const client = new TelegramUserClient({
         ...BASE_CONFIG,
-        mtprotoProxies: [{ server: "proxy1.example.com", port: 443, secret: "aabbcc" }],
+        mtprotoProxies: [{ server: "proxy1.example.com", port: 443, secret: "a".repeat(32) }],
       });
 
       await client.connect();
@@ -158,8 +194,8 @@ describe("TelegramUserClient — proxy connection", () => {
       const client = new TelegramUserClient({
         ...BASE_CONFIG,
         mtprotoProxies: [
-          { server: "proxy1.example.com", port: 443, secret: "aabbcc" },
-          { server: "proxy2.example.com", port: 443, secret: "ddeeff" },
+          { server: "proxy1.example.com", port: 443, secret: "a".repeat(32) },
+          { server: "proxy2.example.com", port: 443, secret: "b".repeat(32) },
         ],
       });
 
@@ -175,8 +211,8 @@ describe("TelegramUserClient — proxy connection", () => {
       const client = new TelegramUserClient({
         ...BASE_CONFIG,
         mtprotoProxies: [
-          { server: "proxy1.example.com", port: 443, secret: "aabbcc" },
-          { server: "proxy2.example.com", port: 443, secret: "ddeeff" },
+          { server: "proxy1.example.com", port: 443, secret: "a".repeat(32) },
+          { server: "proxy2.example.com", port: 443, secret: "b".repeat(32) },
         ],
       });
 
@@ -202,19 +238,19 @@ describe("TelegramUserClient — proxy connection", () => {
       const client = new TelegramUserClient({
         ...BASE_CONFIG,
         mtprotoProxies: [
-          { server: "proxy1.example.com", port: 443, secret: "aabbcc" },
-          { server: "proxy2.example.com", port: 443, secret: "ddeeff" },
+          { server: "proxy1.example.com", port: 443, secret: "a".repeat(32) },
+          { server: "proxy2.example.com", port: 443, secret: "b".repeat(32) },
         ],
       });
 
       await expect(client.connect()).rejects.toThrow("test: auth flow reached via proxy");
 
-      // Only proxy1 was connected (not proxy2, because auth error is not proxy failure)
-      expect(mockConnect).toHaveBeenCalledTimes(1);
+      // Only proxy1 was used. It is reconnected with a fresh session instead of trying proxy2.
+      expect(mockConnect).toHaveBeenCalledTimes(2);
       // getMe was only tried once on proxy1
       expect(mockGetMe).toHaveBeenCalledTimes(1);
-      // Proxy1 client was NOT disconnected (it stays connected for auth flow)
-      expect(mockDisconnect).not.toHaveBeenCalled();
+      // Stale-session client is disconnected before the fresh-session auth flow.
+      expect(mockDisconnect).toHaveBeenCalledTimes(1);
       // Active proxy index is 0 (first proxy)
       expect(client.getActiveProxyIndex()).toBe(0);
       // Auth flow was reached (invoke was called)
@@ -232,18 +268,51 @@ describe("TelegramUserClient — proxy connection", () => {
       const client = new TelegramUserClient({
         ...BASE_CONFIG,
         mtprotoProxies: [
-          { server: "proxy1.example.com", port: 443, secret: "aabbcc" },
-          { server: "proxy2.example.com", port: 443, secret: "ddeeff" },
+          { server: "proxy1.example.com", port: 443, secret: "a".repeat(32) },
+          { server: "proxy2.example.com", port: 443, secret: "b".repeat(32) },
         ],
       });
 
       await expect(client.connect()).rejects.toThrow("test: auth flow reached via proxy");
 
-      expect(mockConnect).toHaveBeenCalledTimes(1);
+      expect(mockConnect).toHaveBeenCalledTimes(2);
       expect(mockGetMe).toHaveBeenCalledTimes(1);
-      expect(mockDisconnect).not.toHaveBeenCalled();
+      expect(mockDisconnect).toHaveBeenCalledTimes(1);
       expect(client.getActiveProxyIndex()).toBe(0);
       expect(mockInvoke).toHaveBeenCalledTimes(1);
+    });
+
+    it("rebuilds a fresh session on the same proxy before re-authentication after auth-key failure", async () => {
+      mockReadFileSync.mockReturnValue("stale-session");
+      const authKeyError = Object.assign(new Error("AUTH_KEY_UNREGISTERED"), {
+        code: 406,
+        errorMessage: "AUTH_KEY_UNREGISTERED",
+      });
+      mockGetMe.mockRejectedValueOnce(authKeyError);
+      mockInvoke.mockRejectedValueOnce(
+        new Error("test: auth flow reached via fresh proxy session")
+      );
+
+      const client = new TelegramUserClient({
+        ...BASE_CONFIG,
+        mtprotoProxies: [
+          { server: "proxy1.example.com", port: 443, secret: "a".repeat(32) },
+          { server: "proxy2.example.com", port: 443, secret: "b".repeat(32) },
+        ],
+      });
+
+      await expect(client.connect()).rejects.toThrow(
+        "test: auth flow reached via fresh proxy session"
+      );
+
+      expect(mockConnect).toHaveBeenCalledTimes(2);
+      expect(mockDisconnect).toHaveBeenCalledTimes(1);
+      expect(mockGetMe).toHaveBeenCalledTimes(1);
+      expect(mockInvoke).toHaveBeenCalledTimes(1);
+      expect(client.getActiveProxyIndex()).toBe(0);
+      expect(mockUnlinkSync).toHaveBeenCalledWith(BASE_CONFIG.sessionPath);
+      expect(constructedSessions).toEqual(["stale-session", "stale-session", ""]);
+      expect(constructedOptions[1].proxy).toEqual(constructedOptions[2].proxy);
     });
 
     it("falls back to direct connection when all proxies fail (session present)", async () => {
@@ -255,8 +324,8 @@ describe("TelegramUserClient — proxy connection", () => {
       const client = new TelegramUserClient({
         ...BASE_CONFIG,
         mtprotoProxies: [
-          { server: "proxy1.example.com", port: 443, secret: "aabbcc" },
-          { server: "proxy2.example.com", port: 443, secret: "ddeeff" },
+          { server: "proxy1.example.com", port: 443, secret: "a".repeat(32) },
+          { server: "proxy2.example.com", port: 443, secret: "b".repeat(32) },
         ],
       });
 
@@ -297,7 +366,7 @@ describe("TelegramUserClient — proxy connection", () => {
 
       const client = new TelegramUserClient({
         ...BASE_CONFIG,
-        mtprotoProxies: [{ server: "proxy1.example.com", port: 443, secret: "aabbcc" }],
+        mtprotoProxies: [{ server: "proxy1.example.com", port: 443, secret: "a".repeat(32) }],
       });
 
       await expect(client.connect()).rejects.toThrow("test: SendCode called via proxy");
@@ -327,7 +396,7 @@ describe("TelegramUserClient — proxy connection", () => {
 
       const client = new TelegramUserClient({
         ...BASE_CONFIG,
-        mtprotoProxies: [{ server: "proxy1.example.com", port: 443, secret: "aabbcc" }],
+        mtprotoProxies: [{ server: "proxy1.example.com", port: 443, secret: "a".repeat(32) }],
       });
 
       await expect(client.connect()).rejects.toThrow("test: SendCode called after direct fallback");
@@ -344,7 +413,7 @@ describe("TelegramUserClient — proxy connection", () => {
 
       const client = new TelegramUserClient({
         ...BASE_CONFIG,
-        mtprotoProxies: [{ server: "proxy1.example.com", port: 443, secret: "aabbcc" }],
+        mtprotoProxies: [{ server: "proxy1.example.com", port: 443, secret: "a".repeat(32) }],
       });
 
       await expect(client.connect()).rejects.toThrow("network unreachable");
@@ -384,8 +453,8 @@ describe("TelegramUserClient — proxy timeout", () => {
     const client = new TelegramUserClient({
       ...BASE_CONFIG,
       mtprotoProxies: [
-        { server: "hanging.example.com", port: 443, secret: "aabbcc" },
-        { server: "proxy2.example.com", port: 443, secret: "ddeeff" },
+        { server: "hanging.example.com", port: 443, secret: "a".repeat(32) },
+        { server: "proxy2.example.com", port: 443, secret: "b".repeat(32) },
       ],
     });
 
@@ -424,8 +493,8 @@ describe("TelegramUserClient — proxy timeout", () => {
     const client = new TelegramUserClient({
       ...BASE_CONFIG,
       mtprotoProxies: [
-        { server: "hanging1.example.com", port: 443, secret: "aabbcc" },
-        { server: "hanging2.example.com", port: 443, secret: "ddeeff" },
+        { server: "hanging1.example.com", port: 443, secret: "a".repeat(32) },
+        { server: "hanging2.example.com", port: 443, secret: "b".repeat(32) },
       ],
     });
 
@@ -449,8 +518,8 @@ describe("TelegramUserClient — proxy timeout", () => {
     const client = new TelegramUserClient({
       ...BASE_CONFIG,
       mtprotoProxies: [
-        { server: "bad.example.com", port: 443, secret: "aabbcc" },
-        { server: "good.example.com", port: 443, secret: "ddeeff" },
+        { server: "bad.example.com", port: 443, secret: "a".repeat(32) },
+        { server: "good.example.com", port: 443, secret: "b".repeat(32) },
       ],
     });
 
@@ -473,7 +542,7 @@ describe("TelegramUserClient — getActiveProxyIndex", () => {
   it("returns undefined before connecting", () => {
     const client = new TelegramUserClient({
       ...BASE_CONFIG,
-      mtprotoProxies: [{ server: "proxy1.example.com", port: 443, secret: "aabbcc" }],
+      mtprotoProxies: [{ server: "proxy1.example.com", port: 443, secret: "a".repeat(32) }],
     });
     expect(client.getActiveProxyIndex()).toBeUndefined();
   });
@@ -484,8 +553,8 @@ describe("TelegramUserClient — getActiveProxyIndex", () => {
     const client = new TelegramUserClient({
       ...BASE_CONFIG,
       mtprotoProxies: [
-        { server: "proxy1.example.com", port: 443, secret: "aabbcc" },
-        { server: "proxy2.example.com", port: 443, secret: "ddeeff" },
+        { server: "proxy1.example.com", port: 443, secret: "a".repeat(32) },
+        { server: "proxy2.example.com", port: 443, secret: "b".repeat(32) },
       ],
     });
 
@@ -502,8 +571,8 @@ describe("TelegramUserClient — getActiveProxyIndex", () => {
     const client = new TelegramUserClient({
       ...BASE_CONFIG,
       mtprotoProxies: [
-        { server: "proxy1.example.com", port: 443, secret: "aabbcc" },
-        { server: "proxy2.example.com", port: 443, secret: "ddeeff" },
+        { server: "proxy1.example.com", port: 443, secret: "a".repeat(32) },
+        { server: "proxy2.example.com", port: 443, secret: "b".repeat(32) },
       ],
     });
 
@@ -519,7 +588,7 @@ describe("TelegramUserClient — getActiveProxyIndex", () => {
 
     const client = new TelegramUserClient({
       ...BASE_CONFIG,
-      mtprotoProxies: [{ server: "proxy1.example.com", port: 443, secret: "aabbcc" }],
+      mtprotoProxies: [{ server: "proxy1.example.com", port: 443, secret: "a".repeat(32) }],
     });
 
     await client.connect();

--- a/src/telegram/__tests__/mtproto-proxy-health.test.ts
+++ b/src/telegram/__tests__/mtproto-proxy-health.test.ts
@@ -123,6 +123,25 @@ describe("MTProto proxy health checks", () => {
     expect(mockDisconnect).toHaveBeenCalledTimes(1);
   });
 
+  it("reports the proxy as available when authenticated validation fails with an auth error", async () => {
+    const authKeyError = Object.assign(new Error("AUTH_KEY_UNREGISTERED"), {
+      code: 406,
+      errorMessage: "AUTH_KEY_UNREGISTERED",
+    });
+    mockGetMe.mockRejectedValueOnce(authKeyError);
+
+    const status = await checkMtprotoProxy(12345, "hash", PROXY, 0, {
+      sessionString: "stale-session",
+    });
+
+    expect(status.status).toBe("available");
+    expect(status.available).toBe(true);
+    expect(status.error).toContain("re-authentication");
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+    expect(mockGetMe).toHaveBeenCalledTimes(1);
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+  });
+
   it("reports an unavailable proxy when the MTProto connection fails", async () => {
     mockConnect.mockRejectedValueOnce(new Error("proxy refused connection"));
 

--- a/src/telegram/__tests__/mtproto-proxy.test.ts
+++ b/src/telegram/__tests__/mtproto-proxy.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMtprotoProxyClientOptions,
+  getMtprotoProxySecretValidationError,
+} from "../mtproto-proxy.js";
+
+describe("MTProto proxy client options", () => {
+  it("uses the GramJS MTProxy path for a 16-byte hex secret", () => {
+    const options = buildMtprotoProxyClientOptions({
+      server: "proxy.example.com",
+      port: 443,
+      secret: "a".repeat(32),
+    });
+
+    expect(options.proxy).toEqual({
+      ip: "proxy.example.com",
+      port: 443,
+      secret: "a".repeat(32),
+      MTProxy: true,
+    });
+    expect(options.connection).toBeUndefined();
+  });
+
+  it("uses randomized intermediate transport for a 17-byte prefixed secret", () => {
+    const options = buildMtprotoProxyClientOptions({
+      server: "proxy.example.com",
+      port: 443,
+      secret: `dd${"b".repeat(32)}`,
+    });
+
+    expect(options.proxy).toMatchObject({
+      ip: "proxy.example.com",
+      port: 443,
+      secret: "b".repeat(32),
+      mtprotoTransport: "randomized-intermediate",
+    });
+    expect("MTProxy" in options.proxy).toBe(false);
+    expect(options.connection).toBeTypeOf("function");
+  });
+
+  it("rejects TLS-emulation secrets with a clear validation error", () => {
+    const secret = `ee${"c".repeat(32)}6578616d706c652e636f6d`;
+
+    expect(getMtprotoProxySecretValidationError(secret)).toContain("TLS-emulation");
+    expect(() =>
+      buildMtprotoProxyClientOptions({
+        server: "proxy.example.com",
+        port: 443,
+        secret,
+      })
+    ).toThrow("TLS-emulation");
+  });
+
+  it("rejects malformed secret lengths", () => {
+    expect(getMtprotoProxySecretValidationError("aabbcc")).toContain("16 bytes");
+  });
+});

--- a/src/telegram/auth-errors.ts
+++ b/src/telegram/auth-errors.ts
@@ -1,0 +1,20 @@
+/**
+ * Telegram auth/session errors indicate stale credentials, not broken transport.
+ * They should trigger re-authentication while preserving the selected connection path.
+ */
+export function isTelegramAuthError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+
+  const record = err as Record<string, unknown>;
+  const numericCode = typeof record.code === "number" ? record.code : Number(record.code);
+  if (numericCode === 401 || numericCode === 406) return true;
+
+  const fields = [
+    record.errorMessage,
+    record.message,
+    err instanceof Error ? err.message : undefined,
+  ];
+  const combined = fields.filter((value): value is string => typeof value === "string").join(" ");
+
+  return /AUTH_KEY|UNAUTHORIZED|SESSION_EXPIRED|SESSION_REVOKED|USER_DEACTIVATED/i.test(combined);
+}

--- a/src/telegram/client.ts
+++ b/src/telegram/client.ts
@@ -1,36 +1,19 @@
 import { TelegramClient, Api } from "telegram";
-import type { ProxyInterface } from "telegram/network/connection/TCPMTProxy.js";
 import { Logger, LogLevel } from "telegram/extensions/Logger.js";
 import { StringSession } from "telegram/sessions/index.js";
 import { NewMessage } from "telegram/events/index.js";
 import type { NewMessageEvent } from "telegram/events/NewMessage.js";
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "fs";
 import { dirname } from "path";
 import { createInterface } from "readline";
 import { markdownToTelegramHtml } from "./formatting.js";
 import { withFloodRetry } from "./flood-retry.js";
 import { TelegramError } from "./errors.js";
+import { isTelegramAuthError } from "./auth-errors.js";
+import { buildMtprotoProxyClientOptions, type MtprotoProxyClientOptions } from "./mtproto-proxy.js";
 import { createLogger } from "../utils/logger.js";
 import type { MtprotoProxyEntry } from "../config/schema.js";
 import { MTPROTO_PROXY_CONNECT_TIMEOUT_MS } from "../constants/timeouts.js";
-
-/**
- * Returns true when the error is an authentication/authorization failure
- * that is NOT caused by the proxy being broken — e.g. expired session,
- * unregistered auth key, or an account-level ban. In those cases the
- * proxy transport is actually working fine; we should keep the proxy and
- * let the normal auth flow handle re-authentication instead of abandoning
- * the proxy and falling back to direct, which may itself be blocked.
- */
-function isAuthError(err: unknown): boolean {
-  if (!err || typeof err !== "object") return false;
-  const code = (err as Record<string, unknown>).code;
-  const msg = String((err as Record<string, unknown>).errorMessage ?? "");
-  // GramJS RPC error codes: 401 = Unauthorized, 406 = AuthKey error
-  if (code === 401 || code === 406) return true;
-  // Match common auth-related error messages
-  return /AUTH_KEY|UNAUTHORIZED|SESSION_EXPIRED|USER_DEACTIVATED/i.test(msg);
-}
 
 const log = createLogger("Telegram");
 
@@ -79,8 +62,11 @@ export class TelegramUserClient {
     this.client = this.buildClient();
   }
 
-  private buildClient(proxy?: ProxyInterface): TelegramClient {
-    const sessionString = this.loadSession();
+  private buildClient(
+    proxyOptions: Partial<MtprotoProxyClientOptions> = {},
+    sessionStringOverride?: string
+  ): TelegramClient {
+    const sessionString = sessionStringOverride ?? this.loadSession();
     const session = new StringSession(sessionString);
     const logger = new Logger(LogLevel.NONE);
     return new TelegramClient(session, this.config.apiId, this.config.apiHash, {
@@ -89,17 +75,8 @@ export class TelegramUserClient {
       autoReconnect: this.config.autoReconnect ?? true,
       floodSleepThreshold: this.config.floodSleepThreshold ?? 60,
       baseLogger: logger,
-      proxy,
+      ...proxyOptions,
     });
-  }
-
-  private buildProxy(entry: MtprotoProxyEntry): ProxyInterface {
-    return {
-      ip: entry.server,
-      port: entry.port,
-      secret: entry.secret,
-      MTProxy: true,
-    } as ProxyInterface;
   }
 
   private loadSession(): string {
@@ -131,19 +108,30 @@ export class TelegramUserClient {
     }
   }
 
+  private clearSavedSession(): void {
+    try {
+      if (existsSync(this.config.sessionPath)) {
+        unlinkSync(this.config.sessionPath);
+        log.info("Stale Telegram session cleared");
+      }
+    } catch (error) {
+      log.warn({ err: error }, "Failed to clear stale Telegram session");
+    }
+  }
+
   /** Try connecting via proxy at `index`, rebuilding the client with that proxy.
    *  Races the connect() call against a timeout to avoid indefinite hangs when
    *  a proxy silently drops packets instead of refusing the connection.
    */
-  private async connectWithProxy(index: number): Promise<void> {
+  private async connectWithProxy(index: number, sessionStringOverride?: string): Promise<void> {
     const proxies = this.config.mtprotoProxies ?? [];
     const entry = proxies[index];
-    const proxy = this.buildProxy(entry);
+    const proxyOptions = buildMtprotoProxyClientOptions(entry);
     log.info(
       { server: entry.server, port: entry.port },
       `[MTProxy] Trying proxy ${index + 1}/${proxies.length}`
     );
-    this.client = this.buildClient(proxy);
+    this.client = this.buildClient(proxyOptions, sessionStringOverride);
     this.activeProxyIndex = index;
 
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -348,11 +336,14 @@ export class TelegramUserClient {
                 // Auth errors (expired session, unregistered key, etc.) mean the
                 // proxy transport is fine — keep this proxy but clear the stale
                 // session state so the auth flow can re-authenticate through it.
-                if (isAuthError(getMeErr)) {
+                if (isTelegramAuthError(getMeErr)) {
                   log.warn(
                     { err: getMeErr, server: proxies[i].server },
                     `[MTProxy] Proxy ${i + 1}/${proxies.length}: auth error, will re-authenticate through this proxy`
                   );
+                  await this.disconnectCurrentClient();
+                  this.clearSavedSession();
+                  await this.connectWithProxy(i, "");
                 } else {
                   // Network-level getMe failure — proxy is broken, try the next one
                   throw getMeErr;

--- a/src/telegram/mtproto-proxy-health.ts
+++ b/src/telegram/mtproto-proxy-health.ts
@@ -1,10 +1,11 @@
 import { TelegramClient } from "telegram";
-import type { ProxyInterface } from "telegram/network/connection/TCPMTProxy.js";
 import { Logger, LogLevel } from "telegram/extensions/Logger.js";
 import { StringSession } from "telegram/sessions/index.js";
 import type { MtprotoProxyEntry } from "../config/schema.js";
 import { MTPROTO_PROXY_STATUS_TIMEOUT_MS } from "../constants/timeouts.js";
 import { getErrorMessage } from "../utils/errors.js";
+import { isTelegramAuthError } from "./auth-errors.js";
+import { buildMtprotoProxyClientOptions } from "./mtproto-proxy.js";
 
 export type MtprotoProxyHealthState = "available" | "unavailable" | "unchecked";
 
@@ -30,15 +31,6 @@ interface CheckAllOptions extends CheckOptions {
   apiId: number;
   apiHash: string;
   proxies: MtprotoProxyEntry[];
-}
-
-function buildProxy(entry: MtprotoProxyEntry): ProxyInterface {
-  return {
-    ip: entry.server,
-    port: entry.port,
-    secret: entry.secret,
-    MTProxy: true,
-  } as ProxyInterface;
 }
 
 function createStatusBase(
@@ -90,7 +82,7 @@ export async function checkMtprotoProxy(
       autoReconnect: false,
       floodSleepThreshold: 0,
       baseLogger: logger,
-      proxy: buildProxy(entry),
+      ...buildMtprotoProxyClientOptions(entry),
     }
   );
 
@@ -116,7 +108,21 @@ export async function checkMtprotoProxy(
   try {
     await withStatusTimeout(client.connect(), "connection check");
     if (options.sessionString) {
-      await withStatusTimeout(client.getMe(), "authenticated check");
+      try {
+        await withStatusTimeout(client.getMe(), "authenticated check");
+      } catch (error) {
+        if (!isTelegramAuthError(error)) {
+          throw error;
+        }
+        return {
+          ...createStatusBase(entry, index, options.activeProxyIndex),
+          status: "available",
+          available: true,
+          latencyMs: Date.now() - startedAt,
+          error: `Telegram session requires re-authentication: ${getErrorMessage(error)}`,
+          checkedAt,
+        };
+      }
     }
     return {
       ...createStatusBase(entry, index, options.activeProxyIndex),

--- a/src/telegram/mtproto-proxy.ts
+++ b/src/telegram/mtproto-proxy.ts
@@ -1,0 +1,270 @@
+import { createRequire } from "module";
+import type { ProxyInterface } from "telegram/network/connection/TCPMTProxy.js";
+import type * as GramjsConnectionModule from "telegram/network/connection/Connection.js";
+import type { Connection } from "telegram/network/connection/Connection.js";
+import type { AbridgedPacketCodec as GramjsAbridgedPacketCodec } from "telegram/network/connection/TCPAbridged.js";
+import type { Logger, PromisedNetSockets, PromisedWebSockets } from "telegram/extensions/index.js";
+import { generateRandomBytes, sha256 } from "telegram/Helpers.js";
+import { CTR } from "telegram/crypto/CTR.js";
+import type { MtprotoProxyEntry } from "../config/schema.js";
+
+const require = createRequire(import.meta.url);
+const HEX_SECRET_RE = /^[0-9a-f]+$/i;
+const MT_PROXY_INIT_FORBIDDEN_PREFIXES = [
+  Buffer.from("50567247", "hex"), // PVrG
+  Buffer.from("47455420", "hex"), // GET
+  Buffer.from("504f5354", "hex"), // POST
+  Buffer.from("48454144", "hex"), // HEAD
+  Buffer.from("16030102", "hex"), // TLS ClientHello
+  Buffer.from("dddddddd", "hex"),
+  Buffer.from("eeeeeeee", "hex"),
+];
+
+type MtprotoSecretTransport = "abridged" | "randomized-intermediate";
+
+interface NormalizedMtprotoSecret {
+  secretHex: string;
+  transport: MtprotoSecretTransport;
+}
+
+interface CustomMtprotoProxy {
+  ip: string;
+  port: number;
+  secret: string;
+  mtprotoTransport: "randomized-intermediate";
+}
+
+interface GramjsConnectionParams {
+  ip: string;
+  port: number;
+  dcId: number;
+  loggers: Logger;
+  proxy?: ProxyInterface | CustomMtprotoProxy;
+  socket: typeof PromisedNetSockets | typeof PromisedWebSockets;
+  testServers: boolean;
+}
+
+export interface MtprotoProxyClientOptions {
+  proxy: ProxyInterface;
+  connection?: typeof Connection;
+}
+
+let randomizedIntermediateConnection: typeof Connection | undefined;
+
+function normalizeHexSecret(secret: string): string {
+  return secret.trim().replace(/^0x/i, "");
+}
+
+export function getMtprotoProxySecretValidationError(secret: string): string | null {
+  const normalized = normalizeHexSecret(secret);
+  if (!normalized) {
+    return "secret is required";
+  }
+  if (!HEX_SECRET_RE.test(normalized) || normalized.length % 2 !== 0) {
+    return "secret must be a hex string";
+  }
+
+  const byteLength = normalized.length / 2;
+  if (byteLength === 16 || byteLength === 17) {
+    return null;
+  }
+
+  if (normalized.toLowerCase().startsWith("ee") && byteLength > 17) {
+    return (
+      "TLS-emulation MTProto secrets (ee-prefixed secrets with a domain) are not supported; " +
+      "use a 32-character hex secret or a 34-character transport-prefixed secret"
+    );
+  }
+
+  return "secret must be 16 bytes (32 hex characters) or 17 bytes (34 hex characters) with a transport prefix";
+}
+
+function normalizeMtprotoSecret(secret: string): NormalizedMtprotoSecret {
+  const normalized = normalizeHexSecret(secret);
+  const validationError = getMtprotoProxySecretValidationError(normalized);
+  if (validationError) {
+    throw new Error(`Invalid MTProto proxy secret: ${validationError}`);
+  }
+
+  if (normalized.length === 34) {
+    return {
+      secretHex: normalized.slice(2),
+      transport: "randomized-intermediate",
+    };
+  }
+
+  return {
+    secretHex: normalized,
+    transport: "abridged",
+  };
+}
+
+export function buildMtprotoProxyClientOptions(
+  entry: MtprotoProxyEntry
+): MtprotoProxyClientOptions {
+  const normalized = normalizeMtprotoSecret(entry.secret);
+
+  if (normalized.transport === "randomized-intermediate") {
+    return {
+      proxy: {
+        ip: entry.server,
+        port: entry.port,
+        secret: normalized.secretHex,
+        mtprotoTransport: "randomized-intermediate",
+      } as unknown as ProxyInterface,
+      connection: getConnectionTCPMTProxyRandomizedIntermediate(),
+    };
+  }
+
+  return {
+    proxy: {
+      ip: entry.server,
+      port: entry.port,
+      secret: normalized.secretHex,
+      MTProxy: true,
+    } as ProxyInterface,
+  };
+}
+
+function getConnectionTCPMTProxyRandomizedIntermediate(): typeof Connection {
+  if (randomizedIntermediateConnection) {
+    return randomizedIntermediateConnection;
+  }
+
+  // GramJS connection submodules have CJS initialization ordering assumptions.
+  // Loading the package root first avoids a circular export failure.
+  require("telegram");
+  const connectionModule =
+    require("telegram/network/connection/Connection.js") as typeof GramjsConnectionModule;
+
+  class RandomizedIntermediatePacketCodec extends connectionModule.PacketCodec {
+    static tag = Buffer.from("dddddddd", "hex");
+    static obfuscateTag = Buffer.from("dddddddd", "hex");
+    tag = RandomizedIntermediatePacketCodec.tag;
+    obfuscateTag = RandomizedIntermediatePacketCodec.obfuscateTag;
+
+    encodePacket(data: Buffer): Buffer {
+      const paddingLength = Math.floor(Math.random() * 4);
+      const padding = paddingLength > 0 ? generateRandomBytes(paddingLength) : Buffer.alloc(0);
+      const packet = Buffer.concat([data, padding]);
+      const length = Buffer.alloc(4);
+      length.writeInt32LE(packet.length, 0);
+      return Buffer.concat([length, packet]);
+    }
+
+    async readPacket(reader: { read: (n: number) => Promise<Buffer> }): Promise<Buffer> {
+      const length = (await reader.read(4)).readInt32LE(0);
+      const packet = await reader.read(length);
+      const paddingLength = packet.length % 4;
+      return paddingLength > 0 ? packet.slice(0, -paddingLength) : packet;
+    }
+  }
+  const gramjsPacketCodecClass =
+    RandomizedIntermediatePacketCodec as unknown as typeof GramjsAbridgedPacketCodec;
+
+  class MtprotoProxyObfuscatedIO {
+    header?: Buffer;
+    private readonly connection: {
+      readExactly: (n: number) => Promise<Buffer>;
+      write: (data: Buffer) => void;
+    };
+    private readonly packetClass: typeof RandomizedIntermediatePacketCodec;
+    private readonly secret: Buffer;
+    private readonly dcId: number;
+    private encryptor?: CTR;
+    private decryptor?: CTR;
+
+    constructor(connection: ConnectionTCPMTProxyRandomizedIntermediate) {
+      this.connection = connection.socket;
+      this.packetClass = RandomizedIntermediatePacketCodec;
+      this.secret = connection.secret;
+      this.dcId = connection._dcId;
+    }
+
+    async initHeader(): Promise<void> {
+      let random: Buffer;
+      do {
+        random = generateRandomBytes(64);
+      } while (!isValidMtproxyInitPayload(random));
+
+      const randomReversed = Buffer.from(random.slice(8, 56)).reverse();
+      const encryptKey = await sha256(Buffer.concat([random.slice(8, 40), this.secret]));
+      const encryptIv = random.slice(40, 56);
+      const decryptKey = await sha256(Buffer.concat([randomReversed.slice(0, 32), this.secret]));
+      const decryptIv = randomReversed.slice(32, 48);
+
+      this.encryptor = new CTR(encryptKey, encryptIv);
+      this.decryptor = new CTR(decryptKey, decryptIv);
+
+      this.packetClass.obfuscateTag.copy(random, 56);
+      random.writeInt16LE(this.dcId, 60);
+
+      const encryptedRandom = this.encryptor.encrypt(random);
+      encryptedRandom.copy(random, 56, 56, 64);
+      this.header = random;
+    }
+
+    async read(n: number): Promise<Buffer> {
+      if (!this.decryptor) {
+        throw new Error("MTProxy decryptor is not initialized");
+      }
+      return this.decryptor.encrypt(await this.connection.readExactly(n));
+    }
+
+    write(data: Buffer): void {
+      if (!this.encryptor) {
+        throw new Error("MTProxy encryptor is not initialized");
+      }
+      this.connection.write(this.encryptor.encrypt(data));
+    }
+  }
+
+  class ConnectionTCPMTProxyRandomizedIntermediate extends connectionModule.ObfuscatedConnection {
+    ObfuscatedIO = MtprotoProxyObfuscatedIO;
+    PacketCodecClass = gramjsPacketCodecClass;
+    secret: Buffer;
+
+    constructor({ dcId, loggers, proxy, socket, testServers }: GramjsConnectionParams) {
+      const mtprotoProxy = requireCustomMtprotoProxy(proxy);
+      super({
+        ip: mtprotoProxy.ip,
+        port: mtprotoProxy.port,
+        dcId,
+        loggers,
+        proxy: {
+          ip: mtprotoProxy.ip,
+          port: mtprotoProxy.port,
+          secret: mtprotoProxy.secret,
+          MTProxy: true,
+        } as ProxyInterface,
+        socket,
+        testServers,
+      });
+      this.secret = Buffer.from(mtprotoProxy.secret, "hex");
+    }
+  }
+
+  const connectionClass =
+    ConnectionTCPMTProxyRandomizedIntermediate as unknown as typeof Connection;
+  randomizedIntermediateConnection = connectionClass;
+  return connectionClass;
+}
+
+function isValidMtproxyInitPayload(random: Buffer): boolean {
+  if (random[0] === 0xef) {
+    return false;
+  }
+  if (random.slice(4, 8).equals(Buffer.alloc(4))) {
+    return false;
+  }
+  return !MT_PROXY_INIT_FORBIDDEN_PREFIXES.some((prefix) => random.slice(0, 4).equals(prefix));
+}
+
+function requireCustomMtprotoProxy(
+  proxy: ProxyInterface | CustomMtprotoProxy | undefined
+): CustomMtprotoProxy {
+  if (!proxy || !("mtprotoTransport" in proxy)) {
+    throw new Error("No MTProto proxy info specified for prefixed-secret transport");
+  }
+  return proxy;
+}

--- a/src/webui/__tests__/mtproto-routes.test.ts
+++ b/src/webui/__tests__/mtproto-routes.test.ts
@@ -169,4 +169,30 @@ describe("MTProto routes", () => {
       1
     );
   });
+
+  it("rejects unsupported TLS-emulation MTProto proxy secrets", async () => {
+    const app = buildApp({
+      telegram: { api_id: 12345, api_hash: "hash" },
+      mtproto: { enabled: true, proxies: [] },
+    });
+
+    const res = await app.request("/mtproto/proxies", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        proxies: [
+          {
+            server: "proxy.example.com",
+            port: 443,
+            secret: `ee${"a".repeat(32)}6578616d706c652e636f6d`,
+          },
+        ],
+      }),
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error).toContain("TLS-emulation");
+  });
 });

--- a/src/webui/routes/mtproto.ts
+++ b/src/webui/routes/mtproto.ts
@@ -8,6 +8,7 @@ import {
   checkMtprotoProxies,
   uncheckedMtprotoProxyStatuses,
 } from "../../telegram/mtproto-proxy-health.js";
+import { getMtprotoProxySecretValidationError } from "../../telegram/mtproto-proxy.js";
 import { TELETON_ROOT } from "../../workspace/paths.js";
 
 function unique(values: Array<string | undefined>): string[] {
@@ -174,11 +175,15 @@ export function createMtprotoRoutes(deps: WebUIServerDeps) {
             400
           );
         }
-        if (!p.secret || typeof p.secret !== "string" || p.secret.length < 32) {
+        const secretError =
+          typeof p.secret === "string"
+            ? getMtprotoProxySecretValidationError(p.secret)
+            : "secret is required";
+        if (secretError) {
           return c.json(
             {
               success: false,
-              error: `Proxy ${i + 1}: 'secret' must be a hex string (32+ characters)`,
+              error: `Proxy ${i + 1}: ${secretError}`,
             } as APIResponse,
             400
           );

--- a/src/webui/setup-auth.ts
+++ b/src/webui/setup-auth.ts
@@ -6,7 +6,6 @@
  */
 
 import { TelegramClient, Api } from "telegram";
-import type { ProxyInterface } from "telegram/network/connection/TCPMTProxy.js";
 import { StringSession } from "telegram/sessions/index.js";
 import { computeCheck } from "telegram/Password.js";
 import { Logger, LogLevel } from "telegram/extensions/Logger.js";
@@ -18,6 +17,10 @@ import { readRawConfig, writeRawConfig } from "../config/configurable-keys.js";
 import { createLogger } from "../utils/logger.js";
 import type { MtprotoProxyEntry } from "../config/schema.js";
 import { MTPROTO_PROXY_CONNECT_TIMEOUT_MS } from "../constants/timeouts.js";
+import {
+  buildMtprotoProxyClientOptions,
+  type MtprotoProxyClientOptions,
+} from "../telegram/mtproto-proxy.js";
 
 const log = createLogger("Setup");
 
@@ -73,22 +76,17 @@ type AuthSession = PhoneAuthSession | QrAuthSession;
 export class TelegramAuthManager {
   private session: AuthSession | null = null;
 
-  private buildProxy(entry: MtprotoProxyEntry): ProxyInterface {
-    return {
-      ip: entry.server,
-      port: entry.port,
-      secret: entry.secret,
-      MTProxy: true,
-    } as ProxyInterface;
-  }
-
-  private buildClient(apiId: number, apiHash: string, proxy?: ProxyInterface): TelegramClient {
+  private buildClient(
+    apiId: number,
+    apiHash: string,
+    proxyOptions: Partial<MtprotoProxyClientOptions> = {}
+  ): TelegramClient {
     const gramLogger = new Logger(LogLevel.NONE);
     return new TelegramClient(new StringSession(""), apiId, apiHash, {
       connectionRetries: 3,
       floodSleepThreshold: 0,
       baseLogger: gramLogger,
-      proxy,
+      ...proxyOptions,
     });
   }
 
@@ -122,7 +120,7 @@ export class TelegramAuthManager {
 
     for (let i = 0; i < proxies.length; i++) {
       const proxy = proxies[i];
-      const client = this.buildClient(apiId, apiHash, this.buildProxy(proxy));
+      const client = this.buildClient(apiId, apiHash, buildMtprotoProxyClientOptions(proxy));
       log.info(
         { server: proxy.server, port: proxy.port },
         `[MTProxy] Trying auth proxy ${i + 1}/${proxies.length}`


### PR DESCRIPTION
Fixes xlabtg/teleton-agent#429

## Root Cause
- MTProxy status checks and runtime startup were treating Telegram auth/session errors as proxy transport failures in some paths. After the previous auth-error preservation fix, runtime startup still tried to re-authenticate using the same stale `StringSession`, so `AUTH_KEY_UNREGISTERED`/401/406 could loop through a bad session instead of starting a fresh auth flow through the working proxy.
- The MTProxy secret handling only used GramJS's built-in abridged MTProxy connection. Telegram's MTProto transport docs specify that a 17-byte proxy secret carries a transport prefix, commonly `dd`, and should use padded/randomized intermediate transport. This made transport-prefixed secrets non-compliant.
- TLS-emulation `ee...domain` secrets are a different transport mode. They are now rejected with an explicit validation error instead of being accepted and later surfacing as a vague timeout.

References:
- https://core.telegram.org/mtproto/mtproto-transports
- https://core.telegram.org/proxy

## Changes
- Added shared MTProxy client option builder and secret validation.
- Added a local randomized-intermediate MTProxy connection for 17-byte prefixed secrets without patching `node_modules`.
- Rebuilt stale sessions before re-authentication, preserving the selected proxy path and clearing the bad saved session.
- Made authenticated health checks report auth/session errors as an available proxy that needs re-authentication.
- Reused the same MTProxy option builder in runtime user client, setup auth, GramJS bot client, and WebUI status checks.
- Added route validation for unsupported TLS-emulation secrets.

## Reproduction Covered
- Existing saved session returns `AUTH_KEY_UNREGISTERED` while the proxy transport is reachable.
- Authenticated health check receives an auth-key error from `getMe()`.
- 17-byte `dd` prefixed MTProxy secret requires randomized intermediate transport.
- `ee...domain` TLS-emulation secret should fail fast with a clear message.

## Verification
- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test` (199 files, 3451 tests)
- `npm run build:backend`
