### PR TITLE
fix(groq): санитизация тел ошибок upstream в STT/TTS провайдерах

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-10T18:28:36.900Z for PR creation at branch issue-540-6970e0af3878 for issue https://github.com/xlabtg/teleton-agent/issues/540

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-10T18:28:36.900Z for PR creation at branch issue-540-6970e0af3878 for issue https://github.com/xlabtg/teleton-agent/issues/540

--- a/src/providers/__tests__/groq-stt-tts-provider.test.ts
+++ b/src/providers/__tests__/groq-stt-tts-provider.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+// Avoid real backoff delays from the rate limiter on retried errors.
+vi.mock("../groq/rateLimiter.js", async (importActual) => {
+  const actual = await importActual<typeof import("../groq/rateLimiter.js")>();
+  return {
+    ...actual,
+    withGroqRateLimit: <T>(fn: () => Promise<T>) => fn(),
+  };
+});
+
+import { groqTranscribe } from "../groq/GroqSTTProvider.js";
+import { groqSpeak } from "../groq/GroqTTSProvider.js";
+
+function mockGroqError(status: number, body: string) {
+  const mockResponse = {
+    ok: false,
+    status,
+    text: vi.fn().mockResolvedValue(body),
+  };
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse));
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("groqTranscribe — error body sanitization", () => {
+  it("sanitizes and truncates Groq STT upstream error bodies", async () => {
+    mockGroqError(500, "x".repeat(5000) + " sk-secret-internal-detail");
+
+    const err = await groqTranscribe(Buffer.from("audio"), "audio.mp3", {
+      apiKey: "gsk_key",
+    }).catch((e: Error) => e.message);
+
+    expect(err.length).toBeLessThan(512);
+    expect(err).not.toContain("sk-secret-internal-detail");
+    expect(err).toContain("…");
+  });
+
+  it("redacts gsk_ tokens in STT error bodies", async () => {
+    mockGroqError(403, '{"error":"token gsk_verysecrettoken123 not authorized"}');
+
+    const err = await groqTranscribe(Buffer.from("audio"), "audio.mp3", {
+      apiKey: "gsk_key",
+    }).catch((e: Error) => e.message);
+
+    expect(err).not.toContain("gsk_verysecrettoken123");
+    expect(err).toContain("[REDACTED]");
+  });
+});
+
+describe("groqSpeak — error body sanitization", () => {
+  it("sanitizes and truncates Groq TTS upstream error bodies", async () => {
+    mockGroqError(500, "x".repeat(5000) + " sk-secret-internal-detail");
+
+    const err = await groqSpeak("hello", { apiKey: "gsk_key" }).catch((e: Error) => e.message);
+
+    expect(err.length).toBeLessThan(512);
+    expect(err).not.toContain("sk-secret-internal-detail");
+    expect(err).toContain("…");
+  });
+
+  it("redacts Bearer tokens in TTS error bodies", async () => {
+    mockGroqError(401, "Bearer gsk_sometoken: forbidden");
+
+    const err = await groqSpeak("hello", { apiKey: "gsk_key" }).catch((e: Error) => e.message);
+
+    expect(err).not.toContain("gsk_sometoken");
+    expect(err).toContain("[REDACTED]");
+  });
+});

--- a/src/providers/groq/GroqSTTProvider.ts
+++ b/src/providers/groq/GroqSTTProvider.ts
@@ -8,6 +8,7 @@
 
 import { createLogger } from "../../utils/logger.js";
 import { withGroqRateLimit, parseGroqErrorType } from "./rateLimiter.js";
+import { sanitizeErrorBody } from "./errorSanitizer.js";
 
 const log = createLogger("GroqSTT");
 
@@ -88,7 +89,7 @@ export async function groqTranscribe(
     if (!response.ok) {
       const errorType = parseGroqErrorType(response.status);
       const errorBody = await response.text().catch(() => "");
-      const msg = `Groq STT error (${response.status} ${errorType}): ${errorBody}`;
+      const msg = `Groq STT error (${response.status} ${errorType}): ${sanitizeErrorBody(errorBody)}`;
       log.error(msg);
       throw new Error(msg);
     }

--- a/src/providers/groq/GroqTTSProvider.ts
+++ b/src/providers/groq/GroqTTSProvider.ts
@@ -7,6 +7,7 @@
 
 import { createLogger } from "../../utils/logger.js";
 import { withGroqRateLimit, parseGroqErrorType } from "./rateLimiter.js";
+import { sanitizeErrorBody } from "./errorSanitizer.js";
 import { GROQ_API_BASE } from "./GroqSTTProvider.js";
 
 const log = createLogger("GroqTTS");
@@ -87,7 +88,7 @@ export async function groqSpeak(text: string, options: GroqSpeechOptions): Promi
     if (!response.ok) {
       const errorType = parseGroqErrorType(response.status);
       const errorBody = await response.text().catch(() => "");
-      const msg = `Groq TTS error (${response.status} ${errorType}): ${errorBody}`;
+      const msg = `Groq TTS error (${response.status} ${errorType}): ${sanitizeErrorBody(errorBody)}`;
       log.error(msg);
       throw new Error(msg);
     }

--- a/src/providers/groq/GroqTextProvider.ts
+++ b/src/providers/groq/GroqTextProvider.ts
@@ -12,18 +12,10 @@
 
 import { createLogger } from "../../utils/logger.js";
 import { withGroqRateLimit, parseGroqErrorType } from "./rateLimiter.js";
+import { sanitizeErrorBody } from "./errorSanitizer.js";
 import { GROQ_API_BASE } from "./GroqSTTProvider.js";
 
 const log = createLogger("GroqText");
-
-const SECRET_PATTERN = /(sk-|gsk_|Bearer )\S+/g;
-const MAX_ERROR_BODY_LENGTH = 200;
-
-function sanitizeErrorBody(body: string): string {
-  const truncated =
-    body.length > MAX_ERROR_BODY_LENGTH ? body.slice(0, MAX_ERROR_BODY_LENGTH) + "…" : body;
-  return truncated.replace(SECRET_PATTERN, "[REDACTED]");
-}
 
 export interface GroqMessage {
   role: "system" | "user" | "assistant";

--- a/src/providers/groq/errorSanitizer.ts
+++ b/src/providers/groq/errorSanitizer.ts
@@ -1,0 +1,26 @@
+/**
+ * Groq Error Body Sanitizer
+ *
+ * Shared helper for sanitizing upstream Groq error response bodies before
+ * surfacing them through API responses. Truncates long bodies and strips
+ * secret-looking tokens to avoid information disclosure (raw, untruncated
+ * upstream detail / request echoes / internal identifiers).
+ */
+
+/** Matches secret-looking tokens (API keys, Bearer tokens) in error bodies. */
+const SECRET_PATTERN = /(sk-|gsk_|Bearer )\S+/g;
+
+/** Maximum length of an upstream error body before truncation. */
+export const MAX_ERROR_BODY_LENGTH = 200;
+
+/**
+ * Truncate an upstream error body and redact secret-looking tokens.
+ *
+ * @param body - Raw upstream error response body
+ * @returns Sanitized, length-bounded string safe to surface to clients
+ */
+export function sanitizeErrorBody(body: string): string {
+  const truncated =
+    body.length > MAX_ERROR_BODY_LENGTH ? body.slice(0, MAX_ERROR_BODY_LENGTH) + "…" : body;
+  return truncated.replace(SECRET_PATTERN, "[REDACTED]");
+}


### PR DESCRIPTION
## 🤖 Решение

Закрывает #540

### 📋 Проблема
Провайдеры Groq STT (`GroqSTTProvider`) и TTS (`GroqTTSProvider`) подставляли
сырое тело ответа об ошибке upstream прямо в текст исключения. Эти сообщения
всплывают через WebUI-маршруты Groq (`src/webui/routes/groq.ts`), раскрывая
клиентам необрезанные детали ошибок Groq (потенциально эхо запросов и
внутренние идентификаторы). Текстовый провайдер при этом уже санитизировал
тело через `sanitizeErrorBody`.

### 🔧 Решение
- Вынес `sanitizeErrorBody` (обрезка до 200 символов + редактирование
  секрето-подобных токенов `sk-`/`gsk_`/`Bearer`) в общий хелпер
  `src/providers/groq/errorSanitizer.ts`.
- Применил хелпер в `GroqSTTProvider` и `GroqTTSProvider`.
- `GroqTextProvider` переключён на общий хелпер (поведение не изменилось).

### ✅ Регрессионные тесты
Добавлен `src/providers/__tests__/groq-stt-tts-provider.test.ts`:
- STT/TTS обрезают длинные тела ошибок (< 512 символов) и не отражают сырой
  upstream-детали (`sk-secret-internal-detail`).
- Секрето-подобные токены (`gsk_…`, `Bearer …`) заменяются на `[REDACTED]`.

### 🧪 Проверка
- `vitest run` по затронутым тестам — 17 passed.
- `eslint --max-warnings 0`, `prettier --check`, `tsc --noEmit` — без ошибок.

### Критерии приёмки
- [x] Ошибки STT/TTS санитизируются и ограничиваются по длине перед отдачей.
- [x] Тесты проверяют, что сырые upstream-тела не отражаются.



Fixes xlabtg/teleton-agent#540