### PR TITLE
fix(tasks): execute Saved Messages scheduled task triggers

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
+# Updated: 2026-05-02T15:50:08.230Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,3 @@
+# .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
+# Updated: 2026-04-26T15:08:27.505Z
+# Updated: 2026-04-26T15:59:46.481Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
-# Updated: 2026-04-26T15:08:27.505Z
-# Updated: 2026-04-26T15:59:46.481Z
-# Updated: 2026-05-02T15:50:08.230Z

--- a/src/__tests__/scheduled-task-trigger.test.ts
+++ b/src/__tests__/scheduled-task-trigger.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { TeletonApp } from "../index.js";
+import { getDatabase, closeDatabase } from "../memory/database.js";
+import { getTaskStore } from "../memory/agent/tasks.js";
+import { MessageDedupCache } from "../telegram/message-dedup-cache.js";
+import type { TelegramMessage } from "../telegram/bridge.js";
+
+vi.mock("../utils/logger.js", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  initLoggerFromConfig: vi.fn(),
+}));
+
+interface TestApp {
+  bridge: {
+    getOwnUserId: ReturnType<typeof vi.fn>;
+    getClient: ReturnType<typeof vi.fn>;
+    sendMessage: ReturnType<typeof vi.fn>;
+  };
+  agent: {
+    getToolRegistry: ReturnType<typeof vi.fn>;
+    processMessage: ReturnType<typeof vi.fn>;
+  };
+  config: Record<string, never>;
+  dependencyResolver: null;
+  messageHandler: { handleMessage: ReturnType<typeof vi.fn> };
+  adminHandler: {
+    parseCommand: ReturnType<typeof vi.fn>;
+    isCommandAllowed: ReturnType<typeof vi.fn>;
+    isPaused: ReturnType<typeof vi.fn>;
+  };
+  scheduledTaskTriggerMessages: MessageDedupCache;
+  messagesProcessed: number;
+  handleSingleMessage(message: TelegramMessage): Promise<void>;
+  handleScheduledTaskTrigger(message: TelegramMessage): Promise<boolean>;
+}
+
+function makeMessage(overrides: Partial<TelegramMessage> = {}): TelegramMessage {
+  return {
+    id: 501,
+    chatId: "192802079",
+    senderId: 0,
+    text: "hello",
+    isGroup: false,
+    isChannel: false,
+    isBot: false,
+    mentionsMe: false,
+    timestamp: new Date("2026-05-02T19:00:00Z"),
+    hasMedia: false,
+    ...overrides,
+  };
+}
+
+function createApp() {
+  const invoke = vi.fn().mockResolvedValue({});
+  const gramJsClient = { invoke };
+  const bridge = {
+    getOwnUserId: vi.fn(() => 192802079n),
+    getClient: vi.fn(() => ({
+      getClient: () => gramJsClient,
+    })),
+    sendMessage: vi.fn().mockResolvedValue({
+      id: 777,
+      date: Math.floor(Date.now() / 1000),
+    }),
+  };
+  const toolRegistry = {
+    execute: vi.fn().mockResolvedValue({ success: true, data: { sent: true } }),
+  };
+  const agent = {
+    getToolRegistry: vi.fn(() => toolRegistry),
+    processMessage: vi.fn().mockResolvedValue({ content: "Task complete", toolCalls: [] }),
+  };
+
+  const app = Object.create(TeletonApp.prototype) as TestApp;
+  app.bridge = bridge;
+  app.agent = agent;
+  app.config = {};
+  app.dependencyResolver = null;
+  app.messageHandler = { handleMessage: vi.fn().mockResolvedValue(undefined) };
+  app.adminHandler = {
+    parseCommand: vi.fn().mockReturnValue(undefined),
+    isCommandAllowed: vi.fn().mockReturnValue(false),
+    isPaused: vi.fn().mockReturnValue(false),
+  };
+  app.scheduledTaskTriggerMessages = new MessageDedupCache();
+  app.messagesProcessed = 0;
+
+  return { app, bridge, agent, toolRegistry, invoke };
+}
+
+describe("TeletonApp scheduled task triggers", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "teleton-task-trigger-"));
+    getDatabase({
+      path: join(tempDir, "memory.db"),
+      enableVectorSearch: false,
+    });
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("executes a Saved Messages [TASK:] trigger even when Telegram omits senderId", async () => {
+    const db = getDatabase().getDb();
+    const store = getTaskStore(db);
+    const task = store.createTask({
+      description: "Send me a reminder",
+      payload: JSON.stringify({
+        type: "tool_call",
+        tool: "telegram_send_message",
+        params: { chatId: "192802079", text: "Privet" },
+      }),
+      scheduledFor: new Date("2026-05-02T19:00:00Z"),
+    });
+    const { app, agent, toolRegistry, invoke } = createApp();
+
+    await app.handleSingleMessage(
+      makeMessage({
+        text: `[TASK:${task.id}] Send me a reminder`,
+        senderId: 0,
+        chatId: "192802079",
+      })
+    );
+
+    expect(app.messageHandler.handleMessage).not.toHaveBeenCalled();
+    expect(toolRegistry.execute).toHaveBeenCalledWith(
+      "telegram_send_message",
+      { chatId: "192802079", text: "Privet" },
+      expect.objectContaining({ chatId: "192802079", db })
+    );
+    expect(agent.processMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: task.id,
+        userName: "self-scheduled-task",
+        userMessage: expect.stringContaining("telegram_send_message"),
+      })
+    );
+    expect(store.getTask(task.id)?.status).toBe("done");
+
+    const deleteRequest = invoke.mock.calls
+      .map(([request]) => request as { className?: string; id?: number[]; revoke?: boolean })
+      .find((request) => request.className === "messages.DeleteMessages");
+    expect(deleteRequest).toMatchObject({ id: [501], revoke: true });
+  });
+
+  it("deduplicates the same trigger across direct and general message handlers", async () => {
+    const db = getDatabase().getDb();
+    const store = getTaskStore(db);
+    const task = store.createTask({ description: "One-shot task" });
+    const { app, agent } = createApp();
+    const message = makeMessage({ text: `[TASK:${task.id}] One-shot task` });
+
+    await Promise.all([
+      app.handleScheduledTaskTrigger(message),
+      app.handleScheduledTaskTrigger(message),
+    ]);
+
+    expect(agent.processMessage).toHaveBeenCalledOnce();
+    expect(store.getTask(task.id)?.status).toBe("done");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { TelegramBotBridge } from "./telegram/bot-bridge.js";
 import { MessageHandler } from "./telegram/handlers.js";
 import { AdminHandler } from "./telegram/admin.js";
 import { MessageDebouncer } from "./telegram/debounce.js";
+import { MessageDedupCache } from "./telegram/message-dedup-cache.js";
 import { getDatabase, closeDatabase, initializeMemory, type MemorySystem } from "./memory/index.js";
 import { getWalletAddress, clearKeyPair } from "./ton/wallet-service.js";
 import { setTonapiKey } from "./constants/api-endpoints.js";
@@ -132,6 +133,8 @@ export class TeletonApp {
   private mcpConnections: McpConnection[] = [];
   private callbackHandlerRegistered = false;
   private messageHandlersRegistered = false;
+  private scheduledTaskMessageHandlerRegistered = false;
+  private scheduledTaskTriggerMessages = new MessageDedupCache();
   private lifecycle = new AgentLifecycle();
   private hookRunner?: ReturnType<typeof createHookRunner>;
   private userHookEvaluator: UserHookEvaluator | null = null;
@@ -997,6 +1000,24 @@ ${blue}  ┌──────────────────────�
 
     // Register GramJS event handlers ONCE (survive agent restart via WebUI)
     if (!this.messageHandlersRegistered) {
+      const ownUserId = this.bridge.getOwnUserId();
+      if (!this.scheduledTaskMessageHandlerRegistered && ownUserId) {
+        this.bridge.onNewMessage(
+          async (message) => {
+            try {
+              await this.handleScheduledTaskTrigger(message);
+            } catch (error) {
+              log.error({ err: error }, "Error handling scheduled task trigger");
+            }
+          },
+          {
+            incoming: true,
+            chats: [ownUserId.toString()],
+          }
+        );
+        this.scheduledTaskMessageHandlerRegistered = true;
+      }
+
       this.bridge.onNewMessage(async (message) => {
         try {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- debouncer always initialized before handlers register
@@ -1117,14 +1138,7 @@ ${blue}  ┌──────────────────────�
   private async handleSingleMessage(message: TelegramMessage): Promise<void> {
     this.messagesProcessed++;
     try {
-      // Check if this is a scheduled task (from self)
-      const ownUserId = this.bridge.getOwnUserId();
-      if (
-        ownUserId &&
-        message.senderId === Number(ownUserId) &&
-        message.text.startsWith("[TASK:")
-      ) {
-        await this.handleScheduledTask(message);
+      if (await this.handleScheduledTaskTrigger(message)) {
         return;
       }
 
@@ -1203,6 +1217,40 @@ ${blue}  ┌──────────────────────�
     }
   }
 
+  private isScheduledTaskTrigger(message: TelegramMessage): boolean {
+    if (!message.text.startsWith("[TASK:")) {
+      return false;
+    }
+
+    const ownUserId = this.bridge.getOwnUserId();
+    if (!ownUserId) {
+      return false;
+    }
+
+    const ownUserIdText = ownUserId.toString();
+    return message.chatId === ownUserIdText || message.senderId === Number(ownUserId);
+  }
+
+  private async handleScheduledTaskTrigger(message: TelegramMessage): Promise<boolean> {
+    if (!this.isScheduledTaskTrigger(message)) {
+      return false;
+    }
+
+    const dedupKey = `${message.chatId}:${message.id}`;
+    if (this.scheduledTaskTriggerMessages.has(dedupKey)) {
+      return true;
+    }
+    this.scheduledTaskTriggerMessages.add(dedupKey);
+
+    log.info(
+      { chatId: message.chatId, messageId: message.id },
+      "Scheduled task trigger detected in Saved Messages"
+    );
+
+    await this.handleScheduledTask(message);
+    return true;
+  }
+
   /**
    * Handle scheduled task message
    */
@@ -1220,16 +1268,19 @@ ${blue}  ┌──────────────────────�
     const match = message.text.match(/^\[TASK:([^\]]+)\]/);
     if (!match) {
       log.warn(`Invalid task format: ${message.text}`);
+      await this.deleteScheduledTaskTriggerMessage(message);
       return;
     }
 
     const taskId = match[1];
+    let shouldDeleteTriggerMessage = false;
 
     try {
       const task = taskStore.getTask(taskId);
 
       if (!task) {
         log.warn(`Task ${taskId} not found in database`);
+        shouldDeleteTriggerMessage = true;
         await this.bridge.sendMessage({
           chatId: message.chatId,
           text: `⚠️ Task ${taskId} not found. It may have been deleted.`,
@@ -1246,6 +1297,7 @@ ${blue}  ┌──────────────────────�
         task.status === "failed"
       ) {
         log.info(`⏭️ Task ${taskId} already ${task.status}, skipping`);
+        shouldDeleteTriggerMessage = true;
         return;
       }
 
@@ -1311,6 +1363,7 @@ ${blue}  ┌──────────────────────�
 
       // Mark task as done if agent responded successfully
       taskStore.completeTask(taskId, response.content);
+      shouldDeleteTriggerMessage = true;
 
       log.info(`✅ Executed scheduled task ${taskId}: ${task.description}`);
 
@@ -1328,6 +1381,7 @@ ${blue}  ┌──────────────────────�
       }
     } catch (error) {
       log.error({ err: error }, "Error handling scheduled task");
+      shouldDeleteTriggerMessage = true;
 
       // Try to mark task as failed and cascade to dependents
       try {
@@ -1343,6 +1397,32 @@ ${blue}  ┌──────────────────────�
       } catch {
         // Ignore if we can't update task
       }
+    } finally {
+      if (shouldDeleteTriggerMessage) {
+        await this.deleteScheduledTaskTriggerMessage(message);
+      }
+    }
+  }
+
+  private async deleteScheduledTaskTriggerMessage(message: TelegramMessage): Promise<void> {
+    try {
+      const { Api } = await import("telegram");
+      const gramJsClient = this.bridge.getClient().getClient();
+      await gramJsClient.invoke(
+        new Api.messages.DeleteMessages({
+          id: [message.id],
+          revoke: true,
+        })
+      );
+      log.info(
+        { chatId: message.chatId, messageId: message.id },
+        "Deleted scheduled task trigger message"
+      );
+    } catch (error) {
+      log.warn(
+        { err: error, chatId: message.chatId, messageId: message.id },
+        "Failed to delete scheduled task trigger message"
+      );
     }
   }
 


### PR DESCRIPTION
Fixes xlabtg/teleton-agent#473

## Summary
- Detect `[TASK:]` messages in the owner Saved Messages chat even when GramJS does not populate `senderId` as the owner.
- Register a dedicated incoming Saved Messages handler and use a bounded dedupe cache so the dedicated and general handlers cannot double execute the same trigger.
- Delete consumed scheduled-task trigger messages after completion, failure, malformed triggers, or stale terminal tasks; dependency-waiting tasks remain pending.
- Add regression coverage for execution, deletion, and dedupe behavior.

## Reproduction
Before this change, a scheduled task could create a `[TASK:<id>]` message in Saved Messages, but Saved Messages delivery could arrive with `senderId` missing or `0`, so the existing self-sender check missed it and the task stayed pending.

After this change, the owner Saved Messages peer is recognized, the task executes through the normal task agent path, the task is marked done, and the trigger message is deleted.

## Tests
- `npm run build -w packages/sdk`
- `npx vitest run src/__tests__/scheduled-task-trigger.test.ts`
- `npx vitest run src/__tests__/scheduled-task-trigger.test.ts src/telegram/__tests__/task-executor.test.ts src/telegram/__tests__/task-dependency-resolver.test.ts src/agent/tools/telegram/tasks/__tests__/recurring-and-update-tasks.test.ts src/agent/tools/telegram/tasks/__tests__/recurrence.test.ts` (82 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test` (209 files / 3511 tests, log saved locally at `logs/npm-test.log`)
- `npm run build:backend`