### PR TITLE
Fix autonomous task completion from reflection success

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
+# Updated: 2026-05-04T11:14:11.453Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-25T03:41:48.178Z for PR creation at branch issue-419-7bf2be69dd38 for issue https://github.com/xlabtg/teleton-agent/issues/419
 # Updated: 2026-04-26T15:08:27.505Z
 # Updated: 2026-04-26T15:59:46.481Z
-# Updated: 2026-05-04T11:14:11.453Z

--- a/src/autonomous/__tests__/integration.test.ts
+++ b/src/autonomous/__tests__/integration.test.ts
@@ -175,6 +175,59 @@ describe("buildDefaultLoopDeps planner prompt", () => {
   });
 });
 
+describe("buildDefaultLoopDeps success reflection", () => {
+  let db: InstanceType<typeof Database>;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    ensureSchema(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("completes a criteria-based task when reflection says the goal is achieved", async () => {
+    const callLLM = vi.fn().mockImplementation(async (prompt: string) => {
+      if (prompt.includes("Answer with JSON")) {
+        return JSON.stringify({
+          progressSummary: "All success criteria are satisfied",
+          isStuck: false,
+          goalAchieved: true,
+        });
+      }
+      return JSON.stringify({
+        toolName: "alpha",
+        params: { query: "status" },
+        reasoning: "Verify the final state",
+        confidence: 0.95,
+      });
+    });
+
+    const deps = buildDefaultLoopDeps({
+      callLLM,
+      callTool: vi.fn().mockResolvedValue({ reportSent: true }),
+      notify: vi.fn().mockResolvedValue(undefined),
+      listTools: () => [{ name: "alpha", description: "Check task status" }],
+    });
+
+    const store = getAutonomousTaskStore(db);
+    const task = store.createTask({
+      goal: "Send the report",
+      successCriteria: ["report sent"],
+      constraints: { maxIterations: 2 },
+    });
+
+    const loop = new AutonomousLoop(store, deps, DEFAULT_POLICY_CONFIG);
+    const result = await loop.run(task);
+
+    expect(result.status).toBe("completed");
+    expect(store.getTask(task.id)?.status).toBe("completed");
+    expect(callLLM).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe("buildIntegratedLoopDeps admin check", () => {
   let db: InstanceType<typeof Database>;
   let registry: ToolRegistry;

--- a/src/autonomous/loop.ts
+++ b/src/autonomous/loop.ts
@@ -58,6 +58,8 @@ export interface ToolExecutionResult {
 export interface Reflection {
   progressSummary: string;
   isStuck: boolean;
+  /** True when self-reflection determines all success criteria are satisfied. */
+  goalAchieved?: boolean;
   adjustments?: {
     contextAdditions?: Record<string, unknown>;
     nextActionHint?: string;
@@ -399,11 +401,17 @@ export class AutonomousLoop {
           step: current.currentStep,
           eventType: "reflect",
           message: reflection.progressSummary,
-          data: { isStuck: reflection.isStuck, adjustments: reflection.adjustments },
+          data: {
+            isStuck: reflection.isStuck,
+            goalAchieved: reflection.goalAchieved,
+            adjustments: reflection.adjustments,
+          },
         });
 
-        // Handle reflection outcomes
-        if (reflection.shouldEscalate) {
+        // Handle reflection outcomes. A completed goal wins over escalation
+        // or "stuck" signals from the same reflection, but we still save the
+        // final checkpoint below before returning.
+        if (!reflection.goalAchieved && reflection.shouldEscalate) {
           const reason = reflection.escalationReason ?? "Agent flagged uncertainty";
           await this.deps.escalate(current, reason);
           this.throwIfAborted();
@@ -415,7 +423,7 @@ export class AutonomousLoop {
           };
         }
 
-        if (reflection.isStuck) {
+        if (!reflection.goalAchieved && reflection.isStuck) {
           const maxConsecutive = 3;
           const shouldEscalate = this.policyEngine.recordUncertain();
           if (shouldEscalate) {
@@ -464,7 +472,8 @@ export class AutonomousLoop {
         });
 
         // 7. Check success criteria
-        const succeeded = await this.deps.evaluateSuccess(current, result);
+        const succeeded =
+          reflection.goalAchieved || (await this.deps.evaluateSuccess(current, result));
         this.throwIfAborted();
         if (succeeded) {
           log.info({ taskId: task.id }, "Task completed successfully");

--- a/src/autonomous/manager.ts
+++ b/src/autonomous/manager.ts
@@ -356,6 +356,7 @@ export function buildDefaultLoopDeps(opts: {
         return {
           progressSummary: parsed.progressSummary ?? "Progress evaluated",
           isStuck: parsed.isStuck ?? false,
+          goalAchieved: parsed.goalAchieved ?? false,
           adjustments: parsed.nextActionHint
             ? { nextActionHint: parsed.nextActionHint }
             : undefined,


### PR DESCRIPTION
## Summary
- Fixes xlabtg/teleton-agent#475.
- Propagates `goalAchieved` from autonomous self-reflection into loop completion logic.
- Prevents the same reflection from pausing as stuck or escalated after the goal is already achieved.
- Adds a regression test for criteria-based task completion from reflection success.

## Root Cause
Criteria-based autonomous tasks could not complete through the default loop dependencies: the reflection prompt asked the LLM for `goalAchieved`, but `buildDefaultLoopDeps.selfReflect()` dropped that value, while `evaluateSuccess()` returned `false` for tasks with explicit success criteria because reflection was intended to decide completion.

## Reproduction and Verification
The new integration test creates a criteria-based task, has the reflection LLM return `goalAchieved: true`, and asserts that the loop returns and stores `completed`.

## Test Plan
- [x] `npm run build:sdk`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test:coverage` (`209` files passed, `3512` tests passed)
- [x] `cd web && npm ci`, then `npm run build`
- [x] `node dist/cli/index.js --help`
- [x] `npm run audit:ci`