### PR TITLE
fix(autonomous): дефолтный потолок итераций при отсутствии maxIterations (#534)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-10T17:14:47.477Z for PR creation at branch issue-534-0b18869da756 for issue https://github.com/xlabtg/teleton-agent/issues/534

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-10T17:14:47.477Z for PR creation at branch issue-534-0b18869da756 for issue https://github.com/xlabtg/teleton-agent/issues/534

--- a/src/autonomous/__tests__/policy-engine.test.ts
+++ b/src/autonomous/__tests__/policy-engine.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { PolicyEngine, DEFAULT_POLICY_CONFIG } from "../policy-engine.js";
+import { PolicyEngine, DEFAULT_POLICY_CONFIG, DEFAULT_MAX_ITERATIONS } from "../policy-engine.js";
+import { MAX_GLOBAL_ITERATIONS } from "../loop.js";
 import type { AutonomousTask } from "../../memory/agent/autonomous-tasks.js";
 
 function makeTask(overrides: Partial<AutonomousTask> = {}): AutonomousTask {
@@ -55,6 +56,46 @@ describe("PolicyEngine", () => {
     const task = makeTask({
       constraints: { maxIterations: 10 },
       currentStep: 5,
+    });
+    const result = engine.checkAction(task, { toolName: "web_fetch" });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  // ─── Default iteration cap (issue #534 / WORK4-012) ──────────────────────────
+
+  it("applies a default iteration cap when constraints omit maxIterations", () => {
+    expect(DEFAULT_MAX_ITERATIONS).toBeGreaterThan(0);
+    expect(DEFAULT_MAX_ITERATIONS).toBeLessThan(MAX_GLOBAL_ITERATIONS);
+  });
+
+  it("blocks an unconstrained task once it reaches the default iteration cap", () => {
+    const task = makeTask({
+      constraints: {},
+      currentStep: DEFAULT_MAX_ITERATIONS,
+    });
+    const result = engine.checkAction(task, { toolName: "web_fetch" });
+
+    expect(result.allowed).toBe(false);
+    expect(result.violations.some((v) => v.type === "max_iterations")).toBe(true);
+  });
+
+  it("allows an unconstrained task while it is below the default iteration cap", () => {
+    const task = makeTask({
+      constraints: {},
+      currentStep: DEFAULT_MAX_ITERATIONS - 1,
+    });
+    const result = engine.checkAction(task, { toolName: "web_fetch" });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it("lets an explicit maxIterations override the default cap", () => {
+    // A task that explicitly raises the bound above the default keeps running
+    // past DEFAULT_MAX_ITERATIONS — the fallback only applies when omitted.
+    const task = makeTask({
+      constraints: { maxIterations: DEFAULT_MAX_ITERATIONS + 10 },
+      currentStep: DEFAULT_MAX_ITERATIONS + 5,
     });
     const result = engine.checkAction(task, { toolName: "web_fetch" });
 

--- a/src/autonomous/policy-engine.ts
+++ b/src/autonomous/policy-engine.ts
@@ -3,6 +3,16 @@ import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("PolicyEngine");
 
+/**
+ * Deterministic fallback iteration cap for tasks whose constraints omit an
+ * explicit `maxIterations`. Without this, an unconstrained task whose
+ * self-reflection never reports `goalAchieved: true` would run all the way to
+ * the global safety cap (`MAX_GLOBAL_ITERATIONS = 500` in loop.ts), burning
+ * ~1000 LLM calls before stopping. 50 keeps the cost ceiling well below that
+ * while leaving genuine multi-step tasks room to finish (issue #534 / WORK4-012).
+ */
+export const DEFAULT_MAX_ITERATIONS = 50;
+
 export interface PolicyConfig {
   tonSpending: {
     perTask: number;
@@ -138,11 +148,14 @@ export class PolicyEngine {
 
     const constraints = task.constraints as TaskConstraints;
 
-    // Check max iterations
-    if (constraints.maxIterations !== undefined && task.currentStep >= constraints.maxIterations) {
+    // Check max iterations. Fall back to DEFAULT_MAX_ITERATIONS when the task
+    // omits an explicit bound so unconstrained tasks still have a deterministic
+    // ceiling well below the global safety cap (issue #534 / WORK4-012).
+    const effectiveMaxIterations = constraints.maxIterations ?? DEFAULT_MAX_ITERATIONS;
+    if (task.currentStep >= effectiveMaxIterations) {
       violations.push({
         type: "max_iterations",
-        message: `Task has reached maximum iterations (${constraints.maxIterations})`,
+        message: `Task has reached maximum iterations (${effectiveMaxIterations})`,
       });
       blockingViolationCount++;
     }


### PR DESCRIPTION
## Описание

Закрывает #534 (WORK4-012).

### Проблема

Когда автономная задача создаётся без явного `constraints.maxIterations`, единственным ограничителем остаётся глобальный аварийный потолок `MAX_GLOBAL_ITERATIONS = 500` (`src/autonomous/loop.ts:24`). При этом:

- `evaluateSuccess` при непустых `successCriteria` всегда возвращает `false` (`src/autonomous/manager.ts:325-329`), так что единственный путь к завершению — `reflection.goalAchieved` от LLM-самооценки, которая при любой ошибке парсинга даёт `false`.
- В результате неудовлетворимая / зацикленная задача без `maxIterations` крутится до 500 итераций (~1000 LLM-вызовов + 500 tool-вызовов), прежде чем упасть.

### Исправление

`PolicyEngine.checkAction` теперь применяет детерминированный фолбэк `DEFAULT_MAX_ITERATIONS = 50`, когда `constraints.maxIterations` не задан:

```ts
const effectiveMaxIterations = constraints.maxIterations ?? DEFAULT_MAX_ITERATIONS;
if (task.currentStep >= effectiveMaxIterations) { /* блокирующее нарушение max_iterations */ }
```

Выбран policy-engine как централизованный шлюз enforcement: фолбэк покрывает **все** задачи единообразно — и новые, и восстановленные из БД, — независимо от того, как они были созданы. Явно заданный `maxIterations` по-прежнему имеет приоритет (фолбэк применяется только при отсутствии).

### Как воспроизвести

1. Запустить задачу с `successCriteria: ["..."]` и недостижимой целью, без `maxIterations`.
2. Reflection каждый ход возвращает `goalAchieved: false`.
3. **До фикса:** цикл доходит до 500 итераций. **После фикса:** задача останавливается на 50.

### Тесты

В `src/autonomous/__tests__/policy-engine.test.ts` добавлены:

- `applies a default iteration cap when constraints omit maxIterations` — проверяет `0 < DEFAULT_MAX_ITERATIONS < MAX_GLOBAL_ITERATIONS` (регресс-тест из issue);
- `blocks an unconstrained task once it reaches the default iteration cap`;
- `allows an unconstrained task while it is below the default iteration cap`;
- `lets an explicit maxIterations override the default cap`.

Все тесты автономного модуля проходят (62 теста в policy-engine/loop/integration), полный прогон — 3126 passed. `eslint` и `tsc --noEmit` чистые.

### Acceptance Criteria

- [x] Неограниченные задачи имеют разумный дефолтный потолок итераций значительно ниже 500 (50).
- [x] Тесты покрывают путь дефолтного потолка.
