### PR TITLE
deprecate(tools): mark telegram_schedule_message as deprecated; steer LLM to telegram_create_scheduled_task

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
-# Updated: 2026-04-29T09:12:33.432Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
+# Updated: 2026-04-29T09:12:33.432Z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+- **`telegram_schedule_message` agent tool**: Now logs a runtime deprecation warning and surfaces `deprecated: true` plus a `deprecationNotice` field in its result. The tool only queues plain text and cannot execute tools, trading functions, or multi-step workflows when the message is delivered, which silently breaks any automation that relies on it. Use `telegram_create_scheduled_task` (with a `tool_call` or `agent_task` payload) for any automation that must run at a scheduled time. The tool description now leads with `[DEPRECATED — use telegram_create_scheduled_task instead]` so the LLM picks the correct tool by default (closes xlabtg/teleton-agent#459).
+
 ### Added
 - **Bot API HTTPS proxy (`mtproto.bot_api_proxy`)**: Optional HTTP/HTTPS or SOCKS5 proxy URL for Telegram Bot API HTTPS calls to `api.telegram.org`. MTProto proxies cannot tunnel HTTPS, so this lets the deals bot reach the Bot API in regions where Telegram is also blocked at the IP level. Wired through to Grammy's `client.baseFetchConfig.agent` via `https-proxy-agent` / `socks-proxy-agent` (closes xlabtg/teleton-agent#439).
 

--- a/src/agent/tools/telegram/messaging/__tests__/schedule-message-deprecation.test.ts
+++ b/src/agent/tools/telegram/messaging/__tests__/schedule-message-deprecation.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Api } from "telegram";
+import {
+  telegramScheduleMessageTool,
+  telegramScheduleMessageExecutor,
+  TELEGRAM_SCHEDULE_MESSAGE_DEPRECATION_NOTICE,
+} from "../schedule-message.js";
+import { addLogListener, type LogListener } from "../../../../../utils/logger.js";
+import type { ToolContext } from "../../../types.js";
+
+const mockInvoke = vi.fn();
+const mockGetEntity = vi.fn();
+
+const mockContext = {
+  bridge: {
+    getClient: () => ({
+      getClient: () => ({
+        invoke: mockInvoke,
+        getEntity: mockGetEntity,
+      }),
+    }),
+  },
+  chatId: "123",
+  senderId: 456,
+  isGroup: false,
+} as unknown as ToolContext;
+
+function buildEmptyUpdates(): Api.Updates {
+  // Build an Api.Updates instance the executor's `instanceof` check will accept.
+  const updates = Object.create(Api.Updates.prototype) as Api.Updates;
+  (updates as { updates: unknown[] }).updates = [];
+  return updates;
+}
+
+describe("telegram_schedule_message deprecation (issue #459)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks the tool as deprecated in its description so the LLM prefers the replacement", () => {
+    expect(telegramScheduleMessageTool.description).toMatch(/\[DEPRECATED/i);
+    expect(telegramScheduleMessageTool.description).toContain("telegram_create_scheduled_task");
+  });
+
+  it("exposes a deprecation notice constant that names the replacement tool", () => {
+    expect(TELEGRAM_SCHEDULE_MESSAGE_DEPRECATION_NOTICE).toMatch(/DEPRECATED/i);
+    expect(TELEGRAM_SCHEDULE_MESSAGE_DEPRECATION_NOTICE).toContain(
+      "telegram_create_scheduled_task"
+    );
+  });
+
+  it("returns deprecated: true and the notice in the success result so the LLM gets it back", async () => {
+    mockGetEntity.mockResolvedValue({ className: "User", id: 1n });
+    mockInvoke.mockResolvedValue(buildEmptyUpdates());
+
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const result = await telegramScheduleMessageExecutor(
+      { chatId: "123", text: "hi", scheduleDate: future },
+      mockContext
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as Record<string, unknown>;
+    expect(data.deprecated).toBe(true);
+    expect(data.deprecationNotice).toBe(TELEGRAM_SCHEDULE_MESSAGE_DEPRECATION_NOTICE);
+  });
+
+  it("rejects past schedule dates without sending the message", async () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const result = await telegramScheduleMessageExecutor(
+      { chatId: "123", text: "hi", scheduleDate: past },
+      mockContext
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/future/i);
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  describe("runtime deprecation warning", () => {
+    let entries: Array<{ level: string; message: string }>;
+    let removeListener: () => void;
+
+    beforeEach(() => {
+      entries = [];
+      const listener: LogListener = (entry) => {
+        entries.push({ level: entry.level, message: entry.message });
+      };
+      removeListener = addLogListener(listener);
+    });
+
+    afterEach(() => {
+      removeListener();
+    });
+
+    it("emits a warn-level log naming the replacement tool when invoked", async () => {
+      mockGetEntity.mockResolvedValue({ className: "User", id: 1n });
+      mockInvoke.mockResolvedValue(buildEmptyUpdates());
+
+      const future = new Date(Date.now() + 60_000).toISOString();
+      await telegramScheduleMessageExecutor(
+        { chatId: "123", text: "hi", scheduleDate: future },
+        mockContext
+      );
+
+      const deprecationWarn = entries.find(
+        (e) => e.level === "warn" && e.message.includes("DEPRECATED")
+      );
+      expect(deprecationWarn).toBeDefined();
+      expect(deprecationWarn?.message).toContain("telegram_create_scheduled_task");
+    });
+  });
+});

--- a/src/agent/tools/telegram/messaging/schedule-message.ts
+++ b/src/agent/tools/telegram/messaging/schedule-message.ts
@@ -18,12 +18,25 @@ interface ScheduleMessageParams {
 }
 
 /**
+ * Deprecation warning shown to the LLM and logged at runtime.
+ * Kept as a constant so tests can assert on the same string.
+ */
+export const TELEGRAM_SCHEDULE_MESSAGE_DEPRECATION_NOTICE =
+  "telegram_schedule_message is DEPRECATED and will be removed in a future release. " +
+  "It only queues plain text — it cannot execute tools, trading functions, or multi-step workflows. " +
+  "Use telegram_create_scheduled_task instead (with a tool_call or agent_task payload) for any automation that must run at a scheduled time.";
+
+/**
  * Tool definition for scheduling Telegram messages
+ *
+ * @deprecated Use telegram_create_scheduled_task instead. This tool only queues
+ * plain text and cannot trigger tool calls or agent actions when the message
+ * is delivered. See issue #459.
  */
 export const telegramScheduleMessageTool: Tool = {
   name: "telegram_schedule_message",
   description:
-    "Queue a text message for delayed delivery at a specific date/time. Sends ONLY text — does NOT execute any functions or tools automatically. Pass scheduleDate as ISO 8601 string or Unix timestamp (must be in the future). When NOT to use: if you need to automatically run trading functions, execute tools, or perform multi-step workflows at a scheduled time, use telegram_create_scheduled_task with an agent_task payload instead. Manage pending messages with telegram_get_scheduled_messages.",
+    "[DEPRECATED — use telegram_create_scheduled_task instead] Queue a plain text message for delayed delivery at a specific date/time. Sends ONLY text — does NOT execute any functions, tools, or agent instructions, even if the message text reads like a command (e.g., 'Check TON price', 'Buy USDT'). Pass scheduleDate as ISO 8601 string or Unix timestamp (must be in the future). For ANY automation that must run at a scheduled time — trading functions, tool calls, multi-step workflows, recurring tasks — use telegram_create_scheduled_task with a tool_call or agent_task payload. Manage pending messages with telegram_get_scheduled_messages.",
   parameters: Type.Object({
     chatId: Type.String({
       description: "The chat ID to send the scheduled message to",
@@ -46,6 +59,11 @@ export const telegramScheduleMessageExecutor: ToolExecutor<ScheduleMessageParams
   params,
   context
 ): Promise<ToolResult> => {
+  log.warn(
+    { tool: "telegram_schedule_message", replacement: "telegram_create_scheduled_task" },
+    TELEGRAM_SCHEDULE_MESSAGE_DEPRECATION_NOTICE
+  );
+
   try {
     const { chatId, text, scheduleDate } = params;
 
@@ -107,6 +125,8 @@ export const telegramScheduleMessageExecutor: ToolExecutor<ScheduleMessageParams
         chatId,
         scheduledFor: new Date(scheduleTimestamp * 1000).toISOString(),
         messageId,
+        deprecated: true,
+        deprecationNotice: TELEGRAM_SCHEDULE_MESSAGE_DEPRECATION_NOTICE,
       },
     };
   } catch (error) {


### PR DESCRIPTION
## Summary

Closes xlabtg/teleton-agent#459.

`telegram_schedule_message` queues plain text only — Telegram never parses or executes the message body, so any \"Check TON price\" / \"Buy USDT\" instructions inside a scheduled message are silently ignored. This silently breaks every automation flow that relied on it.

This PR makes that breakage **loud** by deprecating the tool in three layers (description, runtime log, result payload) so the LLM, the operator, and the audit trail all see the same warning, and steers users to the correct replacement, `telegram_create_scheduled_task`, which actually executes tool calls and agent instructions at the scheduled time.

## What changed

- `src/agent/tools/telegram/messaging/schedule-message.ts`
  - Prepend `[DEPRECATED — use telegram_create_scheduled_task instead]` to the tool description so the LLM picks the correct tool by default, and the WebUI Tools page surfaces the deprecation prominently.
  - Log a `warn`-level deprecation notice on every invocation, with a structured payload (`{ tool, replacement }`) for log analytics and SIEM.
  - Add `deprecated: true` and a `deprecationNotice` string to the success result so the LLM gets the warning back as part of the tool output and can self-correct mid-conversation.
  - Export `TELEGRAM_SCHEDULE_MESSAGE_DEPRECATION_NOTICE` so tests and callers share a single source of truth for the message.
  - Add a `@deprecated` JSDoc tag on the tool definition so any IDE picks it up.
- `src/agent/tools/telegram/messaging/__tests__/schedule-message-deprecation.test.ts` (new) — 5 unit tests covering:
  - Description contains the `[DEPRECATED ...]` prefix and names the replacement.
  - Notice constant is non-empty and names the replacement.
  - Success result contains `deprecated: true` and the notice.
  - Past-date validation still rejects without sending.
  - The `warn`-level log fan-out fires through the existing `addLogListener` bus, with a message that includes `DEPRECATED` and `telegram_create_scheduled_task`.
- `CHANGELOG.md` — `[Unreleased] → Deprecated` entry pointing to the issue.

## What did NOT change

- The executor still successfully schedules plain-text messages — existing integrations that legitimately want to queue a delayed text-only Telegram message keep working.
- The tool is not removed or unregistered. Removal will be done in a future major release once the warnings have soaked.
- `telegram_create_scheduled_task` itself is unchanged — its description already steered users away from `telegram_schedule_message` for tool execution; the change here is on the deprecated side of the pair.

## How to reproduce / verify

Before this PR — calling `telegram_schedule_message` with text like \"Check TON price\" succeeded silently and never executed anything at delivery time, with no warning anywhere.

After this PR:

1. The tool description shown to the LLM begins with `[DEPRECATED — use telegram_create_scheduled_task instead]`, so the LLM prefers `telegram_create_scheduled_task` for any automation request.
2. If the tool is still invoked, the executor logs:
   ```
   WARN [Tools] telegram_schedule_message is DEPRECATED ... Use telegram_create_scheduled_task instead ...
   ```
   with structured fields `{ tool: \"telegram_schedule_message\", replacement: \"telegram_create_scheduled_task\" }`.
3. The successful result payload now includes:
   ```json
   { \"deprecated\": true, \"deprecationNotice\": \"telegram_schedule_message is DEPRECATED ...\" }
   ```
   which is fed back to the LLM in the next turn.

## Test plan

- [x] `npx vitest run src/agent/tools/telegram/messaging/__tests__/schedule-message-deprecation.test.ts` — 5/5 pass
- [x] `npx vitest run src/agent/tools/telegram` — 113/113 pass (no regressions in the wider Telegram tools suite)
- [x] `npx vitest run src/docs/__tests__/user-guide.test.ts` — 3/3 pass (CHANGELOG-adjacent docs lint)
- [x] `npx eslint src/agent/tools/telegram/messaging/schedule-message.ts src/agent/tools/telegram/messaging/__tests__/schedule-message-deprecation.test.ts --max-warnings 0` — clean
- [x] `npx tsc --noEmit` — clean (after `npm run build:sdk` to materialize the workspace package)