### PR TITLE
fix: enable semantic memory route search

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
+# Updated: 2026-04-27T23:30:11.151Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,3 @@
+# .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
+# Updated: 2026-04-26T15:08:27.505Z
+# Updated: 2026-04-26T15:59:46.481Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
-# Updated: 2026-04-26T15:08:27.505Z
-# Updated: 2026-04-26T15:59:46.481Z
-# Updated: 2026-04-27T23:30:11.151Z

--- a/src/api/deps.ts
+++ b/src/api/deps.ts
@@ -18,6 +18,7 @@ export interface ApiServerDeps {
   bridge?: TelegramBridge | null;
   memory?: {
     db: Database;
+    vectorEnabled?: MemorySystem["vectorEnabled"];
     embedder: MemorySystem["embedder"];
     knowledge: MemorySystem["knowledge"];
     vectorStore?: MemorySystem["vectorStore"];

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -32,6 +32,7 @@ import type { TemporalContextConfig } from "../services/temporal-context.js";
 
 export interface MemorySystem {
   db: Database.Database;
+  vectorEnabled: boolean;
   embedder: ReturnType<typeof createEmbeddingProvider>;
   knowledge: KnowledgeIndexer;
   messages: MessageStore;
@@ -87,6 +88,7 @@ export function initializeMemory(config: {
 
   return {
     db: database,
+    vectorEnabled,
     embedder,
     knowledge: new KnowledgeIndexer(
       database,

--- a/src/webui/__tests__/memory-routes.test.ts
+++ b/src/webui/__tests__/memory-routes.test.ts
@@ -27,6 +27,22 @@ function createTestApp(overrides: Partial<WebUIServerDeps>) {
   return app;
 }
 
+function createMemoryDb(): InstanceType<typeof Database> {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  ensureSchema(db);
+  return db;
+}
+
+function insertKnowledge(db: InstanceType<typeof Database>, id: string, text: string): void {
+  db.prepare(
+    `
+      INSERT INTO knowledge (id, source, text, hash)
+      VALUES (?, 'memory', ?, ?)
+    `
+  ).run(id, text, `hash-${id}`);
+}
+
 describe("memory routes", () => {
   let db: InstanceType<typeof Database> | null = null;
 
@@ -192,10 +208,124 @@ describe("memory routes", () => {
     expect(json.data.message).toContain("not configured");
   });
 
+  it("uses embeddings and semantic vector store for memory route search", async () => {
+    db = createMemoryDb();
+    const embedder = {
+      id: "test",
+      model: "test-model",
+      dimensions: 3,
+      embedQuery: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+      embedBatch: vi.fn(),
+    };
+    const vectorStore = {
+      isConfigured: true,
+      namespace: "teleton-memory",
+      healthCheck: vi.fn(),
+      searchKnowledge: vi.fn().mockResolvedValue([
+        {
+          id: "semantic-memory",
+          text: "Semantically related memory",
+          source: "memory",
+          score: 0.92,
+          vectorScore: 0.92,
+        },
+      ]),
+    };
+
+    const app = createTestApp({
+      memory: {
+        db,
+        embedder,
+        knowledge: { indexAll: vi.fn() } as unknown as WebUIServerDeps["memory"]["knowledge"],
+        vectorStore: vectorStore as unknown as WebUIServerDeps["memory"]["vectorStore"],
+      },
+    });
+
+    const res = await app.request("/api/memory/search?q=meaning%20based%20query");
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(embedder.embedQuery).toHaveBeenCalledWith("meaning based query");
+    expect(vectorStore.searchKnowledge).toHaveBeenCalledWith([0.1, 0.2, 0.3], 30);
+    expect(json.success).toBe(true);
+    expect(json.data[0].id).toBe("semantic-memory");
+  });
+
+  it("falls back to keyword memory search when route embedding fails", async () => {
+    db = createMemoryDb();
+    insertKnowledge(db, "keyword-embedding-fallback", "route embedding fallback keyword target");
+    const embedder = {
+      id: "test",
+      model: "test-model",
+      dimensions: 3,
+      embedQuery: vi.fn().mockRejectedValue(new Error("embedding unavailable")),
+      embedBatch: vi.fn(),
+    };
+
+    const app = createTestApp({
+      memory: {
+        db,
+        embedder,
+        knowledge: { indexAll: vi.fn() } as unknown as WebUIServerDeps["memory"]["knowledge"],
+        vectorStore: {
+          isConfigured: true,
+          namespace: "teleton-memory",
+          healthCheck: vi.fn(),
+        } as unknown as WebUIServerDeps["memory"]["vectorStore"],
+      },
+    });
+
+    const res = await app.request("/api/memory/search?q=route%20embedding%20fallback%20keyword");
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(embedder.embedQuery).toHaveBeenCalledWith("route embedding fallback keyword");
+    expect(json.success).toBe(true);
+    expect(json.data.map((result: { id: string }) => result.id)).toContain(
+      "keyword-embedding-fallback"
+    );
+  });
+
+  it("falls back to keyword memory search when semantic vector search fails", async () => {
+    db = createMemoryDb();
+    insertKnowledge(db, "keyword-vector-fallback", "route vector fallback keyword target");
+    const embedder = {
+      id: "test",
+      model: "test-model",
+      dimensions: 3,
+      embedQuery: vi.fn().mockResolvedValue([0.4, 0.5, 0.6]),
+      embedBatch: vi.fn(),
+    };
+    const vectorStore = {
+      isConfigured: true,
+      namespace: "teleton-memory",
+      healthCheck: vi.fn(),
+      searchKnowledge: vi.fn().mockRejectedValue(new Error("vector unavailable")),
+    };
+
+    const app = createTestApp({
+      memory: {
+        db,
+        embedder,
+        knowledge: { indexAll: vi.fn() } as unknown as WebUIServerDeps["memory"]["knowledge"],
+        vectorStore: vectorStore as unknown as WebUIServerDeps["memory"]["vectorStore"],
+      },
+    });
+
+    const res = await app.request("/api/memory/search?q=route%20vector%20fallback%20keyword");
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(embedder.embedQuery).toHaveBeenCalledWith("route vector fallback keyword");
+    expect(vectorStore.searchKnowledge).toHaveBeenCalledWith([0.4, 0.5, 0.6], 30);
+    expect(json.success).toBe(true);
+    expect(json.data.map((result: { id: string }) => result.id)).toContain(
+      "keyword-vector-fallback"
+    );
+  });
+
   it("exposes memory graph nodes, related traversal, path, and task context", async () => {
-    db = new Database(":memory:");
-    db.pragma("foreign_keys = ON");
-    ensureSchema(db);
+    db = createMemoryDb();
     const store = new MemoryGraphStore(db);
     const conversation = store.upsertNode({ type: "conversation", label: "Telegram chat 42" });
     const task = store.upsertNode({
@@ -244,9 +374,7 @@ describe("memory routes", () => {
   });
 
   it("filters memory search by minimum score and exposes priority management endpoints", async () => {
-    db = new Database(":memory:");
-    db.pragma("foreign_keys = ON");
-    ensureSchema(db);
+    db = createMemoryDb();
     db.prepare(
       `
       INSERT INTO knowledge (id, source, text, hash)

--- a/src/webui/routes/memory.ts
+++ b/src/webui/routes/memory.ts
@@ -14,6 +14,9 @@ import { HybridSearch } from "../../memory/search/hybrid.js";
 import { MemoryScorer } from "../../memory/scoring.js";
 import { MemoryRetentionService } from "../../memory/retention.js";
 import type { SemanticVectorIndexStats } from "../../memory/agent/knowledge.js";
+import { createLogger } from "../../utils/logger.js";
+
+const log = createLogger("memory-routes");
 
 function vectorSyncUnavailableMessage(mode: MemoryVectorSyncResult["status"]["mode"]): string {
   if (mode === "standby") {
@@ -92,13 +95,24 @@ export function createMemoryRoutes(deps: WebUIServerDeps) {
       }
 
       const temporalConfig = deps.agent?.getConfig?.()?.temporal_context;
-      const search = new HybridSearch(deps.memory.db, false, deps.memory.vectorStore, {
+      const vectorEnabled = deps.memory.vectorEnabled ?? false;
+      let queryEmbedding: number[] = [];
+      const shouldEmbed = vectorEnabled || (deps.memory.vectorStore?.isConfigured ?? false);
+      if (shouldEmbed) {
+        try {
+          queryEmbedding = await deps.memory.embedder.embedQuery(query);
+        } catch (error) {
+          log.warn({ err: error }, "Memory route search embedding failed; using keyword fallback");
+        }
+      }
+
+      const search = new HybridSearch(deps.memory.db, vectorEnabled, deps.memory.vectorStore, {
         ...temporalConfig?.weighting,
         enabled:
           temporalConfig?.enabled === false ? false : (temporalConfig?.weighting.enabled ?? true),
         timezone: temporalConfig?.timezone,
       });
-      const results = await search.searchKnowledge(query, [], {
+      const results = await search.searchKnowledge(query, queryEmbedding, {
         limit,
         minScore: Number.isFinite(minScore) ? minScore : undefined,
         priorityWeight: 0.25,

--- a/src/webui/types.ts
+++ b/src/webui/types.ts
@@ -34,6 +34,7 @@ export interface WebUIServerDeps {
   bridge: TelegramBridge;
   memory: {
     db: Database;
+    vectorEnabled?: MemorySystem["vectorEnabled"];
     embedder: MemorySystem["embedder"];
     knowledge: MemorySystem["knowledge"];
     vectorStore?: MemorySystem["vectorStore"];


### PR DESCRIPTION
## Summary
- Enables `/api/memory/search` and `/v1/memory/search` to compute query embeddings when local or semantic vector memory is available.
- Passes actual local vector readiness into `HybridSearch` and keeps keyword fallback when embedding generation or semantic vector search fails.
- Adds regression coverage for semantic vector route success plus embedding/vector fallback behavior.

Fixes xlabtg/teleton-agent#450

## Reproduction
Before the fix, the new route-level test failed because `embedQuery` was never called by `/api/memory/search`, so `HybridSearch` received an empty embedding and skipped semantic vector retrieval.

The audit reproduction script now reports `V2-004: not detected`; it still exits non-zero because unrelated V2-001, V2-002, V2-003, and V2-005 findings remain reproducible.

## Verification
- `npx vitest run src/webui/__tests__/memory-routes.test.ts`
- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run format:check`
- `npm run build`
- `npm run audit:ci`
- `npm run test:coverage`
- `node improvements/work3/validation/reproduce-findings.mjs` (V2-004 not detected; exits non-zero for unrelated open findings)
