### PR TITLE
fix(autonomous): соблюдать maxParallelTasks при восстановлении задач после сбоя (#533)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-10T17:07:45.198Z for PR creation at branch issue-533-c1a43bbb2610 for issue https://github.com/xlabtg/teleton-agent/issues/533

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-10T17:07:45.198Z for PR creation at branch issue-533-c1a43bbb2610 for issue https://github.com/xlabtg/teleton-agent/issues/533

--- a/src/autonomous/__tests__/manager.test.ts
+++ b/src/autonomous/__tests__/manager.test.ts
@@ -440,6 +440,69 @@ describe("AutonomousTaskManager", () => {
       queuedManager.stopAll();
     });
 
+    // ─── Regression: issue #533 ──────────────────────────────────────────────
+    // restoreInterruptedTasks() used to call runLoop() unconditionally for every
+    // 'running'/'pending' task, bypassing the maxParallelTasks gate. After a
+    // crash with more active tasks than the cap, restart would start them all at
+    // once and exceed the concurrency limit.
+    it("respects maxParallelTasks when restoring interrupted 'running' tasks (issue #533)", async () => {
+      const localDb = new Database(":memory:");
+      localDb.pragma("foreign_keys = ON");
+      ensureSchema(localDb);
+      const store = getAutonomousTaskStore(localDb);
+
+      const MAX = 10;
+      const TOTAL = 15;
+      // Persist more 'running' tasks than the cap, as if a crash interrupted them.
+      const ids: string[] = [];
+      for (let i = 0; i < TOTAL; i++) {
+        const t = store.createTask({ goal: `Crashed ${i}` });
+        store.updateTaskStatus(t.id, "running");
+        ids.push(t.id);
+      }
+
+      const freshManager = new AutonomousTaskManager(localDb, hangingDeps(), {
+        maxParallelTasks: MAX,
+      });
+      const restored = await freshManager.restoreInterruptedTasks();
+      // All 15 are accounted for (started or re-queued)…
+      expect(restored).toBe(TOTAL);
+      // …but concurrent loops never exceed the cap.
+      expect(freshManager.getRunningTaskIds().length).toBeLessThanOrEqual(MAX);
+      expect(freshManager.getRunningTaskIds()).toHaveLength(MAX);
+
+      // The overflow tasks are parked as 'queued' in storage rather than left
+      // claiming to be 'running' while idle.
+      const queuedInDb = ids.filter((id) => store.getTask(id)?.status === "queued");
+      expect(queuedInDb).toHaveLength(TOTAL - MAX);
+
+      freshManager.stopAll();
+      localDb.close();
+    });
+
+    it("respects maxParallelTasks when restoring interrupted 'pending' tasks (issue #533)", async () => {
+      const localDb = new Database(":memory:");
+      localDb.pragma("foreign_keys = ON");
+      ensureSchema(localDb);
+      const store = getAutonomousTaskStore(localDb);
+
+      const MAX = 3;
+      const TOTAL = 8;
+      for (let i = 0; i < TOTAL; i++) {
+        store.createTask({ goal: `Pending ${i}` });
+      }
+
+      const freshManager = new AutonomousTaskManager(localDb, hangingDeps(), {
+        maxParallelTasks: MAX,
+      });
+      const restored = await freshManager.restoreInterruptedTasks();
+      expect(restored).toBe(TOTAL);
+      expect(freshManager.getRunningTaskIds()).toHaveLength(MAX);
+
+      freshManager.stopAll();
+      localDb.close();
+    });
+
     it("restoreInterruptedTasks() re-enqueues 'queued' tasks from DB", async () => {
       const store = getAutonomousTaskStore(db);
       // Simulate a task that was 'queued' before a restart

--- a/src/autonomous/manager.ts
+++ b/src/autonomous/manager.ts
@@ -194,6 +194,28 @@ export class AutonomousTaskManager {
     let restored = 0;
 
     for (const task of active) {
+      if (task.status !== "running" && task.status !== "pending" && task.status !== "queued") {
+        continue;
+      }
+
+      // Every restore path is gated on the same concurrency cap as startTask().
+      // Without this, a crash with more than maxParallelTasks active tasks would
+      // restart them all at once and blow past the limit (issue #533). Overflow
+      // tasks are parked in the in-memory queue and drain automatically as
+      // running loops finish (see runLoop's `.finally()`).
+      if (this.runningLoops.size >= this.config.maxParallelTasks) {
+        log.info({ taskId: task.id }, "Parallel limit reached on restore — queueing task");
+        // Reflect the parked state in storage so the DB doesn't keep claiming a
+        // "running"/"pending" task is active while it sits idle in the queue.
+        const queued =
+          task.status === "queued"
+            ? task
+            : (this.store.updateTaskStatus(task.id, "queued") ?? task);
+        this.taskQueue.push(queued);
+        restored++;
+        continue;
+      }
+
       if (task.status === "running") {
         log.info({ taskId: task.id }, "Restoring interrupted task from checkpoint");
         this.store.appendLog({
@@ -203,7 +225,6 @@ export class AutonomousTaskManager {
           message: "Agent restarted — resuming from last checkpoint",
         });
         this.runLoop(task);
-        restored++;
       } else if (task.status === "pending") {
         log.info({ taskId: task.id }, "Starting queued pending task");
         this.store.appendLog({
@@ -213,21 +234,11 @@ export class AutonomousTaskManager {
           message: "Agent started — starting queued task",
         });
         this.runLoop(task);
-        restored++;
-      } else if (task.status === "queued") {
-        log.info({ taskId: task.id }, "Re-enqueueing task that was waiting for a slot");
-        this.taskQueue.push(task);
-        restored++;
+      } else {
+        log.info({ taskId: task.id }, "Starting restored queued task");
+        this.runLoop(task);
       }
-    }
-
-    // Drain the queue into any available slots left after restoring running tasks.
-    while (this.taskQueue.length > 0 && this.runningLoops.size < this.config.maxParallelTasks) {
-      const next = this.taskQueue.shift();
-      if (next) {
-        log.info({ taskId: next.id }, "Starting restored queued task");
-        this.runLoop(next);
-      }
+      restored++;
     }
 
     return restored;


### PR DESCRIPTION
## Проблема

`restoreInterruptedTasks()` безусловно вызывал `runLoop()` для каждой задачи в статусе `running` или `pending`. Проверку слота (`runningLoops.size >= maxParallelTasks`) проходили только `queued`-задачи. В результате после сбоя, когда активных задач было больше `maxParallelTasks`, перезапуск агента стартовал их все одновременно и превышал лимит параллелизма.

Каждая восстановленная задача делает по 2 LLM-вызова + 1 вызов инструмента за итерацию, поэтому превышение лимита приводило к всплеску нагрузки/стоимости и давлению на rate-limit провайдера.

Fixes #533

## Решение

Теперь каждый путь восстановления (`running`, `pending`, `queued`) проходит ту же проверку слота, что и `startTask()`:

- Пока `runningLoops.size < maxParallelTasks` — задача запускается немедленно через `runLoop()`.
- Переполняющие задачи помечаются в хранилище как `queued` (чтобы БД не утверждала, что простаивающая задача всё ещё `running`) и паркуются во внутреннюю очередь `taskQueue`.
- Очередь автоматически дренируется по мере завершения активных циклов — через существующий `.finally()` в `runLoop()`.

Это убирает отдельный финальный цикл дренажа: запуск теперь происходит inline в порядке `getActiveTasks()`, а инвариант «число одновременных циклов никогда не превышает `maxParallelTasks`» соблюдается на каждом шаге.

## Как воспроизвести

1. Сохранить 15 задач в статусе `running` при `maxParallelTasks = 10`.
2. Перезапустить агента и вызвать `restoreInterruptedTasks()`.
3. До фикса: `getRunningTaskIds().length === 15`. После фикса: `<= 10`.

## Тесты

Добавлены регрессионные тесты в `src/autonomous/__tests__/manager.test.ts`:

- `respects maxParallelTasks when restoring interrupted 'running' tasks (issue #533)` — 15 `running`-задач при cap=10: ровно 10 запущены, 5 помечены `queued` в БД, восстановлены все 15.
- `respects maxParallelTasks when restoring interrupted 'pending' tasks (issue #533)` — 8 `pending`-задач при cap=3: ровно 3 запущены.

Проверено, что оба теста падают на старом коде (2 failed) и проходят с фиксом.

```
Test Files  8 passed (8)
     Tests  138 passed (138)
```

`tsc --noEmit` и `eslint --max-warnings 0` — без ошибок.
