### PR TITLE
Fix WebUI MTProto fake TLS proxy secrets

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
+# Updated: 2026-04-26T15:59:46.481Z

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -355,7 +355,7 @@ audit_trail:
 #   proxies:
 #     - server: "proxy1.example.com"   # 🖥 Server: hostname or IP
 #       port: 443                      # 🔌 Port: proxy server port
-#       secret: "dd1234abcdef..."      # 🔑 Secret: hex string (32+ chars, dd-prefix for TLS)
+#       secret: "dd1234abcdef..."      # 🔑 Secret: hex/base64url; dd for padded, ee+domain for fake TLS
 #     - server: "proxy2.example.com"
 #       port: 8888
 #       secret: "abcdef1234..."

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -782,7 +782,9 @@ const _MtprotoProxyObject = z.object({
   port: z.number().min(1).max(65535).describe("Proxy server port"),
   secret: z
     .string()
-    .describe("MTProto proxy secret (16-byte hex, or 17-byte transport-prefixed hex)"),
+    .describe(
+      "MTProto proxy secret (16-byte hex/base64url, 17-byte transport-prefixed secret, or ee TLS-emulation secret with domain)"
+    ),
 });
 export type MtprotoProxyEntry = z.infer<typeof _MtprotoProxyObject>;
 

--- a/src/telegram/__tests__/mtproto-proxy.test.ts
+++ b/src/telegram/__tests__/mtproto-proxy.test.ts
@@ -38,17 +38,47 @@ describe("MTProto proxy client options", () => {
     expect(options.connection).toBeTypeOf("function");
   });
 
-  it("rejects TLS-emulation secrets with a clear validation error", () => {
-    const secret = `ee${"c".repeat(32)}6578616d706c652e636f6d`;
+  it("uses fake TLS transport for an ee-prefixed TLS-emulation hex secret", () => {
+    const tlsDomainHex = Buffer.from("example.com", "utf-8").toString("hex");
+    const secret = `ee${"c".repeat(32)}${tlsDomainHex}`;
 
-    expect(getMtprotoProxySecretValidationError(secret)).toContain("TLS-emulation");
-    expect(() =>
-      buildMtprotoProxyClientOptions({
-        server: "proxy.example.com",
-        port: 443,
-        secret,
-      })
-    ).toThrow("TLS-emulation");
+    expect(getMtprotoProxySecretValidationError(secret)).toBeNull();
+    const options = buildMtprotoProxyClientOptions({
+      server: "proxy.example.com",
+      port: 443,
+      secret,
+    });
+
+    expect(options.proxy).toMatchObject({
+      ip: "proxy.example.com",
+      port: 443,
+      secret: "c".repeat(32),
+      mtprotoTransport: "tls-emulation",
+      tlsDomainHex,
+    });
+    expect("MTProxy" in options.proxy).toBe(false);
+    expect(options.connection).toBeTypeOf("function");
+  });
+
+  it("accepts Telegram base64url encoded fake TLS secrets", () => {
+    const rawSecret = Buffer.concat([
+      Buffer.from([0xee]),
+      Buffer.from("d".repeat(32), "hex"),
+      Buffer.from("example.com", "utf-8"),
+    ]).toString("base64url");
+
+    expect(getMtprotoProxySecretValidationError(rawSecret)).toBeNull();
+    const options = buildMtprotoProxyClientOptions({
+      server: "proxy.example.com",
+      port: 443,
+      secret: rawSecret,
+    });
+
+    expect(options.proxy).toMatchObject({
+      secret: "d".repeat(32),
+      mtprotoTransport: "tls-emulation",
+      tlsDomainHex: Buffer.from("example.com", "utf-8").toString("hex"),
+    });
   });
 
   it("rejects malformed secret lengths", () => {

--- a/src/telegram/mtproto-proxy.ts
+++ b/src/telegram/mtproto-proxy.ts
@@ -1,3 +1,4 @@
+import { createHmac, randomBytes, timingSafeEqual } from "crypto";
 import { createRequire } from "module";
 import type { ProxyInterface } from "telegram/network/connection/TCPMTProxy.js";
 import type * as GramjsConnectionModule from "telegram/network/connection/Connection.js";
@@ -10,6 +11,12 @@ import type { MtprotoProxyEntry } from "../config/schema.js";
 
 const require = createRequire(import.meta.url);
 const HEX_SECRET_RE = /^[0-9a-f]+$/i;
+const BASE64_SECRET_RE = /^[A-Za-z0-9+/_-]+={0,2}$/;
+const FAKE_TLS_CLIENT_HELLO_LENGTH = 517;
+const FAKE_TLS_MAX_CLIENT_RECORD_PAYLOAD = 2878;
+const TLS_CHANGE_CIPHER_SPEC = Buffer.from("140303000101", "hex");
+const TLS_HANDSHAKE_PREFIX = Buffer.from("160303", "hex");
+const TLS_APPLICATION_DATA_PREFIX = Buffer.from("170303", "hex");
 const MT_PROXY_INIT_FORBIDDEN_PREFIXES = [
   Buffer.from("50567247", "hex"), // PVrG
   Buffer.from("47455420", "hex"), // GET
@@ -20,18 +27,24 @@ const MT_PROXY_INIT_FORBIDDEN_PREFIXES = [
   Buffer.from("eeeeeeee", "hex"),
 ];
 
-type MtprotoSecretTransport = "abridged" | "randomized-intermediate";
+type MtprotoSecretTransport = "abridged" | "randomized-intermediate" | "tls-emulation";
 
 interface NormalizedMtprotoSecret {
   secretHex: string;
   transport: MtprotoSecretTransport;
+  tlsDomainHex?: string;
+}
+
+interface DecodedMtprotoSecret {
+  bytes: Buffer;
 }
 
 interface CustomMtprotoProxy {
   ip: string;
   port: number;
   secret: string;
-  mtprotoTransport: "randomized-intermediate";
+  mtprotoTransport: "randomized-intermediate" | "tls-emulation";
+  tlsDomainHex?: string;
 }
 
 interface GramjsConnectionParams {
@@ -49,52 +62,125 @@ export interface MtprotoProxyClientOptions {
   connection?: typeof Connection;
 }
 
-let randomizedIntermediateConnection: typeof Connection | undefined;
+let paddedIntermediateConnection: typeof Connection | undefined;
 
-function normalizeHexSecret(secret: string): string {
-  return secret.trim().replace(/^0x/i, "");
+function normalizeSecretInput(secret: string): string {
+  return secret.trim();
 }
 
-export function getMtprotoProxySecretValidationError(secret: string): string | null {
-  const normalized = normalizeHexSecret(secret);
-  if (!normalized) {
-    return "secret is required";
-  }
-  if (!HEX_SECRET_RE.test(normalized) || normalized.length % 2 !== 0) {
-    return "secret must be a hex string";
+function decodeBase64Secret(secret: string): Buffer | null {
+  if (!BASE64_SECRET_RE.test(secret)) {
+    return null;
   }
 
-  const byteLength = normalized.length / 2;
+  const withoutPadding = secret.replace(/=+$/, "");
+  if (withoutPadding.length < 22 || withoutPadding.length % 4 === 1) {
+    return null;
+  }
+
+  const normalized = withoutPadding.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+  const decoded = Buffer.from(padded, "base64");
+  const recoded = decoded
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  const expected = withoutPadding.replace(/\+/g, "-").replace(/\//g, "_");
+
+  return recoded === expected ? decoded : null;
+}
+
+function decodeMtprotoSecret(secret: string): DecodedMtprotoSecret {
+  const normalized = normalizeSecretInput(secret);
+  if (!normalized) {
+    throw new Error("secret is required");
+  }
+
+  const hexCandidate = normalized.replace(/^0x/i, "");
+  const isHex = HEX_SECRET_RE.test(hexCandidate);
+  if (isHex && hexCandidate.length % 2 !== 0) {
+    throw new Error("secret must contain complete bytes (even number of hex characters)");
+  }
+  if (isHex && hexCandidate.length >= 32) {
+    return { bytes: Buffer.from(hexCandidate, "hex") };
+  }
+
+  const base64Decoded = decodeBase64Secret(normalized);
+  if (base64Decoded) {
+    return { bytes: base64Decoded };
+  }
+
+  if (isHex) {
+    return { bytes: Buffer.from(hexCandidate, "hex") };
+  }
+
+  throw new Error("secret must be a hex or base64url string");
+}
+
+function validateFakeTlsDomain(domain: Buffer): string | null {
+  if (domain.length === 0) {
+    return "TLS-emulation secret must include a domain";
+  }
+  if (domain.length > 253) {
+    return "TLS-emulation domain must be 253 bytes or shorter";
+  }
+  if (domain.includes(0)) {
+    return "TLS-emulation domain must not contain NUL bytes";
+  }
+  return null;
+}
+
+function getDecodedMtprotoSecretValidationError(decoded: DecodedMtprotoSecret): string | null {
+  const { bytes } = decoded;
+  const byteLength = bytes.length;
+
   if (byteLength === 16 || byteLength === 17) {
     return null;
   }
 
-  if (normalized.toLowerCase().startsWith("ee") && byteLength > 17) {
-    return (
-      "TLS-emulation MTProto secrets (ee-prefixed secrets with a domain) are not supported; " +
-      "use a 32-character hex secret or a 34-character transport-prefixed secret"
-    );
+  if (bytes[0] === 0xee && byteLength >= 21) {
+    return validateFakeTlsDomain(bytes.subarray(17));
   }
 
-  return "secret must be 16 bytes (32 hex characters) or 17 bytes (34 hex characters) with a transport prefix";
+  return (
+    "secret must be 16 bytes, 17 bytes with a transport prefix, " +
+    "or an ee-prefixed TLS-emulation secret with a domain"
+  );
+}
+
+export function getMtprotoProxySecretValidationError(secret: string): string | null {
+  try {
+    return getDecodedMtprotoSecretValidationError(decodeMtprotoSecret(secret));
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
 }
 
 function normalizeMtprotoSecret(secret: string): NormalizedMtprotoSecret {
-  const normalized = normalizeHexSecret(secret);
-  const validationError = getMtprotoProxySecretValidationError(normalized);
+  const decoded = decodeMtprotoSecret(secret);
+  const validationError = getDecodedMtprotoSecretValidationError(decoded);
   if (validationError) {
     throw new Error(`Invalid MTProto proxy secret: ${validationError}`);
   }
 
-  if (normalized.length === 34) {
+  if (decoded.bytes[0] === 0xee && decoded.bytes.length >= 21) {
     return {
-      secretHex: normalized.slice(2),
+      secretHex: decoded.bytes.subarray(1, 17).toString("hex"),
+      transport: "tls-emulation",
+      tlsDomainHex: decoded.bytes.subarray(17).toString("hex"),
+    };
+  }
+
+  if (decoded.bytes.length === 17) {
+    return {
+      secretHex: decoded.bytes.subarray(1).toString("hex"),
       transport: "randomized-intermediate",
     };
   }
 
   return {
-    secretHex: normalized,
+    secretHex: decoded.bytes.toString("hex"),
     transport: "abridged",
   };
 }
@@ -112,7 +198,20 @@ export function buildMtprotoProxyClientOptions(
         secret: normalized.secretHex,
         mtprotoTransport: "randomized-intermediate",
       } as unknown as ProxyInterface,
-      connection: getConnectionTCPMTProxyRandomizedIntermediate(),
+      connection: getConnectionTCPMTProxyPaddedIntermediate(),
+    };
+  }
+
+  if (normalized.transport === "tls-emulation") {
+    return {
+      proxy: {
+        ip: entry.server,
+        port: entry.port,
+        secret: normalized.secretHex,
+        mtprotoTransport: "tls-emulation",
+        tlsDomainHex: normalized.tlsDomainHex,
+      } as unknown as ProxyInterface,
+      connection: getConnectionTCPMTProxyPaddedIntermediate(),
     };
   }
 
@@ -126,9 +225,180 @@ export function buildMtprotoProxyClientOptions(
   };
 }
 
-function getConnectionTCPMTProxyRandomizedIntermediate(): typeof Connection {
-  if (randomizedIntermediateConnection) {
-    return randomizedIntermediateConnection;
+interface FakeTlsClientHello {
+  data: Buffer;
+  digest: Buffer;
+}
+
+interface MtprotoSocketLike {
+  readExactly: (n: number) => Promise<Buffer>;
+  write: (data: Buffer) => void;
+}
+
+function uint16BE(value: number): Buffer {
+  const result = Buffer.alloc(2);
+  result.writeUInt16BE(value, 0);
+  return result;
+}
+
+function addGrease(parts: Buffer[], greases: Buffer, index: number): void {
+  parts.push(Buffer.from([greases[index], greases[index]]));
+}
+
+function createGreases(): Buffer {
+  const greases = randomBytes(7);
+  for (let i = 0; i < greases.length; i++) {
+    greases[i] = (greases[i] & 0xf0) + 0x0a;
+  }
+  for (let i = 1; i < greases.length; i += 2) {
+    if (greases[i] === greases[i - 1]) {
+      greases[i] ^= 0x10;
+    }
+  }
+  return greases;
+}
+
+function timestampedHmacDigest(key: Buffer, data: Buffer): Buffer {
+  const digest = createHmac("sha256", key).update(data).digest();
+  const timestamp = Buffer.alloc(4);
+  timestamp.writeInt32LE(Math.floor(Date.now() / 1000), 0);
+  for (let i = 0; i < timestamp.length; i++) {
+    digest[28 + i] ^= timestamp[i];
+  }
+  return digest;
+}
+
+function createFakeTlsClientHello(domain: Buffer, key: Buffer): FakeTlsClientHello {
+  const greases = createGreases();
+  const domainLength = domain.length;
+  const parts: Buffer[] = [
+    Buffer.from("1603010200010001fc0303", "hex"),
+    Buffer.alloc(32),
+    Buffer.from("20", "hex"),
+    randomBytes(32),
+    Buffer.from("0022", "hex"),
+  ];
+
+  addGrease(parts, greases, 0);
+  parts.push(
+    Buffer.from("130113021303c02bc02fc02cc030cca9cca8c013c014009c009d002f0035000a01000191", "hex")
+  );
+  addGrease(parts, greases, 2);
+  parts.push(Buffer.from("00000000", "hex"), uint16BE(domainLength + 5));
+  parts.push(uint16BE(domainLength + 3), Buffer.from("00", "hex"), uint16BE(domainLength), domain);
+  parts.push(Buffer.from("00170000ff01000100000a000a0008", "hex"));
+  addGrease(parts, greases, 4);
+  parts.push(
+    Buffer.from(
+      "001d00170018000b00020100002300000010000e000c02683208687474702f312e310005" +
+        "00050100000000000d001400120403080404010503080505010806060102010012000000" +
+        "33002b0029",
+      "hex"
+    )
+  );
+  addGrease(parts, greases, 4);
+  parts.push(Buffer.from("000100001d0020", "hex"), randomBytes(32));
+  parts.push(Buffer.from("002d00020101002b000b0a", "hex"));
+  addGrease(parts, greases, 6);
+  parts.push(Buffer.from("0304030303020301001b0003020002", "hex"));
+  addGrease(parts, greases, 3);
+  parts.push(Buffer.from("0001000015", "hex"));
+
+  const withoutPadding = Buffer.concat(parts);
+  const paddingLength = FAKE_TLS_CLIENT_HELLO_LENGTH - 2 - withoutPadding.length;
+  if (paddingLength < 0) {
+    throw new Error("TLS-emulation domain is too long for ClientHello");
+  }
+
+  const data = Buffer.concat([
+    withoutPadding,
+    uint16BE(paddingLength),
+    Buffer.alloc(paddingLength),
+  ]);
+  const digest = timestampedHmacDigest(key, data);
+  digest.copy(data, 11);
+  return { data, digest };
+}
+
+async function readTlsRecord(socket: MtprotoSocketLike, prefix: Buffer): Promise<Buffer> {
+  const header = await socket.readExactly(5);
+  if (!header.subarray(0, 3).equals(prefix)) {
+    throw new Error("Invalid fake TLS record received from MTProto proxy");
+  }
+  const length = header.readUInt16BE(3);
+  return Buffer.concat([header, await socket.readExactly(length)]);
+}
+
+function verifyFakeTlsServerHello(response: Buffer, clientDigest: Buffer, key: Buffer): void {
+  if (response.length < 43 || !response.subarray(0, 3).equals(TLS_HANDSHAKE_PREFIX)) {
+    throw new Error("Invalid fake TLS ServerHello received from MTProto proxy");
+  }
+
+  const serverDigest = Buffer.from(response.subarray(11, 43));
+  const hmacInput = Buffer.concat([clientDigest, Buffer.from(response)]);
+  hmacInput.fill(0, clientDigest.length + 11, clientDigest.length + 43);
+  const expectedDigest = createHmac("sha256", key).update(hmacInput).digest();
+  if (!timingSafeEqual(serverDigest, expectedDigest)) {
+    throw new Error("Invalid fake TLS ServerHello digest from MTProto proxy");
+  }
+}
+
+class FakeTlsRecordLayer {
+  private incoming = Buffer.alloc(0);
+
+  constructor(
+    private readonly socket: MtprotoSocketLike,
+    private readonly domain: Buffer,
+    private readonly key: Buffer
+  ) {}
+
+  async init(): Promise<void> {
+    const hello = createFakeTlsClientHello(this.domain, this.key);
+    this.socket.write(hello.data);
+    const serverHello = await readTlsRecord(this.socket, TLS_HANDSHAKE_PREFIX);
+    const changeCipherSpec = await this.socket.readExactly(TLS_CHANGE_CIPHER_SPEC.length);
+    if (!changeCipherSpec.equals(TLS_CHANGE_CIPHER_SPEC)) {
+      throw new Error("Invalid fake TLS ChangeCipherSpec received from MTProto proxy");
+    }
+    const applicationData = await readTlsRecord(this.socket, TLS_APPLICATION_DATA_PREFIX);
+    verifyFakeTlsServerHello(
+      Buffer.concat([serverHello, changeCipherSpec, applicationData]),
+      hello.digest,
+      this.key
+    );
+  }
+
+  wrapFirstPayload(data: Buffer): Buffer {
+    return Buffer.concat([TLS_CHANGE_CIPHER_SPEC, this.wrapApplicationData(data)]);
+  }
+
+  write(data: Buffer): void {
+    this.socket.write(this.wrapApplicationData(data));
+  }
+
+  async readExactly(n: number): Promise<Buffer> {
+    while (this.incoming.length < n) {
+      const record = await readTlsRecord(this.socket, TLS_APPLICATION_DATA_PREFIX);
+      this.incoming = Buffer.concat([this.incoming, record.subarray(5)]);
+    }
+    const result = this.incoming.subarray(0, n);
+    this.incoming = this.incoming.subarray(n);
+    return result;
+  }
+
+  private wrapApplicationData(data: Buffer): Buffer {
+    const records: Buffer[] = [];
+    for (let offset = 0; offset < data.length; offset += FAKE_TLS_MAX_CLIENT_RECORD_PAYLOAD) {
+      const chunk = data.subarray(offset, offset + FAKE_TLS_MAX_CLIENT_RECORD_PAYLOAD);
+      records.push(TLS_APPLICATION_DATA_PREFIX, uint16BE(chunk.length), chunk);
+    }
+    return Buffer.concat(records);
+  }
+}
+
+function getConnectionTCPMTProxyPaddedIntermediate(): typeof Connection {
+  if (paddedIntermediateConnection) {
+    return paddedIntermediateConnection;
   }
 
   // GramJS connection submodules have CJS initialization ordering assumptions.
@@ -174,14 +444,21 @@ function getConnectionTCPMTProxyRandomizedIntermediate(): typeof Connection {
     private encryptor?: CTR;
     private decryptor?: CTR;
 
-    constructor(connection: ConnectionTCPMTProxyRandomizedIntermediate) {
+    private readonly tls?: FakeTlsRecordLayer;
+
+    constructor(connection: ConnectionTCPMTProxyPaddedIntermediate) {
       this.connection = connection.socket;
       this.packetClass = RandomizedIntermediatePacketCodec;
       this.secret = connection.secret;
       this.dcId = connection._dcId;
+      this.tls = connection.tlsDomain
+        ? new FakeTlsRecordLayer(this.connection, connection.tlsDomain, this.secret)
+        : undefined;
     }
 
     async initHeader(): Promise<void> {
+      await this.tls?.init();
+
       let random: Buffer;
       do {
         random = generateRandomBytes(64);
@@ -201,28 +478,37 @@ function getConnectionTCPMTProxyRandomizedIntermediate(): typeof Connection {
 
       const encryptedRandom = this.encryptor.encrypt(random);
       encryptedRandom.copy(random, 56, 56, 64);
-      this.header = random;
+      this.header = this.tls ? this.tls.wrapFirstPayload(random) : random;
     }
 
     async read(n: number): Promise<Buffer> {
       if (!this.decryptor) {
         throw new Error("MTProxy decryptor is not initialized");
       }
-      return this.decryptor.encrypt(await this.connection.readExactly(n));
+      const encrypted = this.tls
+        ? await this.tls.readExactly(n)
+        : await this.connection.readExactly(n);
+      return this.decryptor.encrypt(encrypted);
     }
 
     write(data: Buffer): void {
       if (!this.encryptor) {
         throw new Error("MTProxy encryptor is not initialized");
       }
-      this.connection.write(this.encryptor.encrypt(data));
+      const encrypted = this.encryptor.encrypt(data);
+      if (this.tls) {
+        this.tls.write(encrypted);
+      } else {
+        this.connection.write(encrypted);
+      }
     }
   }
 
-  class ConnectionTCPMTProxyRandomizedIntermediate extends connectionModule.ObfuscatedConnection {
+  class ConnectionTCPMTProxyPaddedIntermediate extends connectionModule.ObfuscatedConnection {
     ObfuscatedIO = MtprotoProxyObfuscatedIO;
     PacketCodecClass = gramjsPacketCodecClass;
     secret: Buffer;
+    tlsDomain?: Buffer;
 
     constructor({ dcId, loggers, proxy, socket, testServers }: GramjsConnectionParams) {
       const mtprotoProxy = requireCustomMtprotoProxy(proxy);
@@ -241,12 +527,14 @@ function getConnectionTCPMTProxyRandomizedIntermediate(): typeof Connection {
         testServers,
       });
       this.secret = Buffer.from(mtprotoProxy.secret, "hex");
+      this.tlsDomain = mtprotoProxy.tlsDomainHex
+        ? Buffer.from(mtprotoProxy.tlsDomainHex, "hex")
+        : undefined;
     }
   }
 
-  const connectionClass =
-    ConnectionTCPMTProxyRandomizedIntermediate as unknown as typeof Connection;
-  randomizedIntermediateConnection = connectionClass;
+  const connectionClass = ConnectionTCPMTProxyPaddedIntermediate as unknown as typeof Connection;
+  paddedIntermediateConnection = connectionClass;
   return connectionClass;
 }
 

--- a/src/webui/__tests__/mtproto-routes.test.ts
+++ b/src/webui/__tests__/mtproto-routes.test.ts
@@ -170,11 +170,27 @@ describe("MTProto routes", () => {
     );
   });
 
-  it("rejects unsupported TLS-emulation MTProto proxy secrets", async () => {
-    const app = buildApp({
+  it("accepts TLS-emulation MTProto proxy secrets", async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      "agent:\n" +
+        "  provider: openai\n" +
+        "  model: gpt-4o-mini\n" +
+        "  api_key: sk-testkey123456\n" +
+        "telegram:\n" +
+        "  api_id: 12345\n" +
+        "  api_hash: hash\n" +
+        "  phone: '+1234567890'\n" +
+        "mtproto:\n" +
+        "  enabled: true\n" +
+        "  proxies: []\n"
+    );
+    const tlsSecret = `ee${"a".repeat(32)}${Buffer.from("example.com", "utf-8").toString("hex")}`;
+    const config = {
       telegram: { api_id: 12345, api_hash: "hash" },
       mtproto: { enabled: true, proxies: [] },
-    });
+    };
+    const app = buildApp(config);
 
     const res = await app.request("/mtproto/proxies", {
       method: "PUT",
@@ -184,15 +200,17 @@ describe("MTProto routes", () => {
           {
             server: "proxy.example.com",
             port: 443,
-            secret: `ee${"a".repeat(32)}6578616d706c652e636f6d`,
+            secret: tlsSecret,
           },
         ],
       }),
     });
     const json = await res.json();
 
-    expect(res.status).toBe(400);
-    expect(json.success).toBe(false);
-    expect(json.error).toContain("TLS-emulation");
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.proxies).toEqual([
+      { server: "proxy.example.com", port: 443, secret: tlsSecret },
+    ]);
   });
 });

--- a/web/src/components/MtprotoSettingsPanel.tsx
+++ b/web/src/components/MtprotoSettingsPanel.tsx
@@ -395,14 +395,16 @@ export function MtprotoSettingsPanel({ showSuccess, setError }: MtprotoSettingsP
                         <label style={{ fontSize: 12 }}>
                           <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                             🔑 Secret
-                            <InfoTip text="MTProto proxy secret (32+ hex characters, optionally prefixed with 'dd' for TLS obfuscation). Get it from your proxy provider or @MTProxybot." />
+                            <InfoTip
+                              text="MTProto proxy secret (hex or base64url; dd for padded transport, ee+domain for fake TLS). Get it from your proxy provider or @MTProxybot."
+                            />
                           </span>
                         </label>
                         <input
                           type="text"
                           value={proxy.secret}
                           onChange={(e) => updateProxy(idx, 'secret', e.target.value)}
-                          placeholder="e.g. dd1234abcd...  (hex string)"
+                          placeholder="e.g. dd1234abcd... or ee...domain"
                           style={{ width: '100%', fontFamily: 'monospace', fontSize: 12 }}
                         />
                       </div>


### PR DESCRIPTION
Fixes xlabtg/teleton-agent#431

## Root Cause
- The MTProxy support added in #430 intentionally rejected `ee...domain` TLS-emulation secrets. The WebUI status/config path calls the shared MTProxy option builder, so loading a config with public fake-TLS proxy secrets threw `Invalid MTProto proxy secret` before the UI could report proxy status.
- Telegram clients also accept MTProxy secrets as either hex or Telegram base64url deep-link payloads, while the existing normalizer only accepted hex.

## Changes
- Added Telegram-compatible MTProxy secret decoding for hex and base64url values.
- Added support for `ee + 16-byte secret + domain` fake TLS secrets by wrapping the existing padded-intermediate MTProxy transport in a fake TLS record layer and validating the fake TLS ServerHello HMAC.
- Kept 16-byte secrets on the GramJS MTProxy path and 17-byte prefixed secrets on padded intermediate transport.
- Updated WebUI route coverage, MTProxy option tests, config schema text, example config, and the WebUI proxy secret tooltip/placeholder.

## Reproduction Covered
- `ee` TLS-emulation hex secrets are accepted and mapped to fake TLS transport instead of throwing.
- Telegram base64url-encoded fake TLS secrets are accepted.
- The WebUI `/api/mtproto/proxies` update route accepts an `ee...domain` proxy secret.

## Verification
- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test -- src/telegram/__tests__/mtproto-proxy.test.ts src/webui/__tests__/mtproto-routes.test.ts`
- `npm test` (199 files, 3452 tests)
- `npm run build:backend`
- `cd web && npm run build`

References:
- https://core.telegram.org/mtproto/mtproto-transports
- https://core.telegram.org/proxy