### PR TITLE
fix(bot): avoid blocking startup on Bot API getMe

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
-# Updated: 2026-04-26T19:41:34.080Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
+# Updated: 2026-04-26T19:41:34.080Z

--- a/src/bot/__tests__/deal-bot-start.test.ts
+++ b/src/bot/__tests__/deal-bot-start.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type Database from "better-sqlite3";
 
 const {
-  mockBotInit,
   mockBotStart,
   mockBotStop,
   mockBotOn,
@@ -12,7 +11,6 @@ const {
   mockGramjsDisconnect,
   mockGramjsIsConnected,
 } = vi.hoisted(() => ({
-  mockBotInit: vi.fn(),
   mockBotStart: vi.fn(),
   mockBotStop: vi.fn(),
   mockBotOn: vi.fn(),
@@ -41,7 +39,6 @@ vi.mock("grammy", () => {
     on = mockBotOn;
     use = mockBotUse;
     catch = mockBotCatch;
-    init = mockBotInit;
     start = mockBotStart;
     stop = mockBotStop;
   }
@@ -74,7 +71,6 @@ function nextMacrotask(): Promise<"blocked"> {
 describe("DealBot startup", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockBotInit.mockResolvedValue(undefined);
     mockBotStart.mockResolvedValue(undefined);
     mockBotStop.mockResolvedValue(undefined);
     mockGramjsConnect.mockResolvedValue(undefined);
@@ -109,7 +105,39 @@ describe("DealBot startup", () => {
 
     expect(result).toBe("resolved");
     expect(mockGramjsConnect).toHaveBeenCalledWith("123456:ABC-DEF");
-    expect(mockBotInit).toHaveBeenCalledTimes(1);
+    expect(mockBotStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not block startup when the Bot API path hangs (api.telegram.org blocked)", async () => {
+    // Simulate Grammy bot.start() hanging — Grammy retries getMe / deleteWebhook forever
+    // on HttpError when api.telegram.org is unreachable (e.g. regions with Telegram blocked).
+    // dealBot.start() must still resolve so the agent leaves the "starting" state.
+    mockBotStart.mockImplementationOnce(
+      () =>
+        new Promise(() => {
+          // Never resolves
+        })
+    );
+
+    const bot = new DealBot(
+      {
+        token: "123456:ABC-DEF",
+        username: "tony_idbot",
+        apiId: 12345,
+        apiHash: "hash",
+        gramjsSessionPath: "/tmp/gramjs-bot-session",
+        mtprotoProxies: [{ server: "proxy.example.com", port: 443, secret: "a".repeat(32) }],
+      },
+      {} as Database.Database
+    );
+
+    const result = await Promise.race([
+      bot.start().then(() => "resolved" as const),
+      nextMacrotask(),
+    ]);
+
+    expect(result).toBe("resolved");
+    // bot.start() must still be invoked so polling can self-heal once Bot API is reachable.
     expect(mockBotStart).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -496,12 +496,12 @@ export class DealBot {
   async start(): Promise<void> {
     log.info(`🤖 [Bot] Starting @${this.config.username}...`);
 
-    // bot.init() fetches bot info without starting long polling
-    await this.bot.init();
-
+    // bot.start() will run bot.init() itself if needed; launching polling in the
+    // background prevents a blocked Bot API path (api.telegram.org unreachable)
+    // from holding the agent in the "starting" state. Grammy's polling loop and
+    // GramJS MTProto path both retry transparently once Bot API becomes reachable.
     this.connectGramjsBotInBackground();
 
-    // bot.start() launches long polling - do NOT await (it blocks forever)
     this.bot
       .start({
         onStart: () => log.info(`🤖 [Bot] @${this.config.username} polling started`),


### PR DESCRIPTION
Fixes xlabtg/teleton-agent#437

## Root Cause
- `DealBot.start()` awaited Grammy's `bot.init()`, which calls `getMe` over HTTPS to `api.telegram.org`.
- Grammy's `withRetries` keeps retrying `HttpError` indefinitely with up to a 20-minute backoff, so the await never returned when the Bot API path was unreachable.
- `dealsModule.start()` awaits `dealBot.start()`, which is in turn awaited inside the agent's startup module loop. With Bot API blocked, the lifecycle stayed in `starting` even after the MTProxy work in #434/#436 fixed the GramJS-side hangs.

## Changes
- Drop the explicit `await this.bot.init()` in [`src/bot/index.ts`](src/bot/index.ts:496); `bot.start()` runs `init()` itself, and we already launch `bot.start()` fire-and-forget so a hung Bot API path no longer blocks `DealBot.start()`.
- Update inline comments to document why the Bot API path now runs in the background alongside the GramJS MTProto path.

## Reproduction Covered
- Added a regression test in [`src/bot/__tests__/deal-bot-start.test.ts`](src/bot/__tests__/deal-bot-start.test.ts:111) that simulates `bot.start()` hanging (Grammy's behavior when `api.telegram.org` is unreachable) and asserts `DealBot.start()` still resolves on the next macrotask.

## Verification
- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test -- src/bot/__tests__/deal-bot-start.test.ts`
- `npm test -- src/bot/__tests__ src/telegram/__tests__`
- `npm test` (200 files, 3456 tests)
- `npm run build:backend`