### PR TITLE
Fix MTProxy reconnect metadata for prefixed secrets

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
+# Updated: 2026-04-26T18:37:14.999Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
-# Updated: 2026-04-26T18:37:14.999Z

--- a/src/telegram/__tests__/mtproto-proxy.test.ts
+++ b/src/telegram/__tests__/mtproto-proxy.test.ts
@@ -38,6 +38,81 @@ describe("MTProto proxy client options", () => {
     expect(options.connection).toBeTypeOf("function");
   });
 
+  it.each([
+    {
+      name: "randomized intermediate",
+      secret: `dd${"b".repeat(32)}`,
+      expectedProxy: {
+        mtprotoTransport: "randomized-intermediate",
+        secret: "b".repeat(32),
+      },
+    },
+    {
+      name: "fake TLS",
+      secret: `ee${"c".repeat(32)}${Buffer.from("example.com", "utf-8").toString("hex")}`,
+      expectedProxy: {
+        mtprotoTransport: "tls-emulation",
+        secret: "c".repeat(32),
+        tlsDomainHex: Buffer.from("example.com", "utf-8").toString("hex"),
+      },
+    },
+  ])("preserves $name proxy metadata for GramJS reconnects", ({ secret, expectedProxy }) => {
+    const options = buildMtprotoProxyClientOptions({
+      server: "proxy.example.com",
+      port: 443,
+      secret,
+    });
+
+    class MockSocket {
+      constructor(_proxy?: unknown) {}
+    }
+
+    type ConnectionParams = {
+      ip: string;
+      port: number;
+      dcId: number;
+      loggers: unknown;
+      proxy: unknown;
+      socket: new (proxy?: unknown) => unknown;
+      testServers: boolean;
+    };
+    type ReconnectableConnection = {
+      _ip: string;
+      _port: number;
+      _dcId: number;
+      _log: unknown;
+      _proxy: unknown;
+      _testServers: boolean;
+      constructor: new (params: ConnectionParams) => ReconnectableConnection;
+    };
+
+    const ConnectionClass = options.connection as unknown as new (
+      params: ConnectionParams
+    ) => ReconnectableConnection;
+    const connection = new ConnectionClass({
+      ip: "149.154.167.50",
+      port: 80,
+      dcId: 2,
+      loggers: {},
+      proxy: options.proxy,
+      socket: MockSocket,
+      testServers: false,
+    });
+
+    expect(connection._proxy).toMatchObject(expectedProxy);
+    expect(() => {
+      new connection.constructor({
+        ip: connection._ip,
+        port: connection._port,
+        dcId: connection._dcId,
+        loggers: connection._log,
+        proxy: connection._proxy,
+        socket: MockSocket,
+        testServers: connection._testServers,
+      });
+    }).not.toThrow();
+  });
+
   it("uses fake TLS transport for an ee-prefixed TLS-emulation hex secret", () => {
     const tlsDomainHex = Buffer.from("example.com", "utf-8").toString("hex");
     const secret = `ee${"c".repeat(32)}${tlsDomainHex}`;

--- a/src/telegram/mtproto-proxy.ts
+++ b/src/telegram/mtproto-proxy.ts
@@ -512,17 +512,16 @@ function getConnectionTCPMTProxyPaddedIntermediate(): typeof Connection {
 
     constructor({ dcId, loggers, proxy, socket, testServers }: GramjsConnectionParams) {
       const mtprotoProxy = requireCustomMtprotoProxy(proxy);
+      const reconnectProxy = {
+        ...mtprotoProxy,
+        MTProxy: true,
+      } as ProxyInterface & CustomMtprotoProxy;
       super({
         ip: mtprotoProxy.ip,
         port: mtprotoProxy.port,
         dcId,
         loggers,
-        proxy: {
-          ip: mtprotoProxy.ip,
-          port: mtprotoProxy.port,
-          secret: mtprotoProxy.secret,
-          MTProxy: true,
-        } as ProxyInterface,
+        proxy: reconnectProxy,
         socket,
         testServers,
       });


### PR DESCRIPTION
Fixes xlabtg/teleton-agent#435

## Root Cause
- Prefixed MTProxy secrets (`dd` randomized-intermediate and `ee` TLS-emulation) use a custom GramJS connection class so they do not go through GramJS' built-in abridged MTProxy transport.
- The first connection received the custom proxy metadata, but the connection stored a sanitized `_proxy` object containing only `MTProxy: true` plus ip/port/secret.
- GramJS reconnects by constructing `new connection.constructor({ proxy: connection._proxy, ... })`, so reconnects lost `mtprotoTransport`/`tlsDomainHex` and threw `No MTProto proxy info specified for prefixed-secret transport`.

## Changes
- Preserve the custom MTProxy metadata on the connection's stored proxy object while still adding `MTProxy: true` for GramJS socket/base connection behavior.
- Added a regression test that simulates GramJS reconnect construction for both randomized-intermediate and TLS-emulation prefixed secrets.

## Verification
- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test -- src/telegram/__tests__/mtproto-proxy.test.ts src/telegram/__tests__/client-proxy.test.ts src/telegram/__tests__/mtproto-proxy-health.test.ts src/bot/__tests__/gramjs-bot-proxy.test.ts src/webui/__tests__/setup-auth-proxy.test.ts`
- `npm test` (200 files, 3455 tests)
- `npm run build:backend`
