### PR TITLE
Fix bot startup hang when GramJS MTProxy stalls

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
+# Updated: 2026-04-26T16:49:20.994Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
-# Updated: 2026-04-26T16:49:20.994Z

--- a/src/bot/__tests__/deal-bot-start.test.ts
+++ b/src/bot/__tests__/deal-bot-start.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type Database from "better-sqlite3";
+
+const {
+  mockBotInit,
+  mockBotStart,
+  mockBotStop,
+  mockBotOn,
+  mockBotUse,
+  mockBotCatch,
+  mockGramjsConnect,
+  mockGramjsDisconnect,
+  mockGramjsIsConnected,
+} = vi.hoisted(() => ({
+  mockBotInit: vi.fn(),
+  mockBotStart: vi.fn(),
+  mockBotStop: vi.fn(),
+  mockBotOn: vi.fn(),
+  mockBotUse: vi.fn(),
+  mockBotCatch: vi.fn(),
+  mockGramjsConnect: vi.fn(),
+  mockGramjsDisconnect: vi.fn(),
+  mockGramjsIsConnected: vi.fn(),
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+vi.mock("grammy", () => {
+  class Bot {
+    api = {
+      editMessageTextInline: vi.fn(),
+    };
+    botInfo = { id: 123456, username: "tony_idbot", first_name: "Tony" };
+    on = mockBotOn;
+    use = mockBotUse;
+    catch = mockBotCatch;
+    init = mockBotInit;
+    start = mockBotStart;
+    stop = mockBotStop;
+  }
+
+  class InlineKeyboard {
+    row = vi.fn(() => this);
+    text = vi.fn(() => this);
+    copyText = vi.fn(() => this);
+  }
+
+  return { Bot, InlineKeyboard };
+});
+
+vi.mock("../gramjs-bot.js", () => ({
+  GramJSBotClient: class {
+    connect = mockGramjsConnect;
+    disconnect = mockGramjsDisconnect;
+    isConnected = mockGramjsIsConnected;
+    answerInlineQuery = vi.fn();
+    editInlineMessageByStringId = vi.fn();
+  },
+}));
+
+import { DealBot } from "../index.js";
+
+function nextMacrotask(): Promise<"blocked"> {
+  return new Promise((resolve) => setTimeout(() => resolve("blocked"), 0));
+}
+
+describe("DealBot startup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBotInit.mockResolvedValue(undefined);
+    mockBotStart.mockResolvedValue(undefined);
+    mockBotStop.mockResolvedValue(undefined);
+    mockGramjsConnect.mockResolvedValue(undefined);
+    mockGramjsDisconnect.mockResolvedValue(undefined);
+    mockGramjsIsConnected.mockReturnValue(false);
+  });
+
+  it("does not block Bot API startup while the optional GramJS MTProto bot connection hangs", async () => {
+    mockGramjsConnect.mockImplementationOnce(
+      () =>
+        new Promise(() => {
+          // Simulate a proxy path that never finishes connecting.
+        })
+    );
+
+    const bot = new DealBot(
+      {
+        token: "123456:ABC-DEF",
+        username: "tony_idbot",
+        apiId: 12345,
+        apiHash: "hash",
+        gramjsSessionPath: "/tmp/gramjs-bot-session",
+        mtprotoProxies: [{ server: "proxy.example.com", port: 443, secret: "a".repeat(32) }],
+      },
+      {} as Database.Database
+    );
+
+    const result = await Promise.race([
+      bot.start().then(() => "resolved" as const),
+      nextMacrotask(),
+    ]);
+
+    expect(result).toBe("resolved");
+    expect(mockGramjsConnect).toHaveBeenCalledWith("123456:ABC-DEF");
+    expect(mockBotInit).toHaveBeenCalledTimes(1);
+    expect(mockBotStart).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -496,18 +496,11 @@ export class DealBot {
   async start(): Promise<void> {
     log.info(`🤖 [Bot] Starting @${this.config.username}...`);
 
-    // Connect GramJS bot for styled buttons (best-effort)
-    if (this.gramjsBot) {
-      try {
-        await this.gramjsBot.connect(this.config.token);
-      } catch {
-        log.warn("⚠️ [Bot] GramJS MTProto connection failed, buttons will be unstyled");
-        this.gramjsBot = null;
-      }
-    }
-
     // bot.init() fetches bot info without starting long polling
     await this.bot.init();
+
+    this.connectGramjsBotInBackground();
+
     // bot.start() launches long polling - do NOT await (it blocks forever)
     this.bot
       .start({
@@ -516,6 +509,22 @@ export class DealBot {
       .catch((err) => {
         log.error({ err }, "[Bot] Polling error");
       });
+  }
+
+  private connectGramjsBotInBackground(): void {
+    const gramjsBot = this.gramjsBot;
+    if (!gramjsBot) return;
+
+    // GramJS is optional and only enables styled inline buttons. MTProxy negotiation
+    // must not hold the main bot or agent lifecycle in the "starting" state.
+    void gramjsBot.connect(this.config.token).catch((error) => {
+      if (this.gramjsBot !== gramjsBot) return;
+      log.warn(
+        { err: error },
+        "⚠️ [Bot] GramJS MTProto connection failed, buttons will be unstyled"
+      );
+      this.gramjsBot = null;
+    });
   }
 
   /**


### PR DESCRIPTION
Fixes xlabtg/teleton-agent#433

## Root Cause
- During agent startup, the deals bot awaited `GramJSBotClient.connect()` before initializing and starting the required Grammy Bot API polling path.
- The GramJS bot connection is only needed for styled inline buttons, but with MTProxy enabled it can hang or spend a long time in proxy negotiation. That kept the lifecycle in `starting` after the log line `[GramJS Bot] [MTProxy] Trying proxy ...`, so the agent never reached the normal startup summary.

## Changes
- Start the required Bot API path first and launch the optional GramJS MTProto connection in the background.
- If the GramJS connection fails later, log the failure and disable styled buttons while keeping regular bot functionality and agent startup alive.
- Removed the PR scaffold-only `.gitkeep` metadata diff from the final branch.

## Reproduction Covered
- Added `src/bot/__tests__/deal-bot-start.test.ts`, which simulates a GramJS MTProxy connection that never resolves and verifies `DealBot.start()` still resolves and starts Bot API polling.

## Verification
- `npm test -- src/bot/__tests__/deal-bot-start.test.ts`
- `npm test -- src/bot/__tests__/deal-bot-start.test.ts src/bot/__tests__/gramjs-bot-proxy.test.ts src/telegram/__tests__/client-proxy.test.ts src/telegram/__tests__/mtproto-proxy.test.ts`
- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test` (200 files, 3453 tests)
- `npm run test:coverage` (200 files, 3453 tests)
- `npm run build:backend`
- `npm run audit:ci`
- `cd web && npm ci`
- `npm run build:web`
- `node dist/cli/index.js --help`
