### PR TITLE
Fix self-improvement history display

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
+# Updated: 2026-04-27T21:56:18.964Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
-# Updated: 2026-04-27T21:56:18.964Z

--- a/src/webui/__tests__/self-improvement-routes.test.ts
+++ b/src/webui/__tests__/self-improvement-routes.test.ts
@@ -40,6 +40,24 @@ function buildApp(db: Database.Database) {
   return app;
 }
 
+function buildTriggerApp(db: Database.Database, processMessage = vi.fn()) {
+  const deps = {
+    memory: { db },
+    agent: {
+      getConfig: () => ({ telegram: { admin_ids: [12345] } }),
+      processMessage,
+    },
+    bridge: {
+      isAvailable: () => false,
+      sendMessage: vi.fn(),
+    },
+  } as unknown as WebUIServerDeps;
+
+  const app = new Hono();
+  app.route("/self-improvement", createSelfImprovementRoutes(deps));
+  return app;
+}
+
 // ── Tests ────────────────────────────────────────────────────────────
 
 describe("GET /self-improvement/config", () => {
@@ -225,5 +243,57 @@ describe("GET /self-improvement/status (no plugin DB)", () => {
     const json = await res.json();
     expect(json.success).toBe(true);
     expect(json.data.installed).toBe(false);
+  });
+});
+
+describe("POST /self-improvement/trigger native history", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  it("records completed Web UI-triggered analysis in the main DB when no plugin DB exists", async () => {
+    const processMessage = vi.fn().mockResolvedValue({
+      content: "Analyzed 12 files. Found 3 findings. Created 1 issue.",
+      toolCalls: [{ name: "github_create_issue", input: { title: "Fix issue" } }],
+    });
+    const app = buildTriggerApp(db, processMessage);
+
+    await app.request("/self-improvement/config", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        selected_plugin: "github-dev-assistant",
+        target_repo: "xlabtg/teleton-agent",
+      }),
+    });
+
+    const triggerRes = await app.request("/self-improvement/trigger", { method: "POST" });
+    expect(triggerRes.status).toBe(200);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const analysisRes = await app.request("/self-improvement/analysis");
+    expect(analysisRes.status).toBe(200);
+    const analysisJson = await analysisRes.json();
+    expect(analysisJson.success).toBe(true);
+    expect(analysisJson.data).toHaveLength(1);
+    expect(analysisJson.data[0].repo).toBe("xlabtg/teleton-agent");
+    expect(analysisJson.data[0].files_analyzed).toBe(12);
+    expect(analysisJson.data[0].issues_found).toBe(3);
+    expect(analysisJson.data[0].issues_created).toBe(1);
+    expect(analysisJson.data[0].status).toBe("completed");
+    expect(analysisJson.data[0].source).toBe("native");
+
+    const statusRes = await app.request("/self-improvement/status");
+    expect(statusRes.status).toBe(200);
+    const statusJson = await statusRes.json();
+    expect(statusJson.data.installed).toBe(true);
+    expect(statusJson.data.plugin_installed).toBe(false);
+    expect(statusJson.data.source).toBe("native");
+    expect(statusJson.data.analysis_count).toBe(1);
+    expect(statusJson.data.pending_tasks).toBe(0);
   });
 });

--- a/src/webui/routes/self-improvement.ts
+++ b/src/webui/routes/self-improvement.ts
@@ -8,6 +8,10 @@ import { TELETON_ROOT } from "../../workspace/paths.js";
 
 const PLUGIN_DATA_DIR = join(TELETON_ROOT, "plugins", "data");
 const PLUGIN_DB_PATH = join(PLUGIN_DATA_DIR, "self-improve-orchestrator.db");
+const NATIVE_ANALYSIS_TABLE = "self_improvement_analysis_log";
+const NATIVE_TASKS_TABLE = "self_improvement_tasks";
+const DEFAULT_ANALYSIS_BRANCH = "main";
+const MAX_SUMMARY_LENGTH = 10_000;
 
 /** Key used to persist the meta-orchestrator config in the agent's main DB. */
 const CONFIG_KEY = "self_improvement_orchestrator_config";
@@ -89,6 +93,10 @@ export interface AnalysisLogEntry {
   issues_found: number;
   issues_created: number;
   summary: string | null;
+  source?: "plugin" | "native";
+  status?: "running" | "completed" | "failed";
+  error?: string | null;
+  completed_at?: number | null;
 }
 
 export interface ImprovementTask {
@@ -103,12 +111,322 @@ export interface ImprovementTask {
   status: string;
   created_at: number;
   github_issue_url: string | null;
+  source?: "plugin" | "native";
 }
 
 /** Open (read-only) the plugin SQLite DB if it exists. Returns null otherwise. */
 function openPluginDb(): Database.Database | null {
   if (!existsSync(PLUGIN_DB_PATH)) return null;
   return new Database(PLUGIN_DB_PATH, { readonly: true });
+}
+
+function ensureNativeTables(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS ${NATIVE_ANALYSIS_TABLE} (
+      id              INTEGER PRIMARY KEY AUTOINCREMENT,
+      timestamp       INTEGER NOT NULL,
+      repo            TEXT    NOT NULL,
+      branch          TEXT    NOT NULL DEFAULT '${DEFAULT_ANALYSIS_BRANCH}',
+      executor_plugin TEXT    NOT NULL,
+      files_analyzed  INTEGER NOT NULL DEFAULT 0,
+      issues_found    INTEGER NOT NULL DEFAULT 0,
+      issues_created  INTEGER NOT NULL DEFAULT 0,
+      summary         TEXT,
+      status          TEXT    NOT NULL DEFAULT 'running'
+        CHECK(status IN ('running', 'completed', 'failed')),
+      error           TEXT,
+      completed_at    INTEGER
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_self_improvement_analysis_timestamp
+      ON ${NATIVE_ANALYSIS_TABLE}(timestamp DESC);
+    CREATE INDEX IF NOT EXISTS idx_self_improvement_analysis_status
+      ON ${NATIVE_ANALYSIS_TABLE}(status);
+
+    CREATE TABLE IF NOT EXISTS ${NATIVE_TASKS_TABLE} (
+      id               INTEGER PRIMARY KEY AUTOINCREMENT,
+      analysis_id      INTEGER REFERENCES ${NATIVE_ANALYSIS_TABLE}(id) ON DELETE CASCADE,
+      task_type        TEXT    NOT NULL DEFAULT 'code_improvement',
+      priority         TEXT    NOT NULL DEFAULT 'medium',
+      file_path        TEXT,
+      description      TEXT    NOT NULL,
+      suggestion       TEXT,
+      code_snippet     TEXT,
+      status           TEXT    NOT NULL DEFAULT 'pending',
+      created_at       INTEGER NOT NULL,
+      github_issue_url TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_self_improvement_tasks_analysis
+      ON ${NATIVE_TASKS_TABLE}(analysis_id);
+    CREATE INDEX IF NOT EXISTS idx_self_improvement_tasks_status
+      ON ${NATIVE_TASKS_TABLE}(status, created_at DESC);
+  `);
+}
+
+function tableExists(db: Database.Database, tableName: string): boolean {
+  return Boolean(
+    db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`).get(tableName)
+  );
+}
+
+function parseLimit(value: string | undefined, fallback: number, max: number): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.min(parsed, max);
+}
+
+function truncateSummary(value: string): string {
+  return value.length > MAX_SUMMARY_LENGTH ? `${value.slice(0, MAX_SUMMARY_LENGTH)}...` : value;
+}
+
+function firstNumber(text: string, patterns: RegExp[]): number {
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (!match?.[1]) continue;
+    const parsed = Number.parseInt(match[1], 10);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return 0;
+}
+
+function summarizeAgentResponse(response: {
+  content?: string;
+  toolCalls?: Array<{ name: string; input: Record<string, unknown> }>;
+}): {
+  summary: string;
+  filesAnalyzed: number;
+  issuesFound: number;
+  issuesCreated: number;
+} {
+  const content = (response.content ?? "").trim();
+  const issueCreationToolCalls =
+    response.toolCalls?.filter((toolCall) =>
+      /github_create_(issue|pr)|create_issue_from_finding/i.test(toolCall.name)
+    ).length ?? 0;
+
+  return {
+    summary: truncateSummary(content || "Analysis completed."),
+    filesAnalyzed: firstNumber(content, [
+      /(\d+)\s+(?:source\s+)?files?\s+(?:selected|analyzed|reviewed)/i,
+      /analyz(?:ed|ing)\s+(\d+)\s+(?:source\s+)?files?/i,
+    ]),
+    issuesFound: firstNumber(content, [
+      /found\s+(\d+)\s+(?:issues?|findings?|problems?|opportunities)/i,
+      /(\d+)\s+(?:issues?|findings?|problems?|opportunities)\s+(?:found|identified|detected)/i,
+    ]),
+    issuesCreated: Math.max(
+      firstNumber(content, [
+        /created\s+(\d+)\s+(?:issues?|pull requests?|prs?)/i,
+        /(\d+)\s+(?:issues?|pull requests?|prs?)\s+created/i,
+      ]),
+      issueCreationToolCalls
+    ),
+  };
+}
+
+function createNativeAnalysisRun(db: Database.Database, config: MetaOrchestratorConfig): number {
+  ensureNativeTables(db);
+  const now = Date.now();
+  const repo = config.target_repo || "teleton-agent";
+  const result = db
+    .prepare(
+      `INSERT INTO ${NATIVE_ANALYSIS_TABLE}
+         (timestamp, repo, branch, executor_plugin, files_analyzed, issues_found, issues_created, summary, status)
+       VALUES (?, ?, ?, ?, 0, 0, 0, ?, 'running')`
+    )
+    .run(
+      now,
+      repo,
+      DEFAULT_ANALYSIS_BRANCH,
+      config.selected_plugin,
+      `Analysis dispatched via ${config.selected_plugin}.`
+    );
+  return Number(result.lastInsertRowid);
+}
+
+function completeNativeAnalysisRun(
+  db: Database.Database,
+  runId: number,
+  response: {
+    content?: string;
+    toolCalls?: Array<{ name: string; input: Record<string, unknown> }>;
+  }
+): void {
+  ensureNativeTables(db);
+  const summary = summarizeAgentResponse(response);
+  db.prepare(
+    `UPDATE ${NATIVE_ANALYSIS_TABLE}
+     SET files_analyzed = ?,
+         issues_found = ?,
+         issues_created = ?,
+         summary = ?,
+         status = 'completed',
+         error = NULL,
+         completed_at = ?
+     WHERE id = ?`
+  ).run(
+    summary.filesAnalyzed,
+    summary.issuesFound,
+    summary.issuesCreated,
+    summary.summary,
+    Date.now(),
+    runId
+  );
+}
+
+function failNativeAnalysisRun(db: Database.Database, runId: number, error: unknown): void {
+  ensureNativeTables(db);
+  const message = getErrorMessage(error);
+  db.prepare(
+    `UPDATE ${NATIVE_ANALYSIS_TABLE}
+     SET summary = ?,
+         status = 'failed',
+         error = ?,
+         completed_at = ?
+     WHERE id = ?`
+  ).run(truncateSummary(`Analysis failed: ${message}`), message, Date.now(), runId);
+}
+
+function readNativeStatus(db?: Database.Database): {
+  analysis_count: number;
+  pending_tasks: number;
+  last_analysis: number | null;
+} {
+  if (!db) return { analysis_count: 0, pending_tasks: 0, last_analysis: null };
+  ensureNativeTables(db);
+
+  const analysisCount = (
+    db.prepare(`SELECT COUNT(*) as cnt FROM ${NATIVE_ANALYSIS_TABLE}`).get() as { cnt: number }
+  ).cnt;
+  const pendingCount = (
+    db
+      .prepare(`SELECT COUNT(*) as cnt FROM ${NATIVE_TASKS_TABLE} WHERE status = 'pending'`)
+      .get() as { cnt: number }
+  ).cnt;
+  const lastAnalysis =
+    (
+      db
+        .prepare(`SELECT timestamp FROM ${NATIVE_ANALYSIS_TABLE} ORDER BY timestamp DESC LIMIT 1`)
+        .get() as { timestamp: number } | undefined
+    )?.timestamp ?? null;
+
+  return {
+    analysis_count: analysisCount,
+    pending_tasks: pendingCount,
+    last_analysis: lastAnalysis,
+  };
+}
+
+function readNativeAnalysis(db: Database.Database | undefined, limit: number): AnalysisLogEntry[] {
+  if (!db) return [];
+  ensureNativeTables(db);
+  const rows = db
+    .prepare(`SELECT * FROM ${NATIVE_ANALYSIS_TABLE} ORDER BY timestamp DESC LIMIT ?`)
+    .all(limit) as AnalysisLogEntry[];
+  return rows.map((row) => ({ ...row, source: "native" }));
+}
+
+function readNativeTasks(
+  db: Database.Database | undefined,
+  status: string,
+  limit: number
+): ImprovementTask[] {
+  if (!db) return [];
+  ensureNativeTables(db);
+  const rows =
+    status === "all"
+      ? (db
+          .prepare(`SELECT * FROM ${NATIVE_TASKS_TABLE} ORDER BY created_at DESC LIMIT ?`)
+          .all(limit) as ImprovementTask[])
+      : (db
+          .prepare(
+            `SELECT * FROM ${NATIVE_TASKS_TABLE} WHERE status = ? ORDER BY created_at DESC LIMIT ?`
+          )
+          .all(status, limit) as ImprovementTask[]);
+  return rows.map((row) => ({ ...row, source: "native" }));
+}
+
+function readPluginStatus(): {
+  installed: boolean;
+  analysis_count: number;
+  pending_tasks: number;
+  last_analysis: number | null;
+} {
+  const installed = existsSync(PLUGIN_DB_PATH);
+  if (!installed) {
+    return { installed: false, analysis_count: 0, pending_tasks: 0, last_analysis: null };
+  }
+
+  let db: Database.Database | null = null;
+  try {
+    db = openPluginDb();
+    if (!db) return { installed: false, analysis_count: 0, pending_tasks: 0, last_analysis: null };
+
+    const analysisCount = tableExists(db, "analysis_log")
+      ? (db.prepare(`SELECT COUNT(*) as cnt FROM analysis_log`).get() as { cnt: number }).cnt
+      : 0;
+
+    const pendingCount = tableExists(db, "improvement_tasks")
+      ? (
+          db
+            .prepare(`SELECT COUNT(*) as cnt FROM improvement_tasks WHERE status = 'pending'`)
+            .get() as { cnt: number }
+        ).cnt
+      : 0;
+
+    const lastAnalysis = tableExists(db, "analysis_log")
+      ? ((
+          db.prepare(`SELECT timestamp FROM analysis_log ORDER BY timestamp DESC LIMIT 1`).get() as
+            | { timestamp: number }
+            | undefined
+        )?.timestamp ?? null)
+      : null;
+
+    return {
+      installed: true,
+      analysis_count: analysisCount,
+      pending_tasks: pendingCount,
+      last_analysis: lastAnalysis,
+    };
+  } finally {
+    db?.close();
+  }
+}
+
+function readPluginAnalysis(limit: number): AnalysisLogEntry[] {
+  let db: Database.Database | null = null;
+  try {
+    db = openPluginDb();
+    if (!db || !tableExists(db, "analysis_log")) return [];
+    const rows = db
+      .prepare(`SELECT * FROM analysis_log ORDER BY timestamp DESC LIMIT ?`)
+      .all(limit) as AnalysisLogEntry[];
+    return rows.map((row) => ({ ...row, source: "plugin" }));
+  } finally {
+    db?.close();
+  }
+}
+
+function readPluginTasks(status: string, limit: number): ImprovementTask[] {
+  let db: Database.Database | null = null;
+  try {
+    db = openPluginDb();
+    if (!db || !tableExists(db, "improvement_tasks")) return [];
+    const rows =
+      status === "all"
+        ? (db
+            .prepare(`SELECT * FROM improvement_tasks ORDER BY created_at DESC LIMIT ?`)
+            .all(limit) as ImprovementTask[])
+        : (db
+            .prepare(
+              `SELECT * FROM improvement_tasks WHERE status = ? ORDER BY created_at DESC LIMIT ?`
+            )
+            .all(status, limit) as ImprovementTask[]);
+    return rows.map((row) => ({ ...row, source: "plugin" }));
+  } finally {
+    db?.close();
+  }
 }
 
 /** Load config from the main agent DB's user_hook_config table. */
@@ -250,10 +568,10 @@ export function createSelfImprovementRoutes(deps?: WebUIServerDeps) {
         " Report a summary of findings when complete.";
 
       const sessionChatId = `telegram:direct:${adminChatId}`;
-      const { getDatabase } = await import("../../memory/index.js");
+      const nativeRunId = createNativeAnalysisRun(deps.memory.db, cfg);
       const toolContext = {
         bridge: deps.bridge,
-        db: getDatabase().getDb(),
+        db: deps.memory.db,
         chatId: sessionChatId,
         isGroup: false,
         senderId: adminChatId,
@@ -262,16 +580,19 @@ export function createSelfImprovementRoutes(deps?: WebUIServerDeps) {
 
       // Fire-and-forget: start the analysis in the background so the HTTP
       // response returns immediately.
-      void deps.agent
-        .processMessage({
-          chatId: sessionChatId,
-          userMessage: prompt,
-          userName: "self-improve",
-          timestamp: Date.now(),
-          isGroup: false,
-          toolContext,
-        })
+      void Promise.resolve()
+        .then(() =>
+          deps.agent.processMessage({
+            chatId: sessionChatId,
+            userMessage: prompt,
+            userName: "self-improve",
+            timestamp: Date.now(),
+            isGroup: false,
+            toolContext,
+          })
+        )
         .then(async (response) => {
+          completeNativeAnalysisRun(deps.memory.db, nativeRunId, response);
           const content = response.content ?? "";
           if (content && deps.bridge?.isAvailable()) {
             await deps.bridge.sendMessage({
@@ -280,8 +601,9 @@ export function createSelfImprovementRoutes(deps?: WebUIServerDeps) {
             });
           }
         })
-        .catch(() => {
-          // Errors are logged by the agent runtime itself
+        .catch((error) => {
+          failNativeAnalysisRun(deps.memory.db, nativeRunId, error);
+          // Errors are logged by the agent runtime itself.
         });
 
       return c.json<APIResponse<{ message: string }>>({
@@ -295,57 +617,34 @@ export function createSelfImprovementRoutes(deps?: WebUIServerDeps) {
     }
   });
 
-  // ── Plugin DB endpoints ─────────────────────────────────────────────────────
+  // ── Self-improvement data endpoints ─────────────────────────────────────────
 
   // GET /api/self-improvement/status
-  // Returns whether the self-improve-orchestrator plugin DB exists and basic stats.
+  // Returns whether self-improvement data exists and basic stats.
   app.get("/status", (c) => {
-    const installed = existsSync(PLUGIN_DB_PATH);
-    if (!installed) {
-      return c.json<APIResponse<{ installed: boolean }>>({
-        success: true,
-        data: { installed: false },
-      });
-    }
-
-    let db: Database.Database | null = null;
     try {
-      db = openPluginDb();
-      if (!db) {
-        return c.json<APIResponse<{ installed: boolean }>>({
-          success: true,
-          data: { installed: false },
-        });
-      }
-
-      const tables = db.prepare(`SELECT name FROM sqlite_master WHERE type='table'`).all() as {
-        name: string;
-      }[];
-      const tableNames = tables.map((t) => t.name);
-
-      const analysisCount = tableNames.includes("analysis_log")
-        ? (db.prepare(`SELECT COUNT(*) as cnt FROM analysis_log`).get() as { cnt: number }).cnt
-        : 0;
-
-      const pendingCount = tableNames.includes("improvement_tasks")
-        ? (
-            db
-              .prepare(`SELECT COUNT(*) as cnt FROM improvement_tasks WHERE status = 'pending'`)
-              .get() as { cnt: number }
-          ).cnt
-        : 0;
-
-      const lastAnalysis = tableNames.includes("analysis_log")
-        ? ((
-            db
-              .prepare(`SELECT timestamp FROM analysis_log ORDER BY timestamp DESC LIMIT 1`)
-              .get() as { timestamp: number } | undefined
-          )?.timestamp ?? null)
-        : null;
+      const pluginStatus = readPluginStatus();
+      const nativeStatus = readNativeStatus(deps?.memory?.db);
+      const analysisCount = pluginStatus.analysis_count + nativeStatus.analysis_count;
+      const pendingCount = pluginStatus.pending_tasks + nativeStatus.pending_tasks;
+      const lastAnalysis = Math.max(
+        pluginStatus.last_analysis ?? 0,
+        nativeStatus.last_analysis ?? 0
+      );
+      const source =
+        pluginStatus.installed && nativeStatus.analysis_count > 0
+          ? "mixed"
+          : pluginStatus.installed
+            ? "plugin"
+            : nativeStatus.analysis_count > 0
+              ? "native"
+              : "none";
 
       return c.json<
         APIResponse<{
           installed: boolean;
+          plugin_installed: boolean;
+          source: "plugin" | "native" | "mixed" | "none";
           analysis_count: number;
           pending_tasks: number;
           last_analysis: number | null;
@@ -353,86 +652,48 @@ export function createSelfImprovementRoutes(deps?: WebUIServerDeps) {
       >({
         success: true,
         data: {
-          installed: true,
+          installed: pluginStatus.installed || analysisCount > 0 || pendingCount > 0,
+          plugin_installed: pluginStatus.installed,
+          source,
           analysis_count: analysisCount,
           pending_tasks: pendingCount,
-          last_analysis: lastAnalysis,
+          last_analysis: lastAnalysis || null,
         },
       });
     } catch (error) {
       return c.json<APIResponse>({ success: false, error: getErrorMessage(error) }, 500);
-    } finally {
-      db?.close();
     }
   });
 
   // GET /api/self-improvement/analysis?limit=10
   app.get("/analysis", (c) => {
-    let db: Database.Database | null = null;
     try {
-      db = openPluginDb();
-      if (!db) {
-        return c.json<APIResponse<AnalysisLogEntry[]>>({ success: true, data: [] });
-      }
-
-      const tables = db
-        .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='analysis_log'`)
-        .all();
-      if (tables.length === 0) {
-        return c.json<APIResponse<AnalysisLogEntry[]>>({ success: true, data: [] });
-      }
-
-      const limitParam = c.req.query("limit");
-      const limit = Math.min(parseInt(limitParam ?? "20", 10) || 20, 100);
-
-      const rows = db
-        .prepare(`SELECT * FROM analysis_log ORDER BY timestamp DESC LIMIT ?`)
-        .all(limit) as AnalysisLogEntry[];
+      const limit = parseLimit(c.req.query("limit"), 20, 100);
+      const rows = [...readPluginAnalysis(limit), ...readNativeAnalysis(deps?.memory?.db, limit)]
+        .sort((a, b) => b.timestamp - a.timestamp)
+        .slice(0, limit);
 
       return c.json<APIResponse<AnalysisLogEntry[]>>({ success: true, data: rows });
     } catch (error) {
       return c.json<APIResponse>({ success: false, error: getErrorMessage(error) }, 500);
-    } finally {
-      db?.close();
     }
   });
 
   // GET /api/self-improvement/tasks?status=pending&limit=20
   app.get("/tasks", (c) => {
-    let db: Database.Database | null = null;
     try {
-      db = openPluginDb();
-      if (!db) {
-        return c.json<APIResponse<ImprovementTask[]>>({ success: true, data: [] });
-      }
-
-      const tables = db
-        .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='improvement_tasks'`)
-        .all();
-      if (tables.length === 0) {
-        return c.json<APIResponse<ImprovementTask[]>>({ success: true, data: [] });
-      }
-
       const status = c.req.query("status") ?? "all";
-      const limitParam = c.req.query("limit");
-      const limit = Math.min(parseInt(limitParam ?? "50", 10) || 50, 200);
-
-      const rows =
-        status === "all"
-          ? (db
-              .prepare(`SELECT * FROM improvement_tasks ORDER BY created_at DESC LIMIT ?`)
-              .all(limit) as ImprovementTask[])
-          : (db
-              .prepare(
-                `SELECT * FROM improvement_tasks WHERE status = ? ORDER BY created_at DESC LIMIT ?`
-              )
-              .all(status, limit) as ImprovementTask[]);
+      const limit = parseLimit(c.req.query("limit"), 50, 200);
+      const rows = [
+        ...readPluginTasks(status, limit),
+        ...readNativeTasks(deps?.memory?.db, status, limit),
+      ]
+        .sort((a, b) => b.created_at - a.created_at)
+        .slice(0, limit);
 
       return c.json<APIResponse<ImprovementTask[]>>({ success: true, data: rows });
     } catch (error) {
       return c.json<APIResponse>({ success: false, error: getErrorMessage(error) }, 500);
-    } finally {
-      db?.close();
     }
   });
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2144,6 +2144,10 @@ export interface SelfImprovementAnalysisEntry {
   issues_found: number;
   issues_created: number;
   summary: string | null;
+  source?: "plugin" | "native";
+  status?: "running" | "completed" | "failed";
+  error?: string | null;
+  completed_at?: number | null;
 }
 
 export interface SelfImprovementTask {
@@ -2158,6 +2162,7 @@ export interface SelfImprovementTask {
   status: string;
   created_at: number;
   github_issue_url: string | null;
+  source?: "plugin" | "native";
 }
 
 // ── Fetch helpers ───────────────────────────────────────────────────
@@ -3902,6 +3907,8 @@ export const api = {
     return fetchAPI<
       APIResponse<{
         installed: boolean;
+        plugin_installed?: boolean;
+        source?: "plugin" | "native" | "mixed" | "none";
         analysis_count?: number;
         pending_tasks?: number;
         last_analysis?: number | null;

--- a/web/src/pages/SelfImprove.tsx
+++ b/web/src/pages/SelfImprove.tsx
@@ -535,10 +535,11 @@ function QuickStats({
   const critical = tasks.filter((t) => t.priority === "critical").length;
   const high = tasks.filter((t) => t.priority === "high").length;
   const medium = tasks.filter((t) => t.priority === "medium").length;
-  // Prefer status endpoint data (from plugin DB) over in-memory counts when available
+  // Prefer merged status endpoint data over in-memory counts when available.
   const lastScan = pluginStatus?.last_analysis ?? analysis[0]?.timestamp ?? null;
   const totalScans = pluginStatus?.analysis_count ?? analysis.length;
-  const pendingTasks = pluginStatus?.pending_tasks ?? tasks.filter((t) => t.status === "pending").length;
+  const pendingTasks =
+    pluginStatus?.pending_tasks ?? tasks.filter((t) => t.status === "pending").length;
   const nextScheduled =
     config.schedule_enabled && lastScan
       ? lastScan + config.schedule_interval_hours * 3_600_000
@@ -557,8 +558,7 @@ function QuickStats({
             color: "#d97706",
           }}
         >
-          ⚠ Plugin database not found. Install and run the{" "}
-          <code>github-dev-assistant</code> plugin to see real data.
+          ⚠ No self-improvement history found. Run an analysis to populate these tabs.
         </div>
       )}
       <div
@@ -1245,8 +1245,6 @@ function AnalyticsTab({
           {analysis.length === 0 ? (
             <p style={{ fontSize: "14px", opacity: 0.6 }}>
               No analysis data yet. Run your first analysis to see the security score.
-              Make sure the <code>github-dev-assistant</code> plugin is installed and has been run at
-              least once.
             </p>
           ) : (
             <div style={{ display: "flex", alignItems: "center", gap: "24px", flexWrap: "wrap" }}>
@@ -1294,7 +1292,6 @@ function AnalyticsTab({
           {analysis.length === 0 ? (
             <p style={{ fontSize: "14px", opacity: 0.6 }}>
               No analysis data yet. Run your first analysis to see trends.
-              Make sure the <code>github-dev-assistant</code> plugin is installed and configured.
             </p>
           ) : (
             <>
@@ -1487,7 +1484,7 @@ function LogsTab({
         <p style={{ margin: 0 }}>
           Full audit trail of all agent actions. Filter by status and severity to focus on what
           matters. Click <strong>View GitHub Issue</strong> on any task to open it directly.
-          Data is read from the <code>github-dev-assistant</code> plugin database.
+          Data is read from Teleton's self-improvement history and imported plugin results.
         </p>
       </ExpandableHelp>
 
@@ -1502,8 +1499,7 @@ function LogsTab({
             color: "#d97706",
           }}
         >
-          ⚠ Plugin database not found. Install the <code>github-dev-assistant</code> plugin and
-          run at least one analysis to see logs here.
+          ⚠ No self-improvement history found. Run at least one analysis to see logs here.
         </div>
       )}
 
@@ -1520,6 +1516,7 @@ function LogsTab({
                   <th style={{ textAlign: "left", padding: "8px 12px", fontWeight: 600 }}>Timestamp</th>
                   <th style={{ textAlign: "left", padding: "8px 12px", fontWeight: 600 }}>Repo</th>
                   <th style={{ textAlign: "left", padding: "8px 12px", fontWeight: 600 }}>Branch</th>
+                  <th style={{ textAlign: "left", padding: "8px 12px", fontWeight: 600 }}>Status</th>
                   <th style={{ textAlign: "right", padding: "8px 12px", fontWeight: 600 }}>Files</th>
                   <th style={{ textAlign: "right", padding: "8px 12px", fontWeight: 600 }}>Findings</th>
                   <th style={{ textAlign: "right", padding: "8px 12px", fontWeight: 600 }}>Issues</th>
@@ -1527,7 +1524,10 @@ function LogsTab({
               </thead>
               <tbody>
                 {analysis.map((e) => (
-                  <tr key={e.id} style={{ borderBottom: "1px solid var(--border, #e5e7eb)" }}>
+                  <tr
+                    key={`${e.source ?? "plugin"}:${e.id}`}
+                    style={{ borderBottom: "1px solid var(--border, #e5e7eb)" }}
+                  >
                     <td style={{ padding: "8px 12px", whiteSpace: "nowrap" }}>{fmtTs(e.timestamp)}</td>
                     <td style={{ padding: "8px 12px" }}>
                       <code style={{ fontSize: "12px" }}>{e.repo}</code>
@@ -1535,6 +1535,7 @@ function LogsTab({
                     <td style={{ padding: "8px 12px" }}>
                       <code style={{ fontSize: "12px" }}>{e.branch}</code>
                     </td>
+                    <td style={{ padding: "8px 12px" }}>{e.status ?? "completed"}</td>
                     <td style={{ padding: "8px 12px", textAlign: "right" }}>{e.files_analyzed}</td>
                     <td style={{ padding: "8px 12px", textAlign: "right" }}>{e.issues_found}</td>
                     <td style={{ padding: "8px 12px", textAlign: "right" }}>{e.issues_created}</td>
@@ -1602,7 +1603,7 @@ function LogsTab({
             <p style={{ fontSize: "14px", opacity: 0.6 }}>
               {taskFilter === "all" && severityFilter === "all"
                 ? pluginStatus && !pluginStatus.installed
-                  ? "Plugin database not found — run an analysis first."
+                  ? "No self-improvement history found — run an analysis first."
                   : "No tasks found. Run an analysis to discover improvement opportunities."
                 : "No matching tasks found. Try adjusting the filters."}
             </p>
@@ -1777,6 +1778,7 @@ export function SelfImprove() {
       const res = await api.triggerSelfImprovement();
       if (res.success && res.data) {
         setTriggerMsg({ type: "success", text: res.data.message });
+        await load();
       } else {
         setTriggerMsg({ type: "error", text: "Unknown error" });
       }


### PR DESCRIPTION
## Summary
- persist Web UI-triggered self-improvement runs in the main Teleton DB when the plugin DB is missing
- merge native and plugin self-improvement analysis/task data for status, logs, and analytics endpoints
- update Self-Improvement Center empty states and log rows so runs are visible after triggering analysis

## Reproduction
1. Use Self-Improvement Center with the configured `github-dev-assistant` plugin and no `self-improve-orchestrator.db` file.
2. Trigger a self-improvement analysis from the Web UI.
3. Before this fix, status reported no plugin database and Analytics/Logs stayed empty. After this fix, the triggered run is recorded as native self-improvement history and appears in the tabs.

## Tests
- `npm test -- src/webui/__tests__/self-improvement-routes.test.ts src/webui/__tests__/self-improvement-routes-with-data.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Fixes #443