### PR TITLE
fix(bot): silence "Aborted delay" polling log on Ctrl+C shutdown

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
+# Updated: 2026-04-29T09:12:45.802Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
-# Updated: 2026-04-29T09:12:45.802Z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Bot API HTTPS proxy (`mtproto.bot_api_proxy`)**: Optional HTTP/HTTPS or SOCKS5 proxy URL for Telegram Bot API HTTPS calls to `api.telegram.org`. MTProto proxies cannot tunnel HTTPS, so this lets the deals bot reach the Bot API in regions where Telegram is also blocked at the IP level. Wired through to Grammy's `client.baseFetchConfig.agent` via `https-proxy-agent` / `socks-proxy-agent` (closes xlabtg/teleton-agent#439).
 
 ### Fixed
+- **Spurious `[Bot] Polling error: Aborted delay` on Ctrl+C**: `DealBot.start()` no longer logs the polling promise rejection that Grammy raises when `bot.stop()` aborts the in-flight long-poll delay. Stopping the agent (especially with the MTProxy path active) is now silent on the polling channel, while real polling failures during normal operation continue to be logged (closes xlabtg/teleton-agent#460).
 - **WorkflowScheduler cron deduplication (AUDIT-M7)**: `tick()` now tracks `runningWorkflowIds` (in-memory `Set`) to skip workflows whose previous execution is still in progress, and persists `last_fired_bucket` (`floor(ms/60000)`) to the DB so the same minute bucket never fires twice — even after a process restart. DB migration 1.26.0 adds the `last_fired_bucket` column to `workflows` (closes xlabtg/teleton-agent#327).
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teleton",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "workspaces": [
     "packages/*"
   ],

--- a/src/bot/__tests__/deal-bot-shutdown.test.ts
+++ b/src/bot/__tests__/deal-bot-shutdown.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type Database from "better-sqlite3";
+
+const {
+  mockBotStart,
+  mockBotStop,
+  mockBotOn,
+  mockBotUse,
+  mockBotCatch,
+  mockGramjsConnect,
+  mockGramjsDisconnect,
+  mockGramjsIsConnected,
+  mockLogError,
+  mockLogInfo,
+  mockLogWarn,
+  mockLogDebug,
+} = vi.hoisted(() => ({
+  mockBotStart: vi.fn(),
+  mockBotStop: vi.fn(),
+  mockBotOn: vi.fn(),
+  mockBotUse: vi.fn(),
+  mockBotCatch: vi.fn(),
+  mockGramjsConnect: vi.fn(),
+  mockGramjsDisconnect: vi.fn(),
+  mockGramjsIsConnected: vi.fn(),
+  mockLogError: vi.fn(),
+  mockLogInfo: vi.fn(),
+  mockLogWarn: vi.fn(),
+  mockLogDebug: vi.fn(),
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: vi.fn(() => ({
+    info: mockLogInfo,
+    warn: mockLogWarn,
+    error: mockLogError,
+    debug: mockLogDebug,
+  })),
+}));
+
+vi.mock("grammy", () => {
+  class Bot {
+    api = {
+      editMessageTextInline: vi.fn(),
+    };
+    botInfo = { id: 123456, username: "tony_idbot", first_name: "Tony" };
+    on = mockBotOn;
+    use = mockBotUse;
+    catch = mockBotCatch;
+    start = mockBotStart;
+    stop = mockBotStop;
+  }
+
+  class InlineKeyboard {
+    row = vi.fn(() => this);
+    text = vi.fn(() => this);
+    copyText = vi.fn(() => this);
+  }
+
+  return { Bot, InlineKeyboard };
+});
+
+vi.mock("../gramjs-bot.js", () => ({
+  GramJSBotClient: class {
+    connect = mockGramjsConnect;
+    disconnect = mockGramjsDisconnect;
+    isConnected = mockGramjsIsConnected;
+    answerInlineQuery = vi.fn();
+    editInlineMessageByStringId = vi.fn();
+  },
+}));
+
+import { DealBot } from "../index.js";
+
+describe("DealBot shutdown", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBotStop.mockResolvedValue(undefined);
+    mockGramjsConnect.mockResolvedValue(undefined);
+    mockGramjsDisconnect.mockResolvedValue(undefined);
+    mockGramjsIsConnected.mockReturnValue(false);
+  });
+
+  function makeBot(): DealBot {
+    return new DealBot(
+      {
+        token: "123456:ABC-DEF",
+        username: "tony_idbot",
+        apiId: 12345,
+        apiHash: "hash",
+        gramjsSessionPath: "/tmp/gramjs-bot-session",
+      },
+      {} as Database.Database
+    );
+  }
+
+  it("does not log a Polling error when bot.start() rejects after stop() is called", async () => {
+    // Simulate Grammy's behavior: bot.start() rejects with "Aborted delay" once bot.stop() runs.
+    let rejectStart: ((err: Error) => void) | undefined;
+    mockBotStart.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectStart = reject;
+        })
+    );
+    mockBotStop.mockImplementationOnce(async () => {
+      // Grammy aborts the polling loop's pending delay
+      rejectStart?.(new Error("Aborted delay"));
+    });
+
+    const bot = makeBot();
+    await bot.start();
+    await bot.stop();
+    // Allow the bot.start() rejection to propagate to its .catch handler.
+    await new Promise((r) => setTimeout(r, 0));
+
+    const polling = mockLogError.mock.calls.find((args) =>
+      args.some((a) => typeof a === "string" && a.includes("Polling error"))
+    );
+    expect(polling).toBeUndefined();
+  });
+
+  it("still logs Polling error when bot.start() rejects without an explicit stop()", async () => {
+    let rejectStart: ((err: Error) => void) | undefined;
+    mockBotStart.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectStart = reject;
+        })
+    );
+
+    const bot = makeBot();
+    await bot.start();
+    rejectStart?.(new Error("Connection refused"));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const polling = mockLogError.mock.calls.find((args) =>
+      args.some((a) => typeof a === "string" && a.includes("Polling error"))
+    );
+    expect(polling).toBeDefined();
+  });
+});

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -75,6 +75,7 @@ export class DealBot {
   private db: Database.Database;
   private config: BotConfig;
   private gramjsBot: GramJSBotClient | null = null;
+  private stopping = false;
 
   constructor(config: BotConfig, db: Database.Database, preMiddleware?: MiddlewareFn<Context>) {
     this.config = config;
@@ -538,6 +539,9 @@ export class DealBot {
         onStart: () => log.info(`🤖 [Bot] @${this.config.username} polling started`),
       })
       .catch((err) => {
+        // bot.stop() aborts the polling loop's pending delay, surfacing here as
+        // "Aborted delay". That's an expected shutdown signal, not a real error.
+        if (this.stopping) return;
         log.error({ err }, "[Bot] Polling error");
       });
   }
@@ -563,6 +567,7 @@ export class DealBot {
    */
   async stop(): Promise<void> {
     log.info(`🛑 [Bot] Stopping @${this.config.username}...`);
+    this.stopping = true;
     await this.bot.stop();
     if (this.gramjsBot) {
       await this.gramjsBot.disconnect();


### PR DESCRIPTION
## Summary

When the agent is stopped (Ctrl+C), Grammy's `bot.stop()` aborts the polling loop's pending long-poll delay through an `AbortController`. The resulting rejection surfaces in `DealBot.start()`'s `.catch(...)` handler and was being logged as:

```
[Bot] Polling error
  err: { type: "Error", message: "Aborted delay", stack: ... at Bot.stop (...grammy/out/bot.js:341) }
```

This is misleading — it looks like a real failure but is just Grammy's normal shutdown signal. The annoyance was especially visible on the MTProxy path, where the shutdown sequence is slower.

This PR adds a `stopping` flag to `DealBot` that is set inside `stop()`. The `.catch` handler in `start()` now suppresses the log when the rejection arrives during shutdown. Real polling failures during normal operation continue to be logged.

## Changes

- `src/bot/index.ts`: track `stopping` and skip the `[Bot] Polling error` log when the rejection arrives during a shutdown.
- `src/bot/__tests__/deal-bot-shutdown.test.ts` *(new)*: regression tests covering both the suppressed-during-shutdown case and the still-logged-during-runtime case.
- `CHANGELOG.md`: note under `[Unreleased] / Fixed`.
- `package.json`: bump to `0.8.17`.

## How to reproduce (before this PR)

1. Configure `mtproto.enabled: true` with at least one proxy.
2. `npm start`, wait for `[Bot] @… polling started`.
3. Press Ctrl+C.
4. Observe `ERROR: [Bot] Polling error … Aborted delay` followed (after `SHUTDOWN_TIMEOUT_MS`) by `Shutdown timed out, forcing exit`.

After this PR, the `Polling error` line is gone — stopping is silent on the polling channel.

## Test plan

- [x] `npm run lint` — no errors
- [x] `npm run typecheck` — no errors
- [x] `npm test` — 3498/3498 passing, including the two new shutdown tests in `src/bot/__tests__/deal-bot-shutdown.test.ts`
- [x] `npm run format:check` — clean
- [ ] Manual: run agent with MTProxy, Ctrl+C, confirm no `[Bot] Polling error … Aborted delay` line appears

Fixes xlabtg/teleton-agent#460