### PR TITLE
docs(audit): add V2 work3 audit and follow-up issues

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
+# Updated: 2026-04-27T22:37:35.997Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
-# Updated: 2026-04-27T22:37:35.997Z

--- a/improvements/work3/AUDIT_V2_REPORT.md
+++ b/improvements/work3/AUDIT_V2_REPORT.md
@@ -1,0 +1,218 @@
+# V2 Architecture Full Audit - Teleton Agent
+
+## Executed
+
+- Date: 2026-04-27
+- Model: OpenAI Codex GPT-5
+- Audit issue: [#445](https://github.com/xlabtg/teleton-agent/issues/445)
+- Branch: `issue-445-2a5fadc82968`
+- Audit commit: `1824d777e9ac37acb2b530d7de195f3cbb17891a`
+- Compared base: `upstream/main` at `3eacbbf976023a4aaa7eda290a827ca589d76c47`
+
+Note: the issue requested Claude/Hive Mind execution. This run was performed by
+OpenAI Codex in the prepared issue-solver workspace. The report records the
+actual execution environment for traceability.
+
+## Executive Summary
+
+Overall assessment: Red for production use of the affected V2 paths.
+
+Top release blockers:
+
+1. Public webhook ingress for V2 webhooks and workflow webhooks is effectively
+   unreachable because global WebUI auth and CSRF middleware only bypass the
+   signed agent-network endpoint.
+2. Pipeline steps delegated to managed agents are marked complete as soon as an
+   inbox message is sent, so downstream steps consume dispatch metadata instead
+   of the delegated agent's real result.
+3. Pipeline-level timeouts do not bound an already-running step or level; a
+   hanging agent call can leave a run stuck in `running`.
+4. The WebUI/Management API memory search endpoint bypasses embeddings and
+   semantic vector retrieval even when semantic memory is configured.
+5. Workflow `call_api` actions use raw `fetch()` without a timeout, so one slow
+   endpoint can block webhook/event/cron workflow execution.
+
+Recommendation: No-Go for production use of public webhook automation and
+cross-agent pipeline execution until V2-001, V2-002, and V2-003 are fixed.
+Conditional Go for semantic memory and simple workflows only if operators accept
+the documented fallback and hanging-call risks.
+
+## Quick Links
+
+- Task files: [issues/](./issues/)
+- Validation scripts: [validation/](./validation/)
+- Previous V2 audit workspace: [README.md](./README.md)
+
+## Finding Statistics
+
+| Severity | Count | Task Files Created | Draft PRs |
+| -------- | ----- | ------------------ | --------- |
+| Critical | 0     | 0                  | 0         |
+| High     | 3     | 3                  | 0         |
+| Medium   | 2     | 2                  | 0         |
+| Low      | 0     | 0                  | 0         |
+
+## Prioritized Fix Plan
+
+### Priority 0 - Fix before any production webhook or multi-agent pipeline use
+
+1. [V2-001](./issues/V2-001-public-v2-webhooks-blocked-by-webui-auth.md) -
+   Public V2 webhook ingress is blocked by WebUI auth and CSRF.
+   - Effort: Medium
+   - Validation: route-level tests that unsigned browser mutations still require
+     auth/CSRF while signed webhook ingress reaches the route handler.
+2. [V2-002](./issues/V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md) -
+   Delegated pipeline steps complete on inbox dispatch rather than remote result.
+   - Effort: High
+   - Validation: pipeline test where step B depends on the textual result of a
+     managed-agent step A.
+3. [V2-003](./issues/V2-003-pipeline-run-timeout-does-not-bound-running-steps.md) -
+   Pipeline-level timeouts do not stop hung step execution.
+   - Effort: Medium
+   - Validation: fake-timer test with a never-resolving `processMessage()` and a
+     short `timeoutSeconds` pipeline limit.
+
+### Priority 1 - Fix before v3.0 release
+
+4. [V2-004](./issues/V2-004-memory-search-skips-semantic-vector-retrieval.md) -
+   Memory search API never computes query embeddings for semantic retrieval.
+   - Effort: Medium
+   - Validation: route test with a mock embedder/vector store proving semantic
+     results are returned for queries that keyword search misses.
+5. [V2-005](./issues/V2-005-workflow-call-api-actions-have-no-timeout.md) -
+   Workflow `call_api` actions have no timeout or abort path.
+   - Effort: Small
+   - Validation: fake-timer test where `fetch()` never resolves and the workflow
+     records an error instead of hanging.
+
+## Confirmed Findings
+
+### V2-001 - Public V2 webhook ingress is blocked by WebUI auth and CSRF
+
+- Severity: High
+- Category: Integration / security boundary
+- Evidence:
+  - `src/webui/server.ts:180` installs CSRF globally before route mounting.
+  - `src/webui/server.ts:213` applies auth to `/api/*` and only bypasses
+    `/api/agent-network`.
+  - `src/webui/server.ts:321` and `src/webui/server.ts:324` mount workflows and
+    webhooks under `/api`.
+  - `src/webui/routes/workflows.ts:192` describes `/webhook/:secret` as public,
+    but it is still mounted below `/api/workflows`.
+  - `src/webui/routes/webhooks.ts:72` verifies `X-Webhook-Signature`, but the
+    request cannot reach that verifier without WebUI auth and CSRF.
+- Impact: external providers cannot trigger configured webhooks or workflows
+  using their advertised secret/signature model. Operators may conclude
+  webhooks are active while all real inbound calls fail with 401/403.
+- Task: [V2-001](./issues/V2-001-public-v2-webhooks-blocked-by-webui-auth.md)
+
+### V2-002 - Managed-agent pipeline steps complete on dispatch metadata
+
+- Severity: High
+- Category: Runtime integration
+- Evidence:
+  - `src/services/pipeline/executor.ts:267` sends a message to the selected
+    managed agent.
+  - `src/services/pipeline/executor.ts:272` immediately returns dispatch
+    metadata: `messageId`, `toAgentId`, `toAgentName`, `createdAt`, and
+    `action`.
+  - The returned dispatch object is stored as the step output and can feed
+    downstream interpolation, even though it is not the delegated result.
+- Impact: multi-agent pipelines report success before delegated work is done,
+  dependent steps run on metadata rather than real outputs, and failures in the
+  managed agent are invisible to the pipeline run.
+- Task: [V2-002](./issues/V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md)
+
+### V2-003 - Pipeline run timeout does not bound running steps
+
+- Severity: High
+- Category: Reliability
+- Evidence:
+  - `src/services/pipeline/executor.ts:117` computes a pipeline-level deadline.
+  - `src/services/pipeline/executor.ts:125` checks that deadline only before
+    starting each level.
+  - `src/services/pipeline/executor.ts:136` then awaits the whole level with
+    `Promise.all(...)`.
+  - `src/services/pipeline/executor.ts:281` applies timeout wrapping only when a
+    step has `step.timeoutSeconds`.
+- Impact: a pipeline with `timeoutSeconds` can remain stuck in `running` if a
+  step without its own timeout never resolves. Cancellation only changes stored
+  state; it does not abort the in-flight promise.
+- Task: [V2-003](./issues/V2-003-pipeline-run-timeout-does-not-bound-running-steps.md)
+
+### V2-004 - Memory search API skips semantic vector retrieval
+
+- Severity: Medium
+- Category: UI/API parity
+- Evidence:
+  - `src/webui/routes/memory.ts:95` constructs `HybridSearch` with
+    `vectorEnabled = false`.
+  - `src/webui/routes/memory.ts:101` calls `searchKnowledge(query, [], ...)`
+    with an empty embedding array.
+  - `HybridSearch` requires a non-empty query embedding before it calls the
+    semantic vector store.
+- Impact: the user-facing memory search API remains keyword-only even when
+  semantic vector memory is configured and synchronized. Natural-language
+  queries that should be answered by semantic similarity return empty or
+  incomplete results.
+- Task: [V2-004](./issues/V2-004-memory-search-skips-semantic-vector-retrieval.md)
+
+### V2-005 - Workflow `call_api` actions have no timeout
+
+- Severity: Medium
+- Category: Reliability / integrations
+- Evidence:
+  - `src/services/workflow-executor.ts:51` builds the `call_api` action request.
+  - `src/services/workflow-executor.ts:59` awaits `fetch(action.url, init)`
+    without `AbortController`, `AbortSignal.timeout`, or a configured action
+    timeout.
+- Impact: one slow or never-responding endpoint can block webhook, event, or
+  cron workflow execution. Because `WorkflowScheduler.execute()` awaits the
+  executor, scheduler progress and later workflow actions can stall behind the
+  hung fetch.
+- Task: [V2-005](./issues/V2-005-workflow-call-api-actions-have-no-timeout.md)
+
+## Non-Duplicate Check
+
+The five findings above were checked against the previous V2 work3 findings and
+their follow-up fixes:
+
+- #400 / #405 / #410: agent-network allowlist and recipient checks.
+- #401 / #406: agent-network ingress task dispatch.
+- #402 / #407: replayed signed network messages.
+- #403 / #408: Management API route parity.
+- #404 / #409: widget generator preview parity.
+
+The new findings target public webhook ingress, delegated pipeline result
+semantics, pipeline timeout enforcement, semantic search wiring, and workflow
+HTTP action timeouts. They do not duplicate the closed work3 issues.
+
+## Verification Performed
+
+- Read issue #445, existing PR #446 metadata, issue comments, PR comments,
+  review comments, and recent merged V2/audit PRs.
+- Reviewed prior audit folders `improvements/work`, `improvements/work2`, and
+  `improvements/work3`.
+- Reviewed V2 specifications under `improvements/v2-*.md`.
+- Inspected current implementations in:
+  - `src/webui/server.ts`
+  - `src/webui/routes/workflows.ts`
+  - `src/webui/routes/webhooks.ts`
+  - `src/services/pipeline/executor.ts`
+  - `src/webui/routes/memory.ts`
+  - `src/services/workflow-executor.ts`
+- Installed dependencies with `npm ci --ignore-scripts`; npm reported zero
+  vulnerabilities.
+- Added validation tooling:
+  - `node improvements/work3/validation/check-artifacts.mjs`
+  - `node improvements/work3/validation/reproduce-findings.mjs`
+
+## Out Of Scope
+
+- Applying the five production fixes in this PR. Issue #445 asks for an audit
+  report and ready-to-import issue templates.
+- Creating real GitHub issues from the templates. The files in
+  `improvements/work3/issues/` are structured so maintainers can import or copy
+  them without additional triage.
+- Load testing, browser screenshots, or end-to-end webhook calls against a
+  deployed instance.

--- a/improvements/work3/AUDIT_V2_REPORT.md
+++ b/improvements/work3/AUDIT_V2_REPORT.md
@@ -40,34 +40,63 @@ the documented fallback and hanging-call risks.
 ## Quick Links
 
 - Task files: [issues/](./issues/)
+- Filed GitHub issues: [#447](https://github.com/xlabtg/teleton-agent/issues/447),
+  [#448](https://github.com/xlabtg/teleton-agent/issues/448),
+  [#449](https://github.com/xlabtg/teleton-agent/issues/449),
+  [#450](https://github.com/xlabtg/teleton-agent/issues/450), and
+  [#451](https://github.com/xlabtg/teleton-agent/issues/451)
 - Validation scripts: [validation/](./validation/)
 - Previous V2 audit workspace: [README.md](./README.md)
 
 ## Finding Statistics
 
-| Severity | Count | Task Files Created | Draft PRs |
-| -------- | ----- | ------------------ | --------- |
-| Critical | 0     | 0                  | 0         |
-| High     | 3     | 3                  | 0         |
-| Medium   | 2     | 2                  | 0         |
-| Low      | 0     | 0                  | 0         |
+| Severity | Count | Task Files Created | GitHub Issues Created | Draft PRs |
+| -------- | ----- | ------------------ | --------------------- | --------- |
+| Critical | 0     | 0                  | 0                     | 0         |
+| High     | 3     | 3                  | 3                     | 0         |
+| Medium   | 2     | 2                  | 2                     | 0         |
+| Low      | 0     | 0                  | 0                     | 0         |
+
+## Filed GitHub Issues
+
+The five follow-up issues were created from the task templates on 2026-04-27.
+The issue bodies preserve the requested frontmatter metadata for labels,
+milestone, audit source, finding id, severity, and category.
+
+| Finding | GitHub Issue                                               | Source Template                                                                                                                           |
+| ------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| V2-001  | [#447](https://github.com/xlabtg/teleton-agent/issues/447) | [V2-001-public-v2-webhooks-blocked-by-webui-auth.md](./issues/V2-001-public-v2-webhooks-blocked-by-webui-auth.md)                         |
+| V2-002  | [#448](https://github.com/xlabtg/teleton-agent/issues/448) | [V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md](./issues/V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md) |
+| V2-003  | [#449](https://github.com/xlabtg/teleton-agent/issues/449) | [V2-003-pipeline-run-timeout-does-not-bound-running-steps.md](./issues/V2-003-pipeline-run-timeout-does-not-bound-running-steps.md)       |
+| V2-004  | [#450](https://github.com/xlabtg/teleton-agent/issues/450) | [V2-004-memory-search-skips-semantic-vector-retrieval.md](./issues/V2-004-memory-search-skips-semantic-vector-retrieval.md)               |
+| V2-005  | [#451](https://github.com/xlabtg/teleton-agent/issues/451) | [V2-005-workflow-call-api-actions-have-no-timeout.md](./issues/V2-005-workflow-call-api-actions-have-no-timeout.md)                       |
+
+Metadata application note: the automation token has `READ` permission on
+`xlabtg/teleton-agent`, so GitHub accepted issue creation but rejected upstream
+label and milestone management. Maintainers with triage/write access should add
+the frontmatter labels (`bug`, `audit-finding-v2`, severity, `v3.0-blocker`),
+assign the issues as needed, and create/apply the `v3.0 - Production Ready`
+milestone.
 
 ## Prioritized Fix Plan
 
 ### Priority 0 - Fix before any production webhook or multi-agent pipeline use
 
 1. [V2-001](./issues/V2-001-public-v2-webhooks-blocked-by-webui-auth.md) -
-   Public V2 webhook ingress is blocked by WebUI auth and CSRF.
+   Public V2 webhook ingress is blocked by WebUI auth and CSRF
+   ([#447](https://github.com/xlabtg/teleton-agent/issues/447)).
    - Effort: Medium
    - Validation: route-level tests that unsigned browser mutations still require
      auth/CSRF while signed webhook ingress reaches the route handler.
 2. [V2-002](./issues/V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md) -
-   Delegated pipeline steps complete on inbox dispatch rather than remote result.
+   Delegated pipeline steps complete on inbox dispatch rather than remote result
+   ([#448](https://github.com/xlabtg/teleton-agent/issues/448)).
    - Effort: High
    - Validation: pipeline test where step B depends on the textual result of a
      managed-agent step A.
 3. [V2-003](./issues/V2-003-pipeline-run-timeout-does-not-bound-running-steps.md) -
-   Pipeline-level timeouts do not stop hung step execution.
+   Pipeline-level timeouts do not stop hung step execution
+   ([#449](https://github.com/xlabtg/teleton-agent/issues/449)).
    - Effort: Medium
    - Validation: fake-timer test with a never-resolving `processMessage()` and a
      short `timeoutSeconds` pipeline limit.
@@ -75,12 +104,14 @@ the documented fallback and hanging-call risks.
 ### Priority 1 - Fix before v3.0 release
 
 4. [V2-004](./issues/V2-004-memory-search-skips-semantic-vector-retrieval.md) -
-   Memory search API never computes query embeddings for semantic retrieval.
+   Memory search API never computes query embeddings for semantic retrieval
+   ([#450](https://github.com/xlabtg/teleton-agent/issues/450)).
    - Effort: Medium
    - Validation: route test with a mock embedder/vector store proving semantic
      results are returned for queries that keyword search misses.
 5. [V2-005](./issues/V2-005-workflow-call-api-actions-have-no-timeout.md) -
-   Workflow `call_api` actions have no timeout or abort path.
+   Workflow `call_api` actions have no timeout or abort path
+   ([#451](https://github.com/xlabtg/teleton-agent/issues/451)).
    - Effort: Small
    - Validation: fake-timer test where `fetch()` never resolves and the workflow
      records an error instead of hanging.
@@ -105,6 +136,7 @@ the documented fallback and hanging-call risks.
   using their advertised secret/signature model. Operators may conclude
   webhooks are active while all real inbound calls fail with 401/403.
 - Task: [V2-001](./issues/V2-001-public-v2-webhooks-blocked-by-webui-auth.md)
+- GitHub issue: [#447](https://github.com/xlabtg/teleton-agent/issues/447)
 
 ### V2-002 - Managed-agent pipeline steps complete on dispatch metadata
 
@@ -122,6 +154,7 @@ the documented fallback and hanging-call risks.
   dependent steps run on metadata rather than real outputs, and failures in the
   managed agent are invisible to the pipeline run.
 - Task: [V2-002](./issues/V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md)
+- GitHub issue: [#448](https://github.com/xlabtg/teleton-agent/issues/448)
 
 ### V2-003 - Pipeline run timeout does not bound running steps
 
@@ -139,6 +172,7 @@ the documented fallback and hanging-call risks.
   step without its own timeout never resolves. Cancellation only changes stored
   state; it does not abort the in-flight promise.
 - Task: [V2-003](./issues/V2-003-pipeline-run-timeout-does-not-bound-running-steps.md)
+- GitHub issue: [#449](https://github.com/xlabtg/teleton-agent/issues/449)
 
 ### V2-004 - Memory search API skips semantic vector retrieval
 
@@ -156,6 +190,7 @@ the documented fallback and hanging-call risks.
   queries that should be answered by semantic similarity return empty or
   incomplete results.
 - Task: [V2-004](./issues/V2-004-memory-search-skips-semantic-vector-retrieval.md)
+- GitHub issue: [#450](https://github.com/xlabtg/teleton-agent/issues/450)
 
 ### V2-005 - Workflow `call_api` actions have no timeout
 
@@ -171,6 +206,7 @@ the documented fallback and hanging-call risks.
   executor, scheduler progress and later workflow actions can stall behind the
   hung fetch.
 - Task: [V2-005](./issues/V2-005-workflow-call-api-actions-have-no-timeout.md)
+- GitHub issue: [#451](https://github.com/xlabtg/teleton-agent/issues/451)
 
 ## Non-Duplicate Check
 
@@ -211,8 +247,9 @@ HTTP action timeouts. They do not duplicate the closed work3 issues.
 
 - Applying the five production fixes in this PR. Issue #445 asks for an audit
   report and ready-to-import issue templates.
-- Creating real GitHub issues from the templates. The files in
-  `improvements/work3/issues/` are structured so maintainers can import or copy
-  them without additional triage.
+- Applying labels, milestone, or assignees to the created follow-up issues. The
+  upstream token available to this automation has read-only repository
+  permission, so the requested metadata remains in each issue body frontmatter
+  for maintainers to apply.
 - Load testing, browser screenshots, or end-to-end webhook calls against a
   deployed instance.

--- a/improvements/work3/README.md
+++ b/improvements/work3/README.md
@@ -1,9 +1,10 @@
 # V2 Full Audit Work Folder
 
-This folder is the audit workspace for
-[`#398`](https://github.com/xlabtg/teleton-agent/issues/398). It is not a
+This folder contains V2 audit workspaces for
+[`#398`](https://github.com/xlabtg/teleton-agent/issues/398) and
+[`#445`](https://github.com/xlabtg/teleton-agent/issues/445). It is not a
 scratchpad: each report covers one requested audit lane, and each confirmed
-defect uses the same record format.
+defect uses a reproducible record format.
 
 ## Scope
 
@@ -24,6 +25,7 @@ integrations, dynamic dashboards, feedback learning, and agent network work.
 
 | File                                                                       | Purpose                                                        |
 | -------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [AUDIT_V2_REPORT.md](AUDIT_V2_REPORT.md)                                   | Issue #445 full V2 audit report and task index                 |
 | [01-architecture-consistency.md](01-architecture-consistency.md)           | Cross-feature architecture shape and ownership boundaries      |
 | [02-security-and-trust.md](02-security-and-trust.md)                       | Signed ingress, trust config, replay, and privilege boundaries |
 | [03-runtime-and-integrations.md](03-runtime-and-integrations.md)           | Whether V2 endpoints connect to executable runtime paths       |
@@ -31,8 +33,37 @@ integrations, dynamic dashboards, feedback learning, and agent network work.
 | [05-regressions-and-compatibility.md](05-regressions-and-compatibility.md) | Backward compatibility and externally visible route behavior   |
 | [06-performance-and-reliability.md](06-performance-and-reliability.md)     | Idempotency, duplicate work, and preview reliability           |
 | [07-final-v2-summary.md](07-final-v2-summary.md)                           | Final summary, issue index, and follow-up order                |
+| [audit-config.yaml](audit-config.yaml)                                     | Issue #445 audit metadata and inspected paths                  |
 
-## Confirmed Findings
+## Confirmed Findings From #445
+
+| ID     | Severity | Task File                                                                                                                                      | Status            |
+| ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| V2-001 | High     | [issues/V2-001-public-v2-webhooks-blocked-by-webui-auth.md](issues/V2-001-public-v2-webhooks-blocked-by-webui-auth.md)                         | Filed as template |
+| V2-002 | High     | [issues/V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md](issues/V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md) | Filed as template |
+| V2-003 | High     | [issues/V2-003-pipeline-run-timeout-does-not-bound-running-steps.md](issues/V2-003-pipeline-run-timeout-does-not-bound-running-steps.md)       | Filed as template |
+| V2-004 | Medium   | [issues/V2-004-memory-search-skips-semantic-vector-retrieval.md](issues/V2-004-memory-search-skips-semantic-vector-retrieval.md)               | Filed as template |
+| V2-005 | Medium   | [issues/V2-005-workflow-call-api-actions-have-no-timeout.md](issues/V2-005-workflow-call-api-actions-have-no-timeout.md)                       | Filed as template |
+
+## Validation For #445
+
+Run the structural artifact check:
+
+```bash
+node improvements/work3/validation/check-artifacts.mjs
+```
+
+Run the current-code reproduction check:
+
+```bash
+node improvements/work3/validation/reproduce-findings.mjs
+```
+
+The reproduction check exits non-zero while the five audit findings remain
+present. After future fix PRs, the same script can be used as a quick guard that
+the audited code patterns are gone.
+
+## Confirmed Findings From #398
 
 | ID       | Seriousness | Primary Report                                                                                                                           | GitHub Issue                                               | Status |
 | -------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------ |

--- a/improvements/work3/README.md
+++ b/improvements/work3/README.md
@@ -37,13 +37,18 @@ integrations, dynamic dashboards, feedback learning, and agent network work.
 
 ## Confirmed Findings From #445
 
-| ID     | Severity | Task File                                                                                                                                      | Status            |
-| ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| V2-001 | High     | [issues/V2-001-public-v2-webhooks-blocked-by-webui-auth.md](issues/V2-001-public-v2-webhooks-blocked-by-webui-auth.md)                         | Filed as template |
-| V2-002 | High     | [issues/V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md](issues/V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md) | Filed as template |
-| V2-003 | High     | [issues/V2-003-pipeline-run-timeout-does-not-bound-running-steps.md](issues/V2-003-pipeline-run-timeout-does-not-bound-running-steps.md)       | Filed as template |
-| V2-004 | Medium   | [issues/V2-004-memory-search-skips-semantic-vector-retrieval.md](issues/V2-004-memory-search-skips-semantic-vector-retrieval.md)               | Filed as template |
-| V2-005 | Medium   | [issues/V2-005-workflow-call-api-actions-have-no-timeout.md](issues/V2-005-workflow-call-api-actions-have-no-timeout.md)                       | Filed as template |
+| ID     | Severity | Task File                                                                                                                                      | GitHub Issue                                               | Status  |
+| ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------- |
+| V2-001 | High     | [issues/V2-001-public-v2-webhooks-blocked-by-webui-auth.md](issues/V2-001-public-v2-webhooks-blocked-by-webui-auth.md)                         | [#447](https://github.com/xlabtg/teleton-agent/issues/447) | Created |
+| V2-002 | High     | [issues/V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md](issues/V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md) | [#448](https://github.com/xlabtg/teleton-agent/issues/448) | Created |
+| V2-003 | High     | [issues/V2-003-pipeline-run-timeout-does-not-bound-running-steps.md](issues/V2-003-pipeline-run-timeout-does-not-bound-running-steps.md)       | [#449](https://github.com/xlabtg/teleton-agent/issues/449) | Created |
+| V2-004 | Medium   | [issues/V2-004-memory-search-skips-semantic-vector-retrieval.md](issues/V2-004-memory-search-skips-semantic-vector-retrieval.md)               | [#450](https://github.com/xlabtg/teleton-agent/issues/450) | Created |
+| V2-005 | Medium   | [issues/V2-005-workflow-call-api-actions-have-no-timeout.md](issues/V2-005-workflow-call-api-actions-have-no-timeout.md)                       | [#451](https://github.com/xlabtg/teleton-agent/issues/451) | Created |
+
+The issue body frontmatter contains the requested labels and milestone metadata.
+The automation token used for creation has read-only upstream repository
+permission, so maintainers need to apply the labels, milestone, and assignment
+in GitHub.
 
 ## Validation For #445
 

--- a/improvements/work3/audit-config.yaml
+++ b/improvements/work3/audit-config.yaml
@@ -1,0 +1,39 @@
+audit:
+  source_issue: "https://github.com/xlabtg/teleton-agent/issues/445"
+  prepared_pr: "https://github.com/xlabtg/teleton-agent/pull/446"
+  branch: "issue-445-2a5fadc82968"
+  executed_at: "2026-04-27T22:44:00Z"
+  model: "OpenAI Codex GPT-5"
+  requested_model_note: "Issue requested Claude/Hive Mind; actual executor was Codex."
+  audit_commit: "1824d777e9ac37acb2b530d7de195f3cbb17891a"
+  compared_base: "3eacbbf976023a4aaa7eda290a827ca589d76c47"
+scope:
+  previous_audit_folders:
+    - "improvements/work"
+    - "improvements/work2"
+    - "improvements/work3"
+  v2_specs_glob: "improvements/v2-*.md"
+  inspected_paths:
+    - "src/webui/server.ts"
+    - "src/webui/routes/workflows.ts"
+    - "src/webui/routes/webhooks.ts"
+    - "src/services/pipeline/executor.ts"
+    - "src/services/pipeline/definition.ts"
+    - "src/webui/routes/pipelines.ts"
+    - "src/webui/routes/memory.ts"
+    - "src/services/workflow-executor.ts"
+output:
+  report: "improvements/work3/AUDIT_V2_REPORT.md"
+  issues_dir: "improvements/work3/issues"
+  validation_dir: "improvements/work3/validation"
+finding_policy:
+  create_task_file_for_severity:
+    - "critical"
+    - "high"
+    - "medium"
+  duplicate_baseline:
+    - "#400"
+    - "#401"
+    - "#402"
+    - "#403"
+    - "#404"

--- a/improvements/work3/issues/V2-001-public-v2-webhooks-blocked-by-webui-auth.md
+++ b/improvements/work3/issues/V2-001-public-v2-webhooks-blocked-by-webui-auth.md
@@ -1,0 +1,116 @@
+---
+title: "[AUDIT/V2] Public V2 webhook ingress is blocked by WebUI auth and CSRF"
+labels: ["bug", "audit-finding-v2", "high", "v3.0-blocker"]
+milestone: "v3.0 - Production Ready"
+audit-source: "#445"
+finding-id: "V2-001"
+severity: "high"
+category: "integration"
+---
+
+## Problem Description
+
+The V2 webhook and workflow webhook ingress routes advertise their own
+authentication model: workflow webhooks use a secret token in the URL, and
+external webhooks use `X-Webhook-Signature`. In the real WebUI server these
+routes are mounted under `/api/*`, so the global WebUI CSRF middleware and auth
+middleware run before the route handlers.
+
+Only `/api/agent-network` is bypassed. As a result, valid external webhook calls
+cannot reach the route-level secret/signature verification.
+
+## Location
+
+- `src/webui/server.ts:180`
+- `src/webui/server.ts:213`
+- `src/webui/server.ts:321`
+- `src/webui/server.ts:324`
+- `src/webui/routes/workflows.ts:192`
+- `src/webui/routes/webhooks.ts:72`
+
+## How To Reproduce
+
+```bash
+node improvements/work3/validation/reproduce-findings.mjs
+```
+
+Manual route-level reproduction:
+
+1. Start WebUI with V2 webhooks enabled.
+2. Create an active webhook registration with a secret, or create a workflow
+   with `trigger.type = "webhook"`.
+3. POST a correctly signed request to `/api/webhooks/incoming/:id`, or POST to
+   `/api/workflows/webhook/:secret`, without WebUI session cookies.
+4. Observe that the global middleware returns 401 or 403 before the route-level
+   verifier handles the request.
+
+## Impact
+
+External providers cannot trigger configured V2 webhooks or workflow webhooks.
+Operators can configure apparently valid webhook automation that will never run
+in production unless callers also possess a browser/API session and CSRF token,
+which is incompatible with normal provider webhook delivery.
+
+## Proposed Fix
+
+```typescript
+// Sketch: keep browser API protection, but explicitly exempt signed/public ingress.
+const PUBLIC_SIGNED_API_PATHS = [
+  /^\/api\/agent-network$/,
+  /^\/api\/webhooks\/incoming\/[^/]+$/,
+  /^\/api\/workflows\/webhook\/[^/]+$/,
+];
+
+function isPublicSignedIngress(path: string): boolean {
+  return PUBLIC_SIGNED_API_PATHS.some((pattern) => pattern.test(path));
+}
+
+// Use isPublicSignedIngress() in both CSRF and WebUI auth middleware.
+```
+
+Add route tests proving:
+
+- signed webhook ingress works without WebUI cookie auth;
+- workflow secret ingress works without WebUI cookie auth;
+- normal mutating `/api/*` routes still require auth and CSRF;
+- invalid webhook signatures/secrets are still rejected.
+
+## Regression Test
+
+```typescript
+it("allows signed incoming webhooks through WebUI auth and CSRF middleware", async () => {
+  const app = buildFullWebUiAppWithAuthAndCsrf();
+  const { id, secret } = createWebhookFixture(app.db);
+  const raw = JSON.stringify({ type: "external.test" });
+  const signature = hmac(secret, raw);
+
+  const res = await app.request(`/api/webhooks/incoming/${id}`, {
+    method: "POST",
+    body: raw,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Webhook-Signature": signature,
+    },
+  });
+
+  expect(res.status).toBe(202);
+});
+```
+
+## Acceptance Criteria
+
+- [ ] `/api/webhooks/incoming/:id` reaches signature verification without WebUI
+      session cookies.
+- [ ] `/api/workflows/webhook/:secret` reaches secret verification without
+      WebUI session cookies.
+- [ ] Invalid signatures and secrets remain rejected.
+- [ ] Browser/API mutating routes remain protected by auth and CSRF.
+- [ ] Regression tests cover both public ingress paths and one protected
+      negative control.
+
+## Related Artifacts
+
+- Report: `improvements/work3/AUDIT_V2_REPORT.md#v2-001---public-v2-webhook-ingress-is-blocked-by-webui-auth-and-csrf`
+- Module: `src/webui/server.ts`
+- Previous audits checked agent-network signed ingress in #400-#402; this
+  finding covers different V2 webhook routes.

--- a/improvements/work3/issues/V2-001-public-v2-webhooks-blocked-by-webui-auth.md
+++ b/improvements/work3/issues/V2-001-public-v2-webhooks-blocked-by-webui-auth.md
@@ -6,6 +6,7 @@ audit-source: "#445"
 finding-id: "V2-001"
 severity: "high"
 category: "integration"
+github-issue: "https://github.com/xlabtg/teleton-agent/issues/447"
 ---
 
 ## Problem Description
@@ -110,6 +111,7 @@ it("allows signed incoming webhooks through WebUI auth and CSRF middleware", asy
 
 ## Related Artifacts
 
+- GitHub issue: https://github.com/xlabtg/teleton-agent/issues/447
 - Report: `improvements/work3/AUDIT_V2_REPORT.md#v2-001---public-v2-webhook-ingress-is-blocked-by-webui-auth-and-csrf`
 - Module: `src/webui/server.ts`
 - Previous audits checked agent-network signed ingress in #400-#402; this

--- a/improvements/work3/issues/V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md
+++ b/improvements/work3/issues/V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md
@@ -1,0 +1,115 @@
+---
+title: "[AUDIT/V2] Pipeline delegated-agent steps complete on dispatch metadata"
+labels: ["bug", "audit-finding-v2", "high", "v3.0-blocker"]
+milestone: "v3.0 - Production Ready"
+audit-source: "#445"
+finding-id: "V2-002"
+severity: "high"
+category: "runtime-integration"
+---
+
+## Problem Description
+
+Pipeline steps can target a managed agent by setting `step.agent` to a non-primary
+agent name/type/id. The executor sends an inbox message to that agent and then
+immediately marks the step completed with dispatch metadata (`messageId`,
+`toAgentId`, `createdAt`, and `action`). It does not wait for the managed agent
+to process the message or return a step result.
+
+This breaks the V2 pipeline contract where a step output feeds dependent steps.
+Downstream steps receive message-delivery metadata rather than the delegated
+agent's actual result.
+
+## Location
+
+- `src/services/pipeline/executor.ts:241`
+- `src/services/pipeline/executor.ts:267`
+- `src/services/pipeline/executor.ts:272`
+
+## How To Reproduce
+
+```bash
+node improvements/work3/validation/reproduce-findings.mjs
+```
+
+Manual minimal scenario:
+
+1. Configure a pipeline with step A assigned to `ResearchAgent`, output
+   `research_notes`.
+2. Configure step B with `dependsOn: ["A"]` and action
+   `Summarize {research_notes}`.
+3. Run the pipeline.
+4. Observe that step A completes immediately and step B interpolates an object
+   containing message dispatch metadata instead of research notes.
+
+## Impact
+
+Cross-agent pipelines can report successful completion while delegated work is
+still pending, failed, or never executed. Dependent steps cannot reliably consume
+remote outputs, so multi-agent task delegation becomes a notification system
+rather than an executable pipeline.
+
+## Proposed Fix
+
+Define a delegated step lifecycle and persist it in the pipeline run:
+
+```typescript
+// Sketch only.
+const dispatch = agentManager.sendMessage("primary", agent.id, payload);
+store.updateStep(runId, step.id, {
+  status: "running",
+  outputValue: { messageId: dispatch.id, pending: true },
+});
+
+const result = await agentManager.waitForMessageResult(dispatch.id, {
+  timeoutSeconds: step.timeoutSeconds ?? pipelineRemainingTimeout,
+});
+
+return result.content;
+```
+
+Possible implementation options:
+
+- add a managed-agent result callback and correlate by message id;
+- add an inbox/result table consumed by `PipelineExecutor`;
+- disallow non-primary pipeline steps until result correlation exists.
+
+## Regression Test
+
+```typescript
+it("waits for managed-agent output before running dependent pipeline steps", async () => {
+  const agentManager = fakeManagedAgentManager({
+    resultForMessage: "actual research notes",
+  });
+  const pipeline = store.create({
+    name: "delegated",
+    steps: [
+      { id: "research", agent: "ResearchAgent", action: "Research TON", output: "notes" },
+      { id: "summary", agent: "primary", action: "Summarize {notes}", depends_on: ["research"] },
+    ],
+  });
+
+  const detail = await executor.execute(pipeline);
+
+  expect(detail.run.context.notes).toBe("actual research notes");
+  expect(primaryProcessMessage).toHaveBeenCalledWith(
+    expect.objectContaining({ userMessage: "Summarize actual research notes" })
+  );
+});
+```
+
+## Acceptance Criteria
+
+- [ ] Managed-agent pipeline steps do not complete until a real delegated result
+      or terminal failure is available.
+- [ ] Dependent steps interpolate the delegated result, not dispatch metadata.
+- [ ] Timeout, cancellation, and failure states are persisted for delegated
+      steps.
+- [ ] Regression tests cover success, remote failure, timeout, and cancellation.
+
+## Related Artifacts
+
+- Report: `improvements/work3/AUDIT_V2_REPORT.md#v2-002---managed-agent-pipeline-steps-complete-on-dispatch-metadata`
+- Module: `src/services/pipeline/executor.ts`
+- Related V2 specs: `improvements/v2-08-task-delegation.md`,
+  `improvements/v2-09-pipeline-execution.md`

--- a/improvements/work3/issues/V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md
+++ b/improvements/work3/issues/V2-002-pipeline-delegated-agent-output-is-dispatch-metadata.md
@@ -6,6 +6,7 @@ audit-source: "#445"
 finding-id: "V2-002"
 severity: "high"
 category: "runtime-integration"
+github-issue: "https://github.com/xlabtg/teleton-agent/issues/448"
 ---
 
 ## Problem Description
@@ -109,6 +110,7 @@ it("waits for managed-agent output before running dependent pipeline steps", asy
 
 ## Related Artifacts
 
+- GitHub issue: https://github.com/xlabtg/teleton-agent/issues/448
 - Report: `improvements/work3/AUDIT_V2_REPORT.md#v2-002---managed-agent-pipeline-steps-complete-on-dispatch-metadata`
 - Module: `src/services/pipeline/executor.ts`
 - Related V2 specs: `improvements/v2-08-task-delegation.md`,

--- a/improvements/work3/issues/V2-003-pipeline-run-timeout-does-not-bound-running-steps.md
+++ b/improvements/work3/issues/V2-003-pipeline-run-timeout-does-not-bound-running-steps.md
@@ -1,0 +1,102 @@
+---
+title: "[AUDIT/V2] Pipeline run timeout does not bound already-running steps"
+labels: ["bug", "audit-finding-v2", "high", "v3.0-blocker"]
+milestone: "v3.0 - Production Ready"
+audit-source: "#445"
+finding-id: "V2-003"
+severity: "high"
+category: "performance"
+---
+
+## Problem Description
+
+`PipelineDefinition.timeoutSeconds` is intended to cap the whole run. The
+executor calculates a deadline, but checks it only before starting each
+dependency level. Once a level starts, `Promise.all(...)` waits for every step
+in that level. If a step has no explicit `step.timeoutSeconds` and its
+`processMessage()` call never resolves, the pipeline-level timeout cannot fail
+the run.
+
+## Location
+
+- `src/services/pipeline/executor.ts:117`
+- `src/services/pipeline/executor.ts:125`
+- `src/services/pipeline/executor.ts:136`
+- `src/services/pipeline/executor.ts:281`
+
+## How To Reproduce
+
+```bash
+node improvements/work3/validation/reproduce-findings.mjs
+```
+
+Manual minimal scenario:
+
+1. Create a pipeline with `timeoutSeconds: 1`.
+2. Add one primary-agent step with no `step.timeoutSeconds`.
+3. Use an `AgentRuntime.processMessage()` test double that never resolves.
+4. Start the pipeline and advance timers beyond one second.
+5. Observe that the run remains `running` instead of failing with the pipeline
+   timeout.
+
+## Impact
+
+Operators can configure a run-level timeout and still get stuck pipeline runs.
+Long-running or stalled LLM/tool work can block completion indefinitely and keep
+pipeline state misleadingly active until manual cleanup.
+
+## Proposed Fix
+
+Apply remaining run budget to each step and to the level-level await:
+
+```typescript
+const remainingMs = deadline ? Math.max(0, deadline - Date.now()) : undefined;
+const stepTimeoutSeconds =
+  step.timeoutSeconds ?? (remainingMs ? Math.ceil(remainingMs / 1000) : undefined);
+
+const outputValue = await this.withOptionalTimeout(
+  this.dispatchStep(runId, step, action, context),
+  stepTimeoutSeconds,
+  `Pipeline step "${step.id}"`
+);
+```
+
+Also check cancellation and timeout after each step settles, and mark pending
+steps skipped when the deadline expires.
+
+## Regression Test
+
+```typescript
+it("fails a hung step when only the pipeline run timeout is configured", async () => {
+  vi.useFakeTimers();
+  const processMessage = vi.fn(() => new Promise(() => undefined));
+  const pipeline = store.create({
+    name: "timeout",
+    timeoutSeconds: 1,
+    steps: [{ id: "slow", agent: "primary", action: "never returns", output: "out" }],
+  });
+
+  const promise = executor.execute(pipeline);
+  await vi.advanceTimersByTimeAsync(1_500);
+  const detail = await promise;
+
+  expect(detail.run.status).toBe("failed");
+  expect(detail.run.error).toContain("timed out");
+});
+```
+
+## Acceptance Criteria
+
+- [ ] `PipelineDefinition.timeoutSeconds` bounds total run duration even when
+      individual steps do not define `timeoutSeconds`.
+- [ ] A timed-out run marks running/pending steps as failed or skipped with a
+      clear timeout reason.
+- [ ] Cancellation is checked after long awaits settle and cannot be overwritten
+      by late success.
+- [ ] Regression tests cover hung primary-agent and managed-agent steps.
+
+## Related Artifacts
+
+- Report: `improvements/work3/AUDIT_V2_REPORT.md#v2-003---pipeline-run-timeout-does-not-bound-running-steps`
+- Module: `src/services/pipeline/executor.ts`
+- Related V2 spec: `improvements/v2-09-pipeline-execution.md`

--- a/improvements/work3/issues/V2-003-pipeline-run-timeout-does-not-bound-running-steps.md
+++ b/improvements/work3/issues/V2-003-pipeline-run-timeout-does-not-bound-running-steps.md
@@ -6,6 +6,7 @@ audit-source: "#445"
 finding-id: "V2-003"
 severity: "high"
 category: "performance"
+github-issue: "https://github.com/xlabtg/teleton-agent/issues/449"
 ---
 
 ## Problem Description
@@ -97,6 +98,7 @@ it("fails a hung step when only the pipeline run timeout is configured", async (
 
 ## Related Artifacts
 
+- GitHub issue: https://github.com/xlabtg/teleton-agent/issues/449
 - Report: `improvements/work3/AUDIT_V2_REPORT.md#v2-003---pipeline-run-timeout-does-not-bound-running-steps`
 - Module: `src/services/pipeline/executor.ts`
 - Related V2 spec: `improvements/v2-09-pipeline-execution.md`

--- a/improvements/work3/issues/V2-004-memory-search-skips-semantic-vector-retrieval.md
+++ b/improvements/work3/issues/V2-004-memory-search-skips-semantic-vector-retrieval.md
@@ -1,0 +1,104 @@
+---
+title: "[AUDIT/V2] Memory search API skips semantic vector retrieval"
+labels: ["bug", "audit-finding-v2", "medium", "v3.0-blocker"]
+milestone: "v3.0 - Production Ready"
+audit-source: "#445"
+finding-id: "V2-004"
+severity: "medium"
+category: "ui"
+---
+
+## Problem Description
+
+The `/api/memory/search` route constructs `HybridSearch` with
+`vectorEnabled = false` and passes an empty query embedding to
+`searchKnowledge()`. `HybridSearch` can call the semantic vector store only when
+it receives a non-empty embedding. Therefore the WebUI and Management API memory
+search route remains keyword-only even when semantic vector memory is configured
+and synchronized.
+
+## Location
+
+- `src/webui/routes/memory.ts:95`
+- `src/webui/routes/memory.ts:101`
+- `src/memory/search/hybrid.ts`
+
+## How To Reproduce
+
+```bash
+node improvements/work3/validation/reproduce-findings.mjs
+```
+
+Manual route-level scenario:
+
+1. Configure semantic vector memory and index a memory chunk whose wording is
+   semantically related to, but does not lexically contain, the query.
+2. Call the agent memory search tool and observe semantic results.
+3. Call `/api/memory/search?q=<semantic query>`.
+4. Observe that the API route does not call the embedder/vector store and falls
+   back to keyword-only results.
+
+## Impact
+
+The advertised V2 semantic memory capability is not exposed through the
+operator-facing search API. Users can synchronize vectors successfully but still
+get empty or incomplete memory search results in the UI for natural-language
+queries.
+
+## Proposed Fix
+
+Use the configured memory embedder and vector readiness in the route:
+
+```typescript
+const queryEmbedding = await deps.memory.embedder.embedQuery(query);
+const search = new HybridSearch(
+  deps.memory.db,
+  deps.memory.dbIsVectorReady ?? false,
+  deps.memory.vectorStore,
+  temporalOptions
+);
+const results = await search.searchKnowledge(query, queryEmbedding, options);
+```
+
+If local vector readiness is not available on `WebUIServerDeps`, expose it from
+the memory system or rely on semantic vector store configuration while still
+passing the embedding.
+
+## Regression Test
+
+```typescript
+it("uses embeddings and semantic vector store for memory route search", async () => {
+  const embedder = { embedQuery: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]) };
+  const vectorStore = {
+    isConfigured: true,
+    searchKnowledge: vi
+      .fn()
+      .mockResolvedValue([
+        { id: "semantic", text: "related memory", source: "memory", score: 0.92 },
+      ]),
+  };
+  const app = buildMemoryRoutes({ embedder, vectorStore });
+
+  const res = await app.request("/memory/search?q=meaning based query");
+  const json = await res.json();
+
+  expect(embedder.embedQuery).toHaveBeenCalledWith("meaning based query");
+  expect(vectorStore.searchKnowledge).toHaveBeenCalled();
+  expect(json.data[0].id).toBe("semantic");
+});
+```
+
+## Acceptance Criteria
+
+- [ ] `/api/memory/search` computes a query embedding when embeddings are
+      enabled.
+- [ ] The route calls semantic vector search when a semantic vector store is
+      configured.
+- [ ] Keyword fallback still works when embedding or vector search fails.
+- [ ] Regression tests cover semantic success and fallback behavior.
+
+## Related Artifacts
+
+- Report: `improvements/work3/AUDIT_V2_REPORT.md#v2-004---memory-search-api-skips-semantic-vector-retrieval`
+- Module: `src/webui/routes/memory.ts`
+- Related V2 spec: `improvements/v2-01-semantic-vector-memory.md`

--- a/improvements/work3/issues/V2-004-memory-search-skips-semantic-vector-retrieval.md
+++ b/improvements/work3/issues/V2-004-memory-search-skips-semantic-vector-retrieval.md
@@ -6,6 +6,7 @@ audit-source: "#445"
 finding-id: "V2-004"
 severity: "medium"
 category: "ui"
+github-issue: "https://github.com/xlabtg/teleton-agent/issues/450"
 ---
 
 ## Problem Description
@@ -99,6 +100,7 @@ it("uses embeddings and semantic vector store for memory route search", async ()
 
 ## Related Artifacts
 
+- GitHub issue: https://github.com/xlabtg/teleton-agent/issues/450
 - Report: `improvements/work3/AUDIT_V2_REPORT.md#v2-004---memory-search-api-skips-semantic-vector-retrieval`
 - Module: `src/webui/routes/memory.ts`
 - Related V2 spec: `improvements/v2-01-semantic-vector-memory.md`

--- a/improvements/work3/issues/V2-005-workflow-call-api-actions-have-no-timeout.md
+++ b/improvements/work3/issues/V2-005-workflow-call-api-actions-have-no-timeout.md
@@ -1,0 +1,93 @@
+---
+title: "[AUDIT/V2] Workflow call_api actions have no timeout"
+labels: ["bug", "audit-finding-v2", "medium", "v3.0-blocker"]
+milestone: "v3.0 - Production Ready"
+audit-source: "#445"
+finding-id: "V2-005"
+severity: "medium"
+category: "performance"
+---
+
+## Problem Description
+
+Workflow `call_api` actions await raw `fetch(action.url, init)` with no
+`AbortController`, `AbortSignal.timeout`, or per-action timeout. A slow or
+never-responding endpoint can hang workflow execution indefinitely.
+
+## Location
+
+- `src/services/workflow-executor.ts:51`
+- `src/services/workflow-executor.ts:59`
+- `src/services/workflow-scheduler.ts`
+
+## How To Reproduce
+
+```bash
+node improvements/work3/validation/reproduce-findings.mjs
+```
+
+Manual unit scenario:
+
+1. Create a workflow with one `call_api` action.
+2. Stub global `fetch` to return a promise that never resolves.
+3. Run `WorkflowExecutor.execute(workflow)`.
+4. Observe that the executor never records `last_error` or `last_run_at`
+   because it remains stuck awaiting `fetch()`.
+
+## Impact
+
+Webhook, event, and cron workflows can stall behind one unresponsive endpoint.
+The scheduler awaits the executor, so a hung call can delay later actions and
+leave the workflow with no terminal error state for operators to diagnose.
+
+## Proposed Fix
+
+Add a default timeout and optional action-level override:
+
+```typescript
+const timeoutMs = action.timeoutMs ?? DEFAULT_WORKFLOW_HTTP_TIMEOUT_MS;
+const controller = new AbortController();
+const timer = setTimeout(() => controller.abort(), timeoutMs);
+try {
+  const res = await fetch(action.url, { ...init, signal: controller.signal });
+  if (!res.ok) throw new Error(`HTTP ${res.status} from ${action.url}`);
+} finally {
+  clearTimeout(timer);
+}
+```
+
+Consider reusing integration-layer HTTP execution for shared timeout, SSRF, and
+credential handling instead of maintaining separate raw `fetch()` behavior.
+
+## Regression Test
+
+```typescript
+it("records an error when a call_api action exceeds the default timeout", async () => {
+  vi.useFakeTimers();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => new Promise(() => undefined))
+  );
+
+  const promise = executor.execute(workflowWithCallApi("https://example.com/slow"));
+  await vi.advanceTimersByTimeAsync(DEFAULT_WORKFLOW_HTTP_TIMEOUT_MS + 1);
+  await promise;
+
+  const updated = store.get(workflow.id)!;
+  expect(updated.runCount).toBe(1);
+  expect(updated.lastError).toContain("timed out");
+});
+```
+
+## Acceptance Criteria
+
+- [ ] `call_api` actions have a bounded default timeout.
+- [ ] Optional per-action timeout configuration is validated.
+- [ ] Timed-out calls record workflow errors and do not leave execution pending.
+- [ ] Tests cover success, HTTP error, and timeout paths.
+
+## Related Artifacts
+
+- Report: `improvements/work3/AUDIT_V2_REPORT.md#v2-005---workflow-call_api-actions-have-no-timeout`
+- Module: `src/services/workflow-executor.ts`
+- Related V2 spec: `improvements/v2-16-webhooks-event-bus.md`

--- a/improvements/work3/issues/V2-005-workflow-call-api-actions-have-no-timeout.md
+++ b/improvements/work3/issues/V2-005-workflow-call-api-actions-have-no-timeout.md
@@ -6,6 +6,7 @@ audit-source: "#445"
 finding-id: "V2-005"
 severity: "medium"
 category: "performance"
+github-issue: "https://github.com/xlabtg/teleton-agent/issues/451"
 ---
 
 ## Problem Description
@@ -88,6 +89,7 @@ it("records an error when a call_api action exceeds the default timeout", async 
 
 ## Related Artifacts
 
+- GitHub issue: https://github.com/xlabtg/teleton-agent/issues/451
 - Report: `improvements/work3/AUDIT_V2_REPORT.md#v2-005---workflow-call_api-actions-have-no-timeout`
 - Module: `src/services/workflow-executor.ts`
 - Related V2 spec: `improvements/v2-16-webhooks-event-bus.md`

--- a/improvements/work3/validation/check-artifacts.mjs
+++ b/improvements/work3/validation/check-artifacts.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const root = new URL("..", import.meta.url).pathname;
+const reportPath = join(root, "AUDIT_V2_REPORT.md");
+const issuesDir = join(root, "issues");
+
+const requiredIssueFields = [
+  "title",
+  "labels",
+  "milestone",
+  "audit-source",
+  "finding-id",
+  "severity",
+  "category",
+];
+
+const requiredHeadings = [
+  "## Problem Description",
+  "## Location",
+  "## How To Reproduce",
+  "## Impact",
+  "## Proposed Fix",
+  "## Regression Test",
+  "## Acceptance Criteria",
+  "## Related Artifacts",
+];
+
+function fail(message) {
+  console.error(message);
+  process.exitCode = 1;
+}
+
+if (!existsSync(reportPath)) {
+  fail(`Missing report: ${reportPath}`);
+} else {
+  const report = readFileSync(reportPath, "utf8");
+  for (const id of ["V2-001", "V2-002", "V2-003", "V2-004", "V2-005"]) {
+    if (!report.includes(id)) fail(`Report does not reference ${id}`);
+  }
+}
+
+if (!existsSync(issuesDir)) {
+  fail(`Missing issues directory: ${issuesDir}`);
+} else {
+  const files = readdirSync(issuesDir)
+    .filter((file) => file.endsWith(".md"))
+    .sort();
+  if (files.length !== 5) fail(`Expected 5 issue files, found ${files.length}`);
+
+  for (const file of files) {
+    const body = readFileSync(join(issuesDir, file), "utf8");
+    const frontmatter = body.match(/^---\n([\s\S]*?)\n---/);
+    if (!frontmatter) {
+      fail(`${file}: missing YAML frontmatter`);
+      continue;
+    }
+    for (const field of requiredIssueFields) {
+      if (!new RegExp(`^${field}:`, "m").test(frontmatter[1])) {
+        fail(`${file}: missing frontmatter field ${field}`);
+      }
+    }
+    for (const heading of requiredHeadings) {
+      if (!body.includes(heading)) fail(`${file}: missing ${heading}`);
+    }
+  }
+}
+
+if (process.exitCode) {
+  process.exit();
+}
+
+console.log("work3 audit artifacts are structurally valid");

--- a/improvements/work3/validation/reproduce-findings.mjs
+++ b/improvements/work3/validation/reproduce-findings.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+function read(path) {
+  return readFileSync(path, "utf8");
+}
+
+const files = {
+  webuiServer: read("src/webui/server.ts"),
+  csrf: read("src/webui/middleware/csrf.ts"),
+  pipelineExecutor: read("src/services/pipeline/executor.ts"),
+  memoryRoutes: read("src/webui/routes/memory.ts"),
+  workflowExecutor: read("src/services/workflow-executor.ts"),
+};
+
+const checks = [
+  {
+    id: "V2-001",
+    description: "public webhook ingress is still not bypassed in auth/CSRF middleware",
+    present:
+      files.webuiServer.includes('if (c.req.path === "/api/agent-network")') &&
+      !files.webuiServer.includes("/api/webhooks/incoming") &&
+      !files.webuiServer.includes("/api/workflows/webhook") &&
+      files.csrf.includes('path === "/api/agent-network"') &&
+      !files.csrf.includes("/api/webhooks/incoming") &&
+      !files.csrf.includes("/api/workflows/webhook"),
+  },
+  {
+    id: "V2-002",
+    description: "managed pipeline steps still return dispatch metadata as output",
+    present:
+      files.pipelineExecutor.includes("this.deps.agentManager.sendMessage") &&
+      files.pipelineExecutor.includes("messageId: message.id") &&
+      files.pipelineExecutor.includes("toAgentId: agent.id"),
+  },
+  {
+    id: "V2-003",
+    description: "pipeline timeout is still checked only around levels/step-specific timeouts",
+    present:
+      files.pipelineExecutor.includes("const deadline =") &&
+      files.pipelineExecutor.includes("await Promise.all(") &&
+      files.pipelineExecutor.includes("step.timeoutSeconds") &&
+      !files.pipelineExecutor.includes("pipelineRemainingTimeout"),
+  },
+  {
+    id: "V2-004",
+    description: "memory route search still passes vectorEnabled=false and an empty embedding",
+    present:
+      files.memoryRoutes.includes("new HybridSearch(deps.memory.db, false") &&
+      files.memoryRoutes.includes("search.searchKnowledge(query, []"),
+  },
+  {
+    id: "V2-005",
+    description: "workflow call_api still awaits raw fetch without an abort signal",
+    present:
+      files.workflowExecutor.includes("await fetch(action.url, init)") &&
+      !files.workflowExecutor.includes("AbortSignal.timeout") &&
+      !files.workflowExecutor.includes("AbortController"),
+  },
+];
+
+const present = checks.filter((check) => check.present);
+
+for (const check of checks) {
+  const status = check.present ? "PRESENT" : "not detected";
+  console.log(`${check.id}: ${status} - ${check.description}`);
+}
+
+if (present.length > 0) {
+  console.error(`\n${present.length} audit finding(s) are still reproducible.`);
+  process.exit(1);
+}
+
+console.log("\nNo tracked audit findings detected.");


### PR DESCRIPTION
Fixes xlabtg/teleton-agent#445

## Summary

- Added `improvements/work3/AUDIT_V2_REPORT.md` with the full V2 architecture audit for issue #445.
- Added `improvements/work3/issues/` with five ready-to-import follow-up issue templates.
- Created the real upstream follow-up issues and linked them back from the report, README, and task templates: #447, #448, #449, #450, #451.
- Added `improvements/work3/audit-config.yaml` and validation scripts for artifact structure and current-code finding reproduction.
- Updated `improvements/work3/README.md` so the #445 audit is indexed beside the previous #398 work3 audit.

## Confirmed findings

| ID | Severity | GitHub issue | Summary |
| --- | --- | --- | --- |
| V2-001 | High | #447 | Public V2 webhook/workflow ingress is blocked by global WebUI auth and CSRF. |
| V2-002 | High | #448 | Delegated managed-agent pipeline steps complete on dispatch metadata instead of remote results. |
| V2-003 | High | #449 | Pipeline-level timeout does not bound already-running steps. |
| V2-004 | Medium | #450 | `/api/memory/search` bypasses embeddings and semantic vector retrieval. |
| V2-005 | Medium | #451 | Workflow `call_api` actions await raw `fetch()` without a timeout or abort path. |

## GitHub issue metadata note

The created issue bodies include the requested frontmatter for labels, milestone, audit source, finding id, severity, and category. The automation token has `READ` permission on `xlabtg/teleton-agent`, so GitHub allowed issue creation but rejected label/milestone management. Maintainers with triage/write access should apply the frontmatter labels, assignment, and `v3.0 - Production Ready` milestone in GitHub.

## Validation

- `npm ci --ignore-scripts`
- `npm run build:sdk`
- `npm rebuild better-sqlite3`
- `node improvements/work3/validation/check-artifacts.mjs`
- `node improvements/work3/validation/reproduce-findings.mjs` exits 1 as expected while all five audited findings are still present
- `npx prettier --check "improvements/work3/**/*.md" "improvements/work3/**/*.yaml" "improvements/work3/**/*.mjs"`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test` (`202` test files, `3473` tests)
