### PR TITLE
perf(memory): не пересчитывать все оценки при getStats

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-10T18:20:56.304Z for PR creation at branch issue-539-c5520ed04c58 for issue https://github.com/xlabtg/teleton-agent/issues/539

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-10T18:20:56.304Z for PR creation at branch issue-539-c5520ed04c58 for issue https://github.com/xlabtg/teleton-agent/issues/539

--- a/src/memory/__tests__/prioritization.test.ts
+++ b/src/memory/__tests__/prioritization.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Database from "better-sqlite3";
 import { ensureSchema } from "../schema.js";
 import { MemoryScorer } from "../scoring.js";
@@ -90,6 +90,24 @@ describe("memory prioritization", () => {
     expect(important!.centrality).toBeGreaterThan(0);
     expect(important!.score).toBeGreaterThanOrEqual(0);
     expect(important!.score).toBeLessThanOrEqual(1);
+  });
+
+  it("does not recalculate all scores on getStats", () => {
+    insertKnowledge(db, "plain", "casual note about lunch");
+    insertKnowledge(db, "important", "remember this wallet recovery decision about TON");
+
+    const scorer = new MemoryScorer(db);
+    // Persist scores once so getStats has data to read.
+    scorer.recalculateAll();
+
+    const recalculateAll = vi.spyOn(scorer, "recalculateAll");
+    const recalculate = vi.spyOn(scorer, "recalculate");
+
+    const stats = scorer.getStats();
+
+    expect(recalculateAll).not.toHaveBeenCalled();
+    expect(recalculate).not.toHaveBeenCalled();
+    expect(stats.total).toBe(2);
   });
 
   it("archives low-value cleanup candidates and protects pinned memories", async () => {

--- a/src/memory/scoring.ts
+++ b/src/memory/scoring.ts
@@ -333,7 +333,11 @@ export class MemoryScorer {
   }
 
   getStats(bucketCount = 10): MemoryScoreStats {
-    this.recalculateAll();
+    // Read-only: report already-persisted scores instead of forcing a full
+    // recompute on every call. Recalculation is driven on a schedule by
+    // MemoryPrioritizationScheduler (or on explicit demand via
+    // recalculateAll), so a stats/dashboard read stays O(N read) and never
+    // triggers the O(N·M) centrality pass.
     const safeBucketCount = Math.max(1, Math.min(50, Math.floor(bucketCount)));
     const rows = this.db.prepare(`SELECT score, pinned FROM memory_scores`).all() as Array<{
       score: number;


### PR DESCRIPTION
## Описание

Исправляет #539.

### Проблема

`MemoryScorer.getStats` при каждом вызове запускал `recalculateAll`, который:
- пересчитывает оценку каждой памяти — O(N) по всем записям,
- пересчитывает графовую центральность — проход O(N·M).

Таким образом, read-only запрос статистики (например, периодический поллинг дашборда памяти через `GET /scores/stats`) провоцировал полный дорогой пересчёт, а латентность росла пропорционально размеру графа памяти.

### Решение

`getStats` теперь только читает уже сохранённые в `memory_scores` оценки и не запускает никакого пересчёта. Пересчёт по-прежнему выполняется:
- **по расписанию** — через `MemoryPrioritizationScheduler` (запускается в `initializeMemory`);
- **по явному требованию** — через `recalculateAll` / `recalculate` (используется планировщиком и сервисом retention).

Изменение точечное: удалён единственный вызов `this.recalculateAll()` из `getStats`, остальная логика (бакеты распределения, средняя оценка, число закреплённых) без изменений.

### Как воспроизвести

1. Наполнить большой граф памяти (много узлов/рёбер).
2. Многократно вызвать `getStats` / эндпоинт статистики (поллинг дашборда).
3. До фикса — полный пересчёт и рост латентности на каждый вызов; после фикса — только чтение сохранённых оценок.

### Тест

Добавлен регрессионный тест в `src/memory/__tests__/prioritization.test.ts`:

```typescript
it("does not recalculate all scores on getStats", () => {
  // ...persist scores once
  const recalculateAll = vi.spyOn(scorer, "recalculateAll");
  const recalculate = vi.spyOn(scorer, "recalculate");
  const stats = scorer.getStats();
  expect(recalculateAll).not.toHaveBeenCalled();
  expect(recalculate).not.toHaveBeenCalled();
  expect(stats.total).toBe(2);
});
```

### Критерии приёмки

- [x] `getStats` — O(N read) и не запускает пересчёт центральности.
- [x] Пересчёт выполняется по расписанию (`MemoryPrioritizationScheduler`) или по явному требованию (`recalculateAll`).
- [x] Тест проверяет, что `getStats` не вызывает `recalculateAll`.

### Проверки

- `npx vitest run src/memory/ src/webui/routes` — 376 тестов проходят.
- `npx eslint` по затронутым файлам — без замечаний.
- `npx tsc --noEmit` — без ошибок.



Fixes xlabtg/teleton-agent#539