### PR TITLE
fix(memory): выводить размерность вектора из активного эмбеддера и не терять строки при сбое вставки

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-10T17:36:58.271Z for PR creation at branch issue-537-2c8f3b5d7ddb for issue https://github.com/xlabtg/teleton-agent/issues/537

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-10T17:36:58.271Z for PR creation at branch issue-537-2c8f3b5d7ddb for issue https://github.com/xlabtg/teleton-agent/issues/537

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ## Current Fork Status
 
-Current fork version: `0.8.35`.
+Current fork version: `0.8.38`.
 
 This README reflects the `xlabtg/teleton-agent` fork through merged PR [#480](https://github.com/xlabtg/teleton-agent/pull/480) / closed issue [#479](https://github.com/xlabtg/teleton-agent/issues/479). It was refreshed from the closed work history available at issue [#481](https://github.com/xlabtg/teleton-agent/issues/481): 236 closed issues and the 200 most recent merged pull requests as of the latest analyzed run.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,7 +214,8 @@ export class TeletonApp {
       database: {
         path: join(TELETON_ROOT, "memory.db"),
         enableVectorSearch: embeddingProvider !== "none",
-        vectorDimensions: 384,
+        // vectorDimensions is derived from the active embedder in
+        // initializeMemory so vec tables always match the provider's output.
         onBeforeMigrate: (from, to) => createPreUpgradeBackup(from, to),
       },
       embeddings: {

--- a/src/memory/__tests__/database-vector-dimensions.test.ts
+++ b/src/memory/__tests__/database-vector-dimensions.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { MemoryDatabase } from "../database.js";
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("MemoryDatabase vector dimensions (issue #537)", () => {
+  let dir: string;
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function vecTableSql(db: MemoryDatabase, table: string): string {
+    return (
+      db.getDb().prepare(`SELECT sql FROM sqlite_master WHERE name = ?`).get(table) as {
+        sql: string;
+      }
+    ).sql;
+  }
+
+  it("creates vec0 tables at the configured dimension (non-384 provider)", () => {
+    dir = mkdtempSync(join(tmpdir(), "teleton-db-"));
+    const db = new MemoryDatabase({
+      path: join(dir, "memory.db"),
+      enableVectorSearch: true,
+      vectorDimensions: 1024, // e.g. Voyage voyage-3 (1024), not the local 384
+    });
+    try {
+      if (!db.isVectorSearchReady()) return; // sqlite-vec unavailable
+
+      expect(vecTableSql(db, "tg_messages_vec")).toContain("[1024]");
+      expect(vecTableSql(db, "knowledge_vec")).toContain("[1024]");
+      expect(db.getVectorDimensions()).toBe(1024);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/memory/__tests__/feed-messages.test.ts
+++ b/src/memory/__tests__/feed-messages.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Database from "better-sqlite3";
-import { ensureSchema } from "../schema.js";
+import * as sqliteVec from "sqlite-vec";
+import { ensureSchema, ensureVectorTables } from "../schema.js";
 import { MessageStore, type TelegramMessage } from "../feed/messages.js";
 import type { EmbeddingProvider } from "../embeddings/provider.js";
 
@@ -21,6 +22,29 @@ function makeEmbedder(embedding: number[] = []): EmbeddingProvider {
     embedQuery: vi.fn().mockResolvedValue(embedding),
     embedBatch: vi.fn().mockResolvedValue([embedding]),
   };
+}
+
+/** Vector of the given dimension filled with a constant, for vec0 inserts. */
+function vectorOfDim(dim: number, fill = 0.1): number[] {
+  return new Array(dim).fill(fill);
+}
+
+/**
+ * Create an in-memory DB with the sqlite-vec extension loaded and vec0 tables
+ * created at the given dimension. Returns null if sqlite-vec is unavailable.
+ */
+function createVectorDb(dimensions: number): InstanceType<typeof Database> | null {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  ensureSchema(db);
+  try {
+    sqliteVec.load(db);
+    ensureVectorTables(db, dimensions);
+  } catch {
+    db.close();
+    return null;
+  }
+  return db;
 }
 
 function makeMessage(overrides: Partial<TelegramMessage> = {}): TelegramMessage {
@@ -319,6 +343,80 @@ describe("MessageStore", () => {
       const msgs = store.getRecentMessages("chat-r");
       const child = msgs.find((m) => m.id === "child");
       expect(child!.replyToId).toBe("parent");
+    });
+  });
+
+  // ============================================
+  // Vector insert isolation (issue #537)
+  // ============================================
+
+  describe("vector insert isolation", () => {
+    it("stores message and vector for a non-384-dim provider (Voyage 1024)", async () => {
+      const vdb = createVectorDb(1024);
+      if (!vdb) return; // sqlite-vec unavailable in this environment
+      try {
+        const vecStore = new MessageStore(vdb, makeEmbedder(vectorOfDim(1024)), true);
+        await vecStore.storeMessage(makeMessage({ id: "m1", text: "hello" }));
+
+        const rowCount = (
+          vdb.prepare("SELECT COUNT(*) AS c FROM tg_messages WHERE id='m1'").get() as { c: number }
+        ).c;
+        const vecCount = (
+          vdb.prepare("SELECT COUNT(*) AS c FROM tg_messages_vec WHERE id='m1'").get() as {
+            c: number;
+          }
+        ).c;
+        expect(rowCount).toBe(1);
+        expect(vecCount).toBe(1);
+      } finally {
+        vdb.close();
+      }
+    });
+
+    it("does not drop the message row when the vector insert fails (dimension mismatch)", async () => {
+      // vec0 table expects 1024 dims, embedder emits 384 → vec insert fails the
+      // dimension check. The message row must still be stored.
+      const vdb = createVectorDb(1024);
+      if (!vdb) return;
+      try {
+        const vecStore = new MessageStore(vdb, makeEmbedder(vectorOfDim(384)), true);
+        await expect(
+          vecStore.storeMessage(makeMessage({ id: "m1", text: "hello" }))
+        ).resolves.not.toThrow();
+
+        const rowCount = (
+          vdb.prepare("SELECT COUNT(*) AS c FROM tg_messages WHERE id='m1'").get() as { c: number }
+        ).c;
+        const vecCount = (
+          vdb.prepare("SELECT COUNT(*) AS c FROM tg_messages_vec WHERE id='m1'").get() as {
+            c: number;
+          }
+        ).c;
+        expect(rowCount).toBe(1); // row preserved despite the vec failure
+        expect(vecCount).toBe(0); // vector degraded, not inserted
+      } finally {
+        vdb.close();
+      }
+    });
+
+    it("does not drop the message row when the embedder throws", async () => {
+      const throwingEmbedder: EmbeddingProvider = {
+        id: "mock",
+        model: "mock-model",
+        dimensions: 1024,
+        embedQuery: vi.fn().mockRejectedValue(new Error("provider down")),
+        embedBatch: vi.fn().mockResolvedValue([]),
+      };
+      const vecStore = new MessageStore(db, throwingEmbedder, true);
+
+      await expect(
+        vecStore.storeMessage(makeMessage({ id: "m1", text: "hello" }))
+      ).resolves.not.toThrow();
+
+      const rowCount = (
+        db.prepare("SELECT COUNT(*) AS c FROM tg_messages WHERE id='m1'").get() as { c: number }
+      ).c;
+      expect(rowCount).toBe(1);
     });
   });
 });

--- a/src/memory/agent/__tests__/knowledge-vector-isolation.test.ts
+++ b/src/memory/agent/__tests__/knowledge-vector-isolation.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Database from "better-sqlite3";
+import * as sqliteVec from "sqlite-vec";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureSchema, ensureVectorTables } from "../../schema.js";
+import { KnowledgeIndexer } from "../knowledge.js";
+import type { EmbeddingProvider } from "../../embeddings/provider.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function vectorOfDim(dim: number, fill = 0.1): number[] {
+  return new Array(dim).fill(fill);
+}
+
+/** Embedder that returns the same vector for every chunk. */
+function makeEmbedder(vector: number[]): EmbeddingProvider {
+  return {
+    id: "mock",
+    model: "mock-model",
+    dimensions: vector.length,
+    embedQuery: vi.fn().mockResolvedValue(vector),
+    embedBatch: vi.fn(async (texts: string[]) => texts.map(() => vector)),
+  };
+}
+
+/**
+ * In-memory DB with sqlite-vec loaded and vec0 tables at the given dimension.
+ * Returns null when sqlite-vec is unavailable in the environment.
+ */
+function createVectorDb(dimensions: number): InstanceType<typeof Database> | null {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  ensureSchema(db);
+  try {
+    sqliteVec.load(db);
+    ensureVectorTables(db, dimensions);
+  } catch {
+    db.close();
+    return null;
+  }
+  return db;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("KnowledgeIndexer vector isolation (issue #537)", () => {
+  let workspace: string;
+  let mdPath: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), "teleton-knowledge-"));
+    mdPath = join(workspace, "note.md");
+    writeFileSync(mdPath, "# Title\n\nSome knowledge content to embed and store.");
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("does not drop knowledge rows when the vector insert fails (dimension mismatch)", async () => {
+    // vec0 table expects 1024 dims, embedder emits 384 → vec insert fails.
+    const vdb = createVectorDb(1024);
+    if (!vdb) return; // sqlite-vec unavailable in this environment
+    try {
+      const indexer = new KnowledgeIndexer(vdb, workspace, makeEmbedder(vectorOfDim(384)), true);
+
+      const result = await indexer.indexFile(mdPath, true);
+      expect(result.indexed).toBe(true);
+
+      const rowCount = (
+        vdb.prepare("SELECT COUNT(*) AS c FROM knowledge WHERE source='memory'").get() as {
+          c: number;
+        }
+      ).c;
+      const vecCount = (
+        vdb.prepare("SELECT COUNT(*) AS c FROM knowledge_vec").get() as { c: number }
+      ).c;
+      expect(rowCount).toBeGreaterThan(0); // rows preserved despite vec failure
+      expect(vecCount).toBe(0); // vectors degraded, not inserted
+    } finally {
+      vdb.close();
+    }
+  });
+
+  it("does not drop knowledge rows when the embedder throws", async () => {
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    ensureSchema(db);
+    try {
+      const throwingEmbedder: EmbeddingProvider = {
+        id: "mock",
+        model: "mock-model",
+        dimensions: 1024,
+        embedQuery: vi.fn().mockResolvedValue([]),
+        embedBatch: vi.fn().mockRejectedValue(new Error("provider down")),
+      };
+      const indexer = new KnowledgeIndexer(db, workspace, throwingEmbedder, false);
+
+      const result = await indexer.indexFile(mdPath, true);
+      expect(result.indexed).toBe(true);
+
+      const rowCount = (
+        db.prepare("SELECT COUNT(*) AS c FROM knowledge WHERE source='memory'").get() as {
+          c: number;
+        }
+      ).c;
+      expect(rowCount).toBeGreaterThan(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("stores knowledge rows and vectors for a non-384-dim provider (Voyage 1024)", async () => {
+    const vdb = createVectorDb(1024);
+    if (!vdb) return;
+    try {
+      const indexer = new KnowledgeIndexer(vdb, workspace, makeEmbedder(vectorOfDim(1024)), true);
+
+      await indexer.indexFile(mdPath, true);
+
+      const rowCount = (
+        vdb.prepare("SELECT COUNT(*) AS c FROM knowledge WHERE source='memory'").get() as {
+          c: number;
+        }
+      ).c;
+      const vecCount = (
+        vdb.prepare("SELECT COUNT(*) AS c FROM knowledge_vec").get() as { c: number }
+      ).c;
+      expect(rowCount).toBeGreaterThan(0);
+      expect(vecCount).toBe(rowCount); // every chunk got a vector
+    } finally {
+      vdb.close();
+    }
+  });
+});

--- a/src/memory/agent/knowledge.ts
+++ b/src/memory/agent/knowledge.ts
@@ -125,7 +125,19 @@ export class KnowledgeIndexer {
 
     const chunks = this.chunkMarkdown(content, relPath);
     const texts = chunks.map((c) => c.text);
-    const embeddings = await this.embedder.embedBatch(texts);
+
+    // Compute embeddings outside the DB transaction. An embedding failure
+    // (network error, provider outage) must degrade to "chunks stored without
+    // vectors" rather than dropping the knowledge rows entirely.
+    let embeddings: number[][] = [];
+    try {
+      embeddings = await this.embedder.embedBatch(texts);
+    } catch (error) {
+      log.warn(
+        { err: error, path: relPath },
+        "Embedding failed; storing knowledge chunks without vectors"
+      );
+    }
     const indexedAt = Math.floor(Date.now() / 1000);
 
     this.db.transaction(() => {
@@ -147,10 +159,6 @@ export class KnowledgeIndexer {
         VALUES (?, 'memory', ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
-      const insertVec = this.vectorEnabled
-        ? this.db.prepare(`INSERT INTO knowledge_vec (id, embedding) VALUES (?, ?)`)
-        : null;
-
       for (let i = 0; i < chunks.length; i++) {
         const chunk = chunks[i];
         const embedding = embeddings[i] ?? [];
@@ -166,12 +174,32 @@ export class KnowledgeIndexer {
           indexedAt,
           indexedAt
         );
-
-        if (insertVec && embedding.length > 0) {
-          insertVec.run(chunk.id, serializeEmbedding(embedding));
-        }
       }
     })();
+
+    // Insert vectors in a separate transaction so a vec0 failure (e.g. a
+    // dimension mismatch when the active embedder differs from the table's
+    // configured dimension) cannot roll back the already-stored knowledge rows.
+    if (this.vectorEnabled) {
+      try {
+        this.db.transaction(() => {
+          const insertVec = this.db.prepare(
+            `INSERT INTO knowledge_vec (id, embedding) VALUES (?, ?)`
+          );
+          for (let i = 0; i < chunks.length; i++) {
+            const embedding = embeddings[i] ?? [];
+            if (embedding.length > 0) {
+              insertVec.run(chunks[i].id, serializeEmbedding(embedding));
+            }
+          }
+        })();
+      } catch (error) {
+        log.warn(
+          { err: error, path: relPath },
+          "Vector insert failed; knowledge chunks stored without vectors"
+        );
+      }
+    }
 
     for (const chunk of chunks) {
       try {

--- a/src/memory/feed/messages.ts
+++ b/src/memory/feed/messages.ts
@@ -1,10 +1,13 @@
 import type Database from "better-sqlite3";
 import type { EmbeddingProvider } from "../embeddings/provider.js";
 import { serializeEmbedding } from "../embeddings/index.js";
+import { createLogger } from "../../utils/logger.js";
 import {
   upsertTemporalMetadata,
   type TemporalContextConfig,
 } from "../../services/temporal-context.js";
+
+const log = createLogger("Memory");
 
 export interface TelegramMessage {
   id: string;
@@ -49,8 +52,20 @@ export class MessageStore {
       this.ensureUser(message.senderId);
     }
 
-    const embedding =
-      this.vectorEnabled && message.text ? await this.embedder.embedQuery(message.text) : [];
+    // Compute the embedding outside the DB transaction. An embedding failure
+    // (network error, provider outage) must degrade to "stored without vector"
+    // rather than dropping the message row entirely.
+    let embedding: number[] = [];
+    if (this.vectorEnabled && message.text) {
+      try {
+        embedding = await this.embedder.embedQuery(message.text);
+      } catch (error) {
+        log.warn(
+          { err: error, messageId: message.id },
+          "Embedding failed; storing message without vector"
+        );
+      }
+    }
     const embeddingBuffer = serializeEmbedding(embedding);
 
     this.db.transaction(() => {
@@ -76,17 +91,29 @@ export class MessageStore {
           message.timestamp
         );
 
-      if (this.vectorEnabled && embedding.length > 0 && message.text) {
-        this.db.prepare(`DELETE FROM tg_messages_vec WHERE id = ?`).run(message.id);
-        this.db
-          .prepare(`INSERT INTO tg_messages_vec (id, embedding) VALUES (?, ?)`)
-          .run(message.id, embeddingBuffer);
-      }
-
       this.db
         .prepare(`UPDATE tg_chats SET last_message_at = ?, last_message_id = ? WHERE id = ?`)
         .run(message.timestamp, message.id, message.chatId);
     })();
+
+    // Insert the vector in its own transaction so a vec0 failure (e.g. a
+    // dimension mismatch when the active embedder differs from the table's
+    // configured dimension) cannot roll back the already-stored message row.
+    if (this.vectorEnabled && embedding.length > 0 && message.text) {
+      try {
+        this.db.transaction(() => {
+          this.db.prepare(`DELETE FROM tg_messages_vec WHERE id = ?`).run(message.id);
+          this.db
+            .prepare(`INSERT INTO tg_messages_vec (id, embedding) VALUES (?, ?)`)
+            .run(message.id, embeddingBuffer);
+        })();
+      } catch (error) {
+        log.warn(
+          { err: error, messageId: message.id },
+          "Vector insert failed; message stored without vector"
+        );
+      }
+    }
 
     upsertTemporalMetadata(this.db, "message", message.id, message.timestamp, {
       timezone: this.temporalConfig?.timezone,

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -52,8 +52,17 @@ export function initializeMemory(config: {
   autonomous?: AutonomousConfig;
   workspaceDir: string;
 }): MemorySystem {
-  const db = getDatabase(config.database);
   const rawEmbedder = createEmbeddingProvider(config.embeddings);
+  // Derive the vec0 table dimension from the active embedder so the vector
+  // tables always match the provider's output. A hardcoded dimension only
+  // matches one provider (e.g. 384 for `local`) and silently breaks inserts
+  // for every other provider (Voyage 512/1024). The embedder is the single
+  // source of truth; only override when it reports a real dimension.
+  const databaseConfig: DatabaseConfig =
+    rawEmbedder.dimensions > 0
+      ? { ...config.database, vectorDimensions: rawEmbedder.dimensions }
+      : config.database;
+  const db = getDatabase(databaseConfig);
   const vectorEnabled = db.isVectorSearchReady();
   const database: Database.Database = db.getDb();
   const vectorStore = createSemanticVectorStoreFromConfig(config.vectorMemory);


### PR DESCRIPTION
## Описание

Закрывает #537.

### Проблема

vec0-таблицы создавались с жёстко заданной `vectorDimensions: 384`, что совпадало только с провайдером эмбеддингов `local`. Другие провайдеры выдают иные размерности (например, Voyage: `voyage-3-lite`=512, `voyage-3`=1024), поэтому вставка вектора падала на проверке размерности vec0. А поскольку вставка вектора выполнялась **внутри той же транзакции**, что и вставка базовой строки (без отдельного try/catch), сбой откатывал и саму строку сообщения/знания — данные молча терялись, а смена провайдера эффективно ломала ingestion.

### Решение

- **`src/memory/index.ts`** — `initializeMemory` выводит `vectorDimensions` из `embedder.dimensions` активного провайдера до создания БД. Эмбеддер — единственный источник истины; переопределение происходит только когда он сообщает реальную размерность (>0).
- **`src/index.ts`** — удалена жёстко заданная `vectorDimensions: 384`.
- **`src/memory/feed/messages.ts`** и **`src/memory/agent/knowledge.ts`**:
  - Вычисление эмбеддинга вынесено за пределы транзакции и обёрнуто в try/catch — сбой провайдера деградирует до «строка сохранена без вектора».
  - Вставка вектора вынесена в **отдельную транзакцию** с try/catch, поэтому ошибка vec0 (например, несоответствие размерности) больше не откатывает уже сохранённую базовую строку. Сбой логируется.
- **`README.md`** — синхронизирована версия форка (`0.8.38`) под существующий тест `src/docs/__tests__/readme.test.ts` (был красным на base из-за рассинхрона с `package.json`).

### Как воспроизвести (до фикса)

1. Установить провайдер эмбеддингов `anthropic` (Voyage, 1024-dim).
2. Загрузить сообщение/знание.
3. Вставка вектора падает по размерности, транзакция откатывается — строка сообщения не сохраняется.

### Тесты

Регрессионные тесты с провайдером размерности 1024 (не 384), end-to-end через реальное расширение `sqlite-vec`:

- `src/memory/__tests__/feed-messages.test.ts` (блок «vector insert isolation»):
  - сообщение и вектор сохраняются для 1024-dim провайдера;
  - при несоответствии размерности строка сообщения **сохраняется** (вектор деградирует, `vecCount=0`);
  - при исключении эмбеддера строка сообщения **сохраняется**.
- `src/memory/agent/__tests__/knowledge-vector-isolation.test.ts` — те же сценарии для `KnowledgeIndexer`.
- `src/memory/__tests__/database-vector-dimensions.test.ts` — vec0-таблицы создаются с настроенной размерностью (`FLOAT[1024]`).

Проверено, что новые тесты падают на старом коде (2 из 3 в каждом файле) и проходят на новом. Полный прогон: **3669 тестов проходят**, `tsc --noEmit` и `eslint --max-warnings 0` чисты.

### Критерии приёмки

- [x] vec-таблицы создаются с размерностью активного эмбеддера.
- [x] Сбой вставки эмбеддинга не приводит к потере базовой строки.
- [x] Тесты покрывают провайдер не на 384 end-to-end.
