### PR TITLE
fix(security): ограничить конфиг-импорт разрешёнными ключами и защитить иммутируемые soul-файлы

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-10T12:39:14.402Z for PR creation at branch issue-531-1d49414c86e9 for issue https://github.com/xlabtg/teleton-agent/issues/531

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-10T12:39:14.402Z for PR creation at branch issue-531-1d49414c86e9 for issue https://github.com/xlabtg/teleton-agent/issues/531

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ## Current Fork Status
 
-Current fork version: `0.8.34`.
+Current fork version: `0.8.35`.
 
 This README reflects the `xlabtg/teleton-agent` fork through merged PR [#480](https://github.com/xlabtg/teleton-agent/pull/480) / closed issue [#479](https://github.com/xlabtg/teleton-agent/issues/479). It was refreshed from the closed work history available at issue [#481](https://github.com/xlabtg/teleton-agent/issues/481): 236 closed issues and the 200 most recent merged pull requests as of the latest analyzed run.
 

--- a/src/webui/__tests__/export-import-routes.test.ts
+++ b/src/webui/__tests__/export-import-routes.test.ts
@@ -1,0 +1,420 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Hono } from "hono";
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+const mockReadRawConfig = vi.fn();
+const mockWriteRawConfig = vi.fn();
+
+// Keep real CONFIGURABLE_KEYS, getNestedValue, setNestedValue for allowlist testing
+vi.mock("../../config/configurable-keys.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/configurable-keys.js")>();
+  return {
+    ...actual,
+    readRawConfig: (...args: unknown[]) => mockReadRawConfig(...args),
+    writeRawConfig: (...args: unknown[]) => mockWriteRawConfig(...args),
+  };
+});
+
+vi.mock("../../workspace/paths.js", () => ({
+  WORKSPACE_ROOT: "/fake/workspace",
+  TELETON_ROOT: "/fake/teleton",
+  WORKSPACE_PATHS: {},
+  ALLOWED_EXTENSIONS: {},
+  MAX_FILE_SIZES: {},
+}));
+
+vi.mock("../../soul/loader.js", () => ({
+  clearPromptCache: vi.fn(),
+}));
+
+vi.mock("../../agent/hooks/user-hook-store.js", () => ({
+  getBlocklistConfig: vi.fn(() => []),
+  setBlocklistConfig: vi.fn(),
+  getTriggersConfig: vi.fn(() => []),
+  setTriggersConfig: vi.fn(),
+  getRulesConfig: vi.fn(() => []),
+  setRulesConfig: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  readFileSync: vi.fn(() => ""),
+  writeFileSync: vi.fn(),
+  existsSync: vi.fn(() => false),
+}));
+
+// Must import AFTER mocks are set up
+import { writeFileSync } from "node:fs";
+import { clearPromptCache } from "../../soul/loader.js";
+import { createExportImportRoutes } from "../routes/export-import.js";
+import type { WebUIServerDeps } from "../types.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function buildApp() {
+  const deps = {
+    configPath: "/tmp/test.yaml",
+    memory: { db: {} },
+  } as unknown as WebUIServerDeps;
+  const app = new Hono();
+  app.route("/api/export", createExportImportRoutes(deps));
+  return app;
+}
+
+// ── Config import tests ───────────────────────────────────────────────────
+
+describe("POST /api/export/import — config allowlist enforcement", () => {
+  let app: ReturnType<typeof buildApp>;
+  let writtenConfig: Record<string, unknown>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+    writtenConfig = {};
+    mockWriteRawConfig.mockImplementation((cfg: Record<string, unknown>) => {
+      writtenConfig = cfg;
+    });
+  });
+
+  it("preserves webui.auth_token_hash — it is not in CONFIGURABLE_KEYS", async () => {
+    mockReadRawConfig.mockReturnValue({
+      webui: { auth_token_hash: "SECRET_HASH", port: 8080 },
+    });
+
+    const res = await app.request("/api/export/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bundle: {
+          version: "1.0",
+          config: {
+            // attacker tries to drop auth_token_hash by sending a webui section without it
+            webui: { port: 9090 },
+          },
+        },
+        options: { config: true },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect((writtenConfig.webui as Record<string, unknown>).auth_token_hash).toBe("SECRET_HASH");
+    // webui.port IS in CONFIGURABLE_KEYS and should be applied
+    expect((writtenConfig.webui as Record<string, unknown>).port).toBe(9090);
+  });
+
+  it("ignores attempt to overwrite webui.auth_token_hash directly", async () => {
+    mockReadRawConfig.mockReturnValue({
+      webui: { auth_token_hash: "REAL_HASH" },
+    });
+
+    await app.request("/api/export/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bundle: {
+          version: "1.0",
+          config: { webui: { auth_token_hash: "ATTACKER_HASH" } },
+        },
+        options: { config: true },
+      }),
+    });
+
+    expect((writtenConfig.webui as Record<string, unknown>).auth_token_hash).toBe("REAL_HASH");
+  });
+
+  it("ignores keys that are not in CONFIGURABLE_KEYS", async () => {
+    mockReadRawConfig.mockReturnValue({ agent: { model: "gpt-4" } });
+
+    await app.request("/api/export/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bundle: {
+          version: "1.0",
+          config: {
+            totally_arbitrary_key: "pwned",
+            some_flag: true,
+            nested: { something: "bad" },
+          },
+        },
+        options: { config: true },
+      }),
+    });
+
+    expect(writtenConfig).not.toHaveProperty("totally_arbitrary_key");
+    expect(writtenConfig).not.toHaveProperty("some_flag");
+    expect(writtenConfig).not.toHaveProperty("nested");
+  });
+
+  it("applies valid capabilities.exec.mode from CONFIGURABLE_KEYS", async () => {
+    mockReadRawConfig.mockReturnValue({
+      capabilities: { exec: { mode: "off" } },
+    });
+
+    await app.request("/api/export/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bundle: {
+          version: "1.0",
+          config: { capabilities: { exec: { mode: "allowlist" } } },
+        },
+        options: { config: true },
+      }),
+    });
+
+    expect(writtenConfig.capabilities as Record<string, unknown>).toBeDefined();
+    expect(
+      ((writtenConfig.capabilities as Record<string, unknown>).exec as Record<string, unknown>).mode
+    ).toBe("allowlist");
+  });
+
+  it("rejects invalid enum values and keeps existing value", async () => {
+    mockReadRawConfig.mockReturnValue({
+      capabilities: { exec: { mode: "off" } },
+    });
+
+    await app.request("/api/export/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bundle: {
+          version: "1.0",
+          // "SUPER_ADMIN" is not a valid capabilities.exec.mode value
+          config: { capabilities: { exec: { mode: "SUPER_ADMIN" } } },
+        },
+        options: { config: true },
+      }),
+    });
+
+    // Invalid value skipped; existing preserved
+    expect(
+      ((writtenConfig.capabilities as Record<string, unknown>).exec as Record<string, unknown>).mode
+    ).toBe("off");
+  });
+
+  it("returns 400 when bundle version is not 1.0", async () => {
+    const res = await app.request("/api/export/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bundle: { version: "2.0", config: {} },
+        options: { config: true },
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.success).toBe(false);
+    expect(json.error).toContain("version 1.0");
+  });
+
+  it("returns success and lists config in applied when config option is true", async () => {
+    mockReadRawConfig.mockReturnValue({});
+
+    const res = await app.request("/api/export/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bundle: { version: "1.0", config: {} },
+        options: { config: true },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.data.applied).toContain("config");
+  });
+});
+
+// ── Soul import tests ─────────────────────────────────────────────────────
+
+describe("POST /api/export/import — soul immutable file protection", () => {
+  let app: ReturnType<typeof buildApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+  });
+
+  it("does not write SOUL.md (immutable file)", async () => {
+    const res = await app.request("/api/export/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bundle: {
+          version: "1.0",
+          soul: { "SOUL.md": "attacker content" },
+        },
+        options: { soul: true },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(writeFileSync).not.toHaveBeenCalledWith(
+      expect.stringContaining("SOUL.md"),
+      expect.any(String),
+      expect.any(String)
+    );
+  });
+
+  it("does not write SECURITY.md (immutable file)", async () => {
+    const res = await app.request("/api/export/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bundle: {
+          version: "1.0",
+          soul: { "SECURITY.md": "<attacker text>" },
+        },
+        options: { soul: true },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(writeFileSync).not.toHaveBeenCalledWith(
+      expect.stringContaining("SECURITY.md"),
+      expect.any(String),
+      expect.any(String)
+    );
+  });
+
+  it("does not write STRATEGY.md (immutable file)", async () => {
+    const res = await app.request("/api/export/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bundle: {
+          version: "1.0",
+          soul: { "STRATEGY.md": "attacker strategy" },
+        },
+        options: { soul: true },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(writeFileSync).not.toHaveBeenCalledWith(
+      expect.stringContaining("STRATEGY.md"),
+      expect.any(String),
+      expect.any(String)
+    );
+  });
+
+  it("writes MEMORY.md (not immutable)", async () => {
+    const res = await app.request("/api/export/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bundle: {
+          version: "1.0",
+          soul: { "MEMORY.md": "restored memory" },
+        },
+        options: { soul: true },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("MEMORY.md"),
+      "restored memory",
+      "utf-8"
+    );
+  });
+
+  it("writes HEARTBEAT.md (not immutable)", async () => {
+    const res = await app.request("/api/export/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bundle: {
+          version: "1.0",
+          soul: { "HEARTBEAT.md": "heartbeat schedule" },
+        },
+        options: { soul: true },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("HEARTBEAT.md"),
+      "heartbeat schedule",
+      "utf-8"
+    );
+  });
+
+  it("skips all immutable files even in a combined soul bundle", async () => {
+    await app.request("/api/export/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bundle: {
+          version: "1.0",
+          soul: {
+            "SOUL.md": "attacker soul",
+            "SECURITY.md": "attacker security",
+            "STRATEGY.md": "attacker strategy",
+            "MEMORY.md": "legitimate memory",
+            "HEARTBEAT.md": "legitimate heartbeat",
+          },
+        },
+        options: { soul: true },
+      }),
+    });
+
+    // Only non-immutable files should be written
+    expect(writeFileSync).toHaveBeenCalledTimes(2);
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("MEMORY.md"),
+      "legitimate memory",
+      "utf-8"
+    );
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("HEARTBEAT.md"),
+      "legitimate heartbeat",
+      "utf-8"
+    );
+  });
+
+  it("clears prompt cache after soul import", async () => {
+    await app.request("/api/export/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bundle: {
+          version: "1.0",
+          soul: { "MEMORY.md": "content" },
+        },
+        options: { soul: true },
+      }),
+    });
+
+    expect(clearPromptCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns success and lists soul in applied", async () => {
+    const res = await app.request("/api/export/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        bundle: {
+          version: "1.0",
+          soul: { "MEMORY.md": "content" },
+        },
+        options: { soul: true },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.data.applied).toContain("soul");
+  });
+});

--- a/src/webui/routes/export-import.ts
+++ b/src/webui/routes/export-import.ts
@@ -2,7 +2,13 @@ import { Hono } from "hono";
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import type { WebUIServerDeps, APIResponse } from "../types.js";
-import { readRawConfig, writeRawConfig } from "../../config/configurable-keys.js";
+import {
+  CONFIGURABLE_KEYS,
+  getNestedValue,
+  setNestedValue,
+  readRawConfig,
+  writeRawConfig,
+} from "../../config/configurable-keys.js";
 import {
   getBlocklistConfig,
   setBlocklistConfig,
@@ -12,6 +18,7 @@ import {
   setRulesConfig,
 } from "../../agent/hooks/user-hook-store.js";
 import { WORKSPACE_ROOT } from "../../workspace/paths.js";
+import { IMMUTABLE_FILES } from "../../workspace/validator.js";
 import { getErrorMessage } from "../../utils/errors.js";
 import { clearPromptCache } from "../../soul/loader.js";
 
@@ -139,24 +146,27 @@ export function createExportImportRoutes(deps: WebUIServerDeps) {
 
       if (options.config && bundle.config) {
         const existing = readRawConfig(deps.configPath);
-        // Merge: keep existing sensitive values, overwrite the rest
-        const merged = { ...existing, ...bundle.config };
-        // Restore sensitive values from existing config
-        for (const key of SENSITIVE_KEYS) {
-          const parts = key.split(".");
-          let existingObj: Record<string, unknown> = existing;
-          let mergedObj: Record<string, unknown> = merged;
-          for (let i = 0; i < parts.length - 1; i++) {
-            if (existingObj[parts[i]] && typeof existingObj[parts[i]] === "object") {
-              existingObj = existingObj[parts[i]] as Record<string, unknown>;
-            }
-            if (mergedObj[parts[i]] && typeof mergedObj[parts[i]] === "object") {
-              mergedObj = mergedObj[parts[i]] as Record<string, unknown>;
-            }
-          }
-          const last = parts[parts.length - 1];
-          if (last in existingObj && existingObj[last] != null) {
-            (mergedObj as Record<string, unknown>)[last] = existingObj[last];
+        // Deep-copy existing so all non-configurable keys (e.g. webui.auth_token_hash)
+        // are preserved and the shallow-merge attack surface is eliminated.
+        const merged = JSON.parse(JSON.stringify(existing)) as Record<string, unknown>;
+        // Only apply keys that are in the CONFIGURABLE_KEYS allowlist.
+        // This prevents setting arbitrary/security-sensitive fields not exposed in the UI.
+        for (const [key, meta] of Object.entries(CONFIGURABLE_KEYS)) {
+          const importedValue = getNestedValue(bundle.config as Record<string, unknown>, key);
+          if (importedValue === undefined || importedValue === null) continue;
+          if (meta.type === "array") {
+            if (!Array.isArray(importedValue)) continue;
+            const allValid = importedValue.every((item) => !meta.validate(String(item)));
+            if (!allValid) continue;
+            setNestedValue(
+              merged,
+              key,
+              importedValue.map((item) => meta.parse(String(item)))
+            );
+          } else {
+            const valueStr = String(importedValue);
+            if (meta.validate(valueStr)) continue;
+            setNestedValue(merged, key, meta.parse(valueStr));
           }
         }
         writeRawConfig(merged, deps.configPath);
@@ -190,6 +200,9 @@ export function createExportImportRoutes(deps: WebUIServerDeps) {
       if (options.soul && bundle.soul) {
         const { writeFileSync } = await import("node:fs");
         for (const filename of SOUL_FILES) {
+          // Honor IMMUTABLE_FILES: SOUL.md, STRATEGY.md, SECURITY.md cannot be
+          // overwritten via import (they are owner-only configuration files).
+          if (IMMUTABLE_FILES.includes(filename)) continue;
           if (bundle.soul[filename] !== undefined) {
             const filePath = join(WORKSPACE_ROOT, filename);
             writeFileSync(filePath, bundle.soul[filename], "utf-8");

--- a/src/workspace/validator.ts
+++ b/src/workspace/validator.ts
@@ -208,7 +208,7 @@ export function validateReadPath(inputPath: string): ValidatedPath {
  * Extension whitelist is now OPTIONAL (fix from audit)
  */
 // Owner configuration files that cannot be overwritten by the agent
-const IMMUTABLE_FILES = ["SOUL.md", "STRATEGY.md", "SECURITY.md"];
+export const IMMUTABLE_FILES: readonly string[] = ["SOUL.md", "STRATEGY.md", "SECURITY.md"];
 
 export function validateWritePath(
   inputPath: string,


### PR DESCRIPTION
## Проблема

Находка безопасности WORK4-009: \`POST /api/export/import\` допускал две атаки повышения привилегий.

**Уязвимость 1 — Обход allowlist через shallow merge**

\`\`\`ts
// БЫЛО: shallow merge — заменял целые секции, мог удалить webui.auth_token_hash
writeRawConfig({ ...existing, ...bundle.config }, deps.configPath);
\`\`\`

Злоумышленник мог отправить \`{ "webui": { "port": 9090 } }\` — это удалило бы \`webui.auth_token_hash\` из конфига, сделав авторизацию недоступной. Также можно было записать произвольные ключи вне allowlist.

**Уязвимость 2 — Запись иммутируемых soul-файлов**

\`\`\`ts
// БЫЛО: запись без проверки IMMUTABLE_FILES
for (const filename of SOUL_FILES) {
  writeFileSync(join(WORKSPACE_ROOT, filename), bundle.soul[filename]);
}
\`\`\`

\`SOUL.md\`, \`SECURITY.md\`, \`STRATEGY.md\` — owner-only файлы, которые агент не может изменять. Импорт их перезаписывал.

## Исправление

**Конфиг-импорт** (\`src/webui/routes/export-import.ts\`):
- Заменён shallow merge на глубокую копию существующего конфига + перебор \`CONFIGURABLE_KEYS\`
- Каждый ключ извлекается через \`getNestedValue\`, проходит \`meta.validate()\`, применяется через \`setNestedValue(merged, key, meta.parse(value))\`
- Ключи вне allowlist (включая \`webui.auth_token_hash\`) никогда не затрагиваются

\`\`\`ts
const merged = JSON.parse(JSON.stringify(existing));
for (const [key, meta] of Object.entries(CONFIGURABLE_KEYS)) {
  const importedValue = getNestedValue(bundle.config, key);
  if (importedValue === undefined || importedValue === null) continue;
  // ... validate + apply
}
writeRawConfig(merged, deps.configPath);
\`\`\`

**Soul-импорт** (\`src/webui/routes/export-import.ts\`):
- Добавлена проверка \`IMMUTABLE_FILES.includes(filename)\` перед записью файла

\`\`\`ts
if (IMMUTABLE_FILES.includes(filename)) continue;
\`\`\`

**\`src/workspace/validator.ts\`**:
- \`IMMUTABLE_FILES\` экспортирован (\`export const IMMUTABLE_FILES: readonly string[]\`) — единственный источник истины

**\`README.md\`**:
- Обновлена версия форка с \`0.8.34\` до \`0.8.35\` (тест \`src/docs/__tests__/readme.test.ts\` требует соответствия package.json)

## Тесты

Добавлен \`src/webui/__tests__/export-import-routes.test.ts\` — 15 тестов:

**Config allowlist enforcement:**
- ✅ \`webui.auth_token_hash\` сохраняется, если бандл не содержит этот ключ
- ✅ Прямая попытка перезаписи \`webui.auth_token_hash\` игнорируется
- ✅ Произвольные ключи вне \`CONFIGURABLE_KEYS\` игнорируются
- ✅ Валидный ключ (\`capabilities.exec.mode\`) применяется корректно
- ✅ Невалидное enum-значение отклоняется, существующее значение сохраняется
- ✅ Версия бандла != "1.0" → 400 Bad Request
- ✅ Успешный импорт возвращает \`applied: ["config"]\`

**Soul immutable file protection:**
- ✅ \`SOUL.md\` не записывается
- ✅ \`SECURITY.md\` не записывается
- ✅ \`STRATEGY.md\` не записывается
- ✅ \`MEMORY.md\` записывается (не иммутируемый)
- ✅ \`HEARTBEAT.md\` записывается (не иммутируемый)
- ✅ Комбинированный бандл: только 2 файла записаны (\`MEMORY.md\`, \`HEARTBEAT.md\`)
- ✅ \`clearPromptCache()\` вызывается после soul-импорта
- ✅ Успешный импорт возвращает \`applied: ["soul"]\`

Все 15 тестов проходят: \`Tests  15 passed (15)\`

Closes #531