### PR TITLE
feat(services): добавить TaskScheduler для фоновой диспетчеризации задач

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-10T18:34:50.989Z for PR creation at branch issue-542-c8e0eba45551 for issue https://github.com/xlabtg/teleton-agent/issues/542

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-10T18:34:50.989Z for PR creation at branch issue-542-c8e0eba45551 for issue https://github.com/xlabtg/teleton-agent/issues/542

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ import { getEventBus } from "./services/event-bus.js";
 import { getWebhookDispatcher } from "./services/webhook-dispatcher.js";
 import { flushOffsets } from "./telegram/offset-store.js";
 import { WorkflowScheduler } from "./services/workflow-scheduler.js";
+import { TaskScheduler } from "./services/task-scheduler.js";
 import { ManagedAgentService } from "./agents/service.js";
 import type { ManagedAgentMode } from "./agents/types.js";
 
@@ -144,6 +145,7 @@ export class TeletonApp {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private heartbeatRunning = false;
   private workflowScheduler: WorkflowScheduler | null = null;
+  private taskScheduler: TaskScheduler | null = null;
   private autonomousManager: AutonomousTaskManager | null = null;
   private agentManager: ManagedAgentService;
   private readonly agentMode: ManagedAgentMode;
@@ -949,6 +951,14 @@ ${blue}  ┌──────────────────────�
       log.warn({ err }, "Workflow agent.start event failed");
     });
 
+    // Start DB-backed task scheduler — picks up tasks whose scheduled_for has
+    // elapsed and executes them, independent of any Telegram delivery.
+    this.taskScheduler = new TaskScheduler({
+      db: getDatabase().getDb(),
+      executeTask: (task) => this.executeScheduledTaskFromScheduler(task),
+    });
+    this.taskScheduler.start();
+
     // Start heartbeat timer if enabled
     if (this.config.heartbeat.enabled) {
       const hbInterval = this.config.heartbeat.interval_ms;
@@ -1260,7 +1270,6 @@ ${blue}  ┌──────────────────────�
   private async handleScheduledTask(message: TelegramMessage): Promise<void> {
     // Hoist all dynamic imports to top of function
     const { getTaskStore } = await import("./memory/agent/tasks.js");
-    const { executeScheduledTask } = await import("./telegram/task-executor.js");
     const { TaskDependencyResolver } = await import("./telegram/task-dependency-resolver.js");
     const { getDatabase } = await import("./memory/index.js");
 
@@ -1315,73 +1324,16 @@ ${blue}  ┌──────────────────────�
         return;
       }
 
-      // Mark task as in_progress
-      taskStore.startTask(taskId);
-
-      // Get parent task results for context
-      const parentResults = taskStore.getParentResults(taskId);
-
-      // Build tool context
-      const toolContext = {
-        bridge: this.bridge,
-        db,
+      // Execute via the shared core (claims the task, runs the agent,
+      // persists the result, fires dependents, reschedules recurrence).
+      await this.executeTaskRecord(task, {
         chatId: message.chatId,
         isGroup: message.isGroup,
         senderId: message.senderId,
-        config: this.config,
-      };
-
-      // Get tool registry from agent runtime
-      const toolRegistry = this.agent.getToolRegistry();
-
-      // Execute task and get prompt for agent (with parent context)
-      const agentPrompt = await executeScheduledTask(
-        task,
-        this.agent,
-        toolContext,
-        toolRegistry,
-        parentResults
-      );
-
-      // Feed prompt to agent (agent loop with full context)
-      const response = await this.agent.processMessage({
-        chatId: message.chatId,
-        userMessage: agentPrompt,
-        userName: "self-scheduled-task",
-        timestamp: message.timestamp.getTime(),
-        isGroup: false,
-        toolContext,
         messageId: message.id,
-        taskId,
+        timestamp: message.timestamp.getTime(),
       });
-
-      // Send agent response
-      if (response.content && response.content.trim().length > 0) {
-        await this.bridge.sendMessage({
-          chatId: message.chatId,
-          text: response.content,
-          replyToId: message.id,
-        });
-      }
-
-      // Mark task as done if agent responded successfully
-      taskStore.completeTask(taskId, response.content);
       shouldDeleteTriggerMessage = true;
-
-      log.info(`✅ Executed scheduled task ${taskId}: ${task.description}`);
-
-      // Initialize dependency resolver if needed
-      if (!this.dependencyResolver) {
-        this.dependencyResolver = new TaskDependencyResolver(taskStore, this.bridge);
-      }
-
-      // Trigger any dependent tasks
-      await this.dependencyResolver.onTaskComplete(taskId);
-
-      // Reschedule recurring tasks
-      if (task.recurrenceInterval && task.recurrenceInterval > 0) {
-        await this.rescheduleRecurringTask(task, taskStore);
-      }
     } catch (error) {
       log.error({ err: error }, "Error handling scheduled task");
       shouldDeleteTriggerMessage = true;
@@ -1403,6 +1355,148 @@ ${blue}  ┌──────────────────────�
     } finally {
       if (shouldDeleteTriggerMessage) {
         await this.deleteScheduledTaskTriggerMessage(message);
+      }
+    }
+  }
+
+  /**
+   * Shared execution core for a single scheduled task record.
+   *
+   * Atomically claims the task (preventing double execution when both the Saved
+   * Messages `[TASK:]` trigger and the DB-backed {@link TaskScheduler} fire),
+   * runs it through the agent loop, persists the result, fires dependent tasks,
+   * and reschedules recurring tasks.
+   *
+   * @returns true if this caller claimed and executed the task; false if it was
+   *          already claimed/terminal and skipped.
+   * @throws on execution error so the caller can mark the task failed.
+   */
+  private async executeTaskRecord(
+    task: Task,
+    ctx: {
+      chatId: string;
+      isGroup?: boolean;
+      senderId?: number;
+      messageId?: number;
+      timestamp?: number;
+    }
+  ): Promise<boolean> {
+    const { getTaskStore } = await import("./memory/agent/tasks.js");
+    const { executeScheduledTask } = await import("./telegram/task-executor.js");
+    const { TaskDependencyResolver } = await import("./telegram/task-dependency-resolver.js");
+    const { getDatabase } = await import("./memory/index.js");
+
+    const db = getDatabase().getDb();
+    const taskStore = getTaskStore(db);
+
+    // Atomic claim — only one caller can flip pending → in_progress.
+    if (!taskStore.claimTask(task.id)) {
+      log.info(`⏭️ Task ${task.id} already claimed or not pending, skipping`);
+      return false;
+    }
+
+    // Get parent task results for context
+    const parentResults = taskStore.getParentResults(task.id);
+
+    // Build tool context
+    const toolContext = {
+      bridge: this.bridge,
+      db,
+      chatId: ctx.chatId,
+      isGroup: ctx.isGroup ?? false,
+      senderId: ctx.senderId ?? 0,
+      config: this.config,
+    };
+
+    // Get tool registry from agent runtime
+    const toolRegistry = this.agent.getToolRegistry();
+
+    // Execute task and get prompt for agent (with parent context)
+    const agentPrompt = await executeScheduledTask(
+      task,
+      this.agent,
+      toolContext,
+      toolRegistry,
+      parentResults
+    );
+
+    // Feed prompt to agent (agent loop with full context)
+    const response = await this.agent.processMessage({
+      chatId: ctx.chatId,
+      userMessage: agentPrompt,
+      userName: "self-scheduled-task",
+      timestamp: ctx.timestamp ?? Date.now(),
+      isGroup: false,
+      toolContext,
+      messageId: ctx.messageId,
+      taskId: task.id,
+    });
+
+    // Send agent response
+    if (response.content && response.content.trim().length > 0) {
+      await this.bridge.sendMessage({
+        chatId: ctx.chatId,
+        text: response.content,
+        replyToId: ctx.messageId,
+      });
+    }
+
+    // Mark task as done if agent responded successfully
+    taskStore.completeTask(task.id, response.content);
+
+    log.info(`✅ Executed scheduled task ${task.id}: ${task.description}`);
+
+    // Initialize dependency resolver if needed
+    if (!this.dependencyResolver) {
+      this.dependencyResolver = new TaskDependencyResolver(taskStore, this.bridge);
+    }
+
+    // Trigger any dependent tasks
+    await this.dependencyResolver.onTaskComplete(task.id);
+
+    // Reschedule recurring tasks
+    if (task.recurrenceInterval && task.recurrenceInterval > 0) {
+      await this.rescheduleRecurringTask(task, taskStore);
+    }
+
+    return true;
+  }
+
+  /**
+   * Execute a task picked up by the DB-backed {@link TaskScheduler}.
+   *
+   * Unlike the Saved Messages trigger there is no incoming message — results go
+   * to the owner's Saved Messages chat. On failure the task is marked failed and
+   * the failure cascades to dependents.
+   */
+  private async executeScheduledTaskFromScheduler(task: Task): Promise<void> {
+    const { getTaskStore } = await import("./memory/agent/tasks.js");
+    const { TaskDependencyResolver } = await import("./telegram/task-dependency-resolver.js");
+    const { getDatabase } = await import("./memory/index.js");
+
+    const ownId = this.bridge.getOwnUserId();
+    const chatId = ownId !== undefined ? String(ownId) : "";
+    const senderId = ownId !== undefined ? Number(ownId) : 0;
+
+    try {
+      await this.executeTaskRecord(task, {
+        chatId,
+        isGroup: false,
+        senderId,
+        timestamp: Date.now(),
+      });
+    } catch (error) {
+      log.error({ err: error, taskId: task.id }, "Scheduler failed to execute task");
+      try {
+        const db = getDatabase().getDb();
+        const taskStore = getTaskStore(db);
+        taskStore.failTask(task.id, getErrorMessage(error));
+        if (!this.dependencyResolver) {
+          this.dependencyResolver = new TaskDependencyResolver(taskStore, this.bridge);
+        }
+        await this.dependencyResolver.onTaskFail(task.id);
+      } catch {
+        // Ignore if we can't update task
       }
     }
   }
@@ -1781,6 +1875,12 @@ ${blue}  ┌──────────────────────�
       this.workflowScheduler.stop();
       this.workflowScheduler = null;
       this.agent.setOnToolCompleteCallback(undefined);
+    }
+
+    // Stop DB-backed task scheduler
+    if (this.taskScheduler) {
+      this.taskScheduler.stop();
+      this.taskScheduler = null;
     }
 
     // Stop heartbeat timer

--- a/src/memory/agent/tasks.ts
+++ b/src/memory/agent/tasks.ts
@@ -243,6 +243,49 @@ export class TaskStore {
     return this.updateTask(taskId, { status: "in_progress" });
   }
 
+  /**
+   * Atomically claim a pending task for execution.
+   *
+   * Flips `status` from `pending` to `in_progress` in a single UPDATE so that
+   * only one caller can ever win — this prevents double execution when both the
+   * Saved Messages `[TASK:]` trigger and the DB-backed {@link TaskScheduler}
+   * fire for the same task, or when two scheduler ticks overlap.
+   *
+   * @returns true if this caller claimed the task; false if it was already
+   *          claimed, terminal, or does not exist.
+   */
+  claimTask(taskId: string): boolean {
+    const now = Math.floor(Date.now() / 1000);
+    const result = this.db
+      .prepare(
+        `UPDATE tasks
+         SET status = 'in_progress', started_at = COALESCE(started_at, ?)
+         WHERE id = ? AND status = 'pending'`
+      )
+      .run(now, taskId);
+    return result.changes > 0;
+  }
+
+  /**
+   * Return all pending tasks whose `scheduled_for` is at or before `nowSeconds`.
+   * Used by the {@link TaskScheduler} tick loop to find tasks due for execution.
+   * Tasks without a `scheduled_for` (e.g. dependency-triggered tasks) are
+   * excluded — they are dispatched by the dependency resolver instead.
+   */
+  getDueTasks(nowSeconds: number = Math.floor(Date.now() / 1000)): Task[] {
+    const rows = this.db
+      .prepare(
+        `SELECT * FROM tasks
+         WHERE status = 'pending'
+           AND scheduled_for IS NOT NULL
+           AND scheduled_for <= ?
+         ORDER BY priority DESC, scheduled_for ASC`
+      )
+      .all(nowSeconds) as TaskRow[];
+
+    return rows.map(rowToTask);
+  }
+
   cancelTask(taskId: string): Task | undefined {
     const task = this.getTask(taskId);
     if (!task) return undefined;

--- a/src/services/__tests__/task-scheduler.test.ts
+++ b/src/services/__tests__/task-scheduler.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import { ensureSchema } from "../../memory/schema.js";
+import { TaskStore, getTaskStore } from "../../memory/agent/tasks.js";
+import { TaskScheduler } from "../task-scheduler.js";
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+function createDb(): InstanceType<typeof Database> {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  ensureSchema(db);
+  return db;
+}
+
+describe("TaskStore claim + due-task queries", () => {
+  let db: InstanceType<typeof Database>;
+  let store: TaskStore;
+
+  beforeEach(() => {
+    db = createDb();
+    store = getTaskStore(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("claimTask flips pending → in_progress exactly once", () => {
+    const task = store.createTask({ description: "claim me" });
+
+    expect(store.claimTask(task.id)).toBe(true);
+    expect(store.getTask(task.id)?.status).toBe("in_progress");
+    expect(store.getTask(task.id)?.startedAt).toBeInstanceOf(Date);
+
+    // Second claim returns false (already in_progress).
+    expect(store.claimTask(task.id)).toBe(false);
+  });
+
+  it("claimTask refuses to reclaim terminal tasks", () => {
+    const task = store.createTask({ description: "done already" });
+    store.completeTask(task.id, "ok");
+
+    expect(store.claimTask(task.id)).toBe(false);
+    expect(store.getTask(task.id)?.status).toBe("done");
+  });
+
+  it("claimTask returns false for unknown task id", () => {
+    expect(store.claimTask("does-not-exist")).toBe(false);
+  });
+
+  it("getDueTasks returns only pending tasks whose scheduled_for has elapsed", () => {
+    const past = new Date(Date.now() - 60_000);
+    const future = new Date(Date.now() + 60_000);
+
+    const due = store.createTask({ description: "past", scheduledFor: past });
+    store.createTask({ description: "future", scheduledFor: future });
+    store.createTask({ description: "no schedule" });
+    const inProgress = store.createTask({ description: "running", scheduledFor: past });
+    store.startTask(inProgress.id);
+
+    const result = store.getDueTasks();
+    expect(result.map((t) => t.id)).toEqual([due.id]);
+  });
+
+  it("getDueTasks accepts a custom now and orders by priority desc", () => {
+    const past = new Date("2026-01-01T00:00:00Z");
+    const low = store.createTask({ description: "low", scheduledFor: past, priority: 1 });
+    const high = store.createTask({ description: "high", scheduledFor: past, priority: 9 });
+
+    const result = store.getDueTasks(Math.floor(past.getTime() / 1000) + 1);
+    expect(result.map((t) => t.id)).toEqual([high.id, low.id]);
+  });
+});
+
+describe("TaskScheduler", () => {
+  let db: InstanceType<typeof Database>;
+  let store: TaskStore;
+
+  beforeEach(() => {
+    db = createDb();
+    store = getTaskStore(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("tick() executes every due task once", async () => {
+    const past = new Date(Date.now() - 1000);
+    const t1 = store.createTask({ description: "one", scheduledFor: past });
+    const t2 = store.createTask({ description: "two", scheduledFor: past });
+
+    const executeTask = vi.fn().mockResolvedValue(undefined);
+    const scheduler = new TaskScheduler({ db, executeTask });
+
+    await scheduler.tick();
+
+    expect(executeTask).toHaveBeenCalledTimes(2);
+    const calledIds = executeTask.mock.calls.map(([t]) => t.id).sort();
+    expect(calledIds).toEqual([t1.id, t2.id].sort());
+  });
+
+  it("tick() skips tasks scheduled for the future", async () => {
+    store.createTask({ description: "later", scheduledFor: new Date(Date.now() + 60_000) });
+
+    const executeTask = vi.fn().mockResolvedValue(undefined);
+    const scheduler = new TaskScheduler({ db, executeTask });
+
+    await scheduler.tick();
+    expect(executeTask).not.toHaveBeenCalled();
+  });
+
+  it("tick() skips tasks whose dependencies are not satisfied", async () => {
+    const parent = store.createTask({ description: "parent" });
+    const child = store.createTask({
+      description: "child",
+      scheduledFor: new Date(Date.now() - 1000),
+      dependsOn: [parent.id],
+    });
+
+    const executeTask = vi.fn().mockResolvedValue(undefined);
+    const scheduler = new TaskScheduler({ db, executeTask });
+
+    await scheduler.tick();
+    expect(executeTask).not.toHaveBeenCalledWith(expect.objectContaining({ id: child.id }));
+  });
+
+  it("tick() swallows executor errors without crashing the loop", async () => {
+    const past = new Date(Date.now() - 1000);
+    store.createTask({ description: "fails", scheduledFor: past });
+    store.createTask({ description: "succeeds", scheduledFor: past });
+
+    const executeTask = vi
+      .fn<(task: { id: string }) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(undefined);
+    const scheduler = new TaskScheduler({ db, executeTask });
+
+    await expect(scheduler.tick()).resolves.toBeUndefined();
+    expect(executeTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("start() schedules ticks at the configured interval and stop() clears them", async () => {
+    vi.useFakeTimers();
+    try {
+      // Realistic executor: atomic claim + complete, so the same task isn't
+      // re-executed on the next tick.
+      const executeTask = vi.fn(async (task: { id: string }) => {
+        if (store.claimTask(task.id)) {
+          store.completeTask(task.id, "ok");
+        }
+      });
+      const scheduler = new TaskScheduler({ db, executeTask, tickIntervalMs: 1_000 });
+
+      const past = new Date(Date.now() - 1000);
+      store.createTask({ description: "first", scheduledFor: past });
+
+      scheduler.start();
+      // Initial tick is queued via a microtask — flush all pending promises.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(executeTask).toHaveBeenCalledTimes(1);
+
+      store.createTask({ description: "second", scheduledFor: past });
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(executeTask).toHaveBeenCalledTimes(2);
+
+      scheduler.stop();
+      store.createTask({ description: "third", scheduledFor: past });
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(executeTask).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/services/task-scheduler.ts
+++ b/src/services/task-scheduler.ts
@@ -1,0 +1,95 @@
+import type Database from "better-sqlite3";
+import { getTaskStore, type Task, type TaskStore } from "../memory/agent/tasks.js";
+import { createLogger } from "../utils/logger.js";
+
+const log = createLogger("TaskScheduler");
+
+const TICK_INTERVAL_MS = 60_000;
+
+export interface TaskSchedulerOptions {
+  db: Database.Database;
+  /**
+   * Executes a single due task. Implementations claim the task atomically
+   * (via {@link TaskStore.claimTask}), run it, persist the result, and handle
+   * recurrence/dependents. Errors are reported back to the scheduler via a
+   * rejected promise but the scheduler only logs them — task-level failure
+   * bookkeeping is the executor's responsibility.
+   */
+  executeTask: (task: Task) => Promise<void>;
+  /** Override the tick interval (ms). Defaults to 60_000. Mainly for tests. */
+  tickIntervalMs?: number;
+}
+
+/**
+ * DB-backed dispatcher for scheduled and recurring tasks.
+ *
+ * Mirrors {@link WorkflowScheduler}: a 60-second tick loop queries the `tasks`
+ * table for pending tasks whose `scheduled_for` is due and executes them. This
+ * is the reliable execution path that does not depend on Telegram delivering a
+ * Saved Messages `[TASK:]` reminder — tasks created via any API
+ * (`telegram_create_scheduled_task`, network ingress, WebUI, predictions) are
+ * picked up here.
+ *
+ * Double execution is prevented by {@link TaskStore.claimTask}: even if a
+ * Saved Messages trigger and a scheduler tick race for the same task, only one
+ * flips it from `pending` to `in_progress`. An in-memory guard additionally
+ * keeps overlapping ticks from re-dispatching a task already running this tick.
+ */
+export class TaskScheduler {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private store: TaskStore;
+  private runningTaskIds = new Set<string>();
+  private readonly tickIntervalMs: number;
+
+  constructor(private opts: TaskSchedulerOptions) {
+    this.store = getTaskStore(opts.db);
+    this.tickIntervalMs = opts.tickIntervalMs ?? TICK_INTERVAL_MS;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    void this.tick().catch((err) => {
+      log.warn({ err }, "Task scheduler initial tick failed");
+    });
+    this.timer = setInterval(() => {
+      void this.tick().catch((err) => {
+        log.warn({ err }, "Task scheduler tick failed");
+      });
+    }, this.tickIntervalMs);
+    this.timer.unref?.();
+    log.info("Task scheduler started");
+  }
+
+  stop(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+    log.info("Task scheduler stopped");
+  }
+
+  /**
+   * Query and execute all due tasks. Public so tests can drive a single tick
+   * deterministically without waiting on the timer.
+   */
+  async tick(): Promise<void> {
+    const due = this.store.getDueTasks();
+    for (const task of due) {
+      if (this.runningTaskIds.has(task.id)) continue;
+      // Skip tasks whose dependencies are not yet satisfied — those are fired
+      // by the dependency resolver, not the scheduler.
+      if (!this.store.canExecute(task.id)) continue;
+      await this.execute(task);
+    }
+  }
+
+  private async execute(task: Task): Promise<void> {
+    this.runningTaskIds.add(task.id);
+    try {
+      await this.opts.executeTask(task);
+    } catch (err) {
+      log.error({ err, taskId: task.id }, "Task execution failed");
+    } finally {
+      this.runningTaskIds.delete(task.id);
+    }
+  }
+}


### PR DESCRIPTION
## Резюме

Добавляет фоновый DB-backed диспетчер `TaskScheduler` (по аналогии с существующим `WorkflowScheduler`), который раз в 60 секунд опрашивает таблицу `tasks` и запускает просроченные `pending`-задачи. Закрывает баг #542 — задачи, созданные через `telegram_create_scheduled_task` и другие API, ранее зависели от доставки триггера `[TASK:uuid]` из Saved Messages и могли никогда не выполниться.

Fixes #542

## Что было

- `TaskStore.createTask()` сохранял задачу со `status = pending` и `scheduled_for`.
- `executeScheduledTask()` существовал, но вызывался **только** из обработчика Saved Messages при получении сообщения вида `[TASK:uuid] …`.
- Если Telegram не доставлял триггерное сообщение (например, при перезапуске), задача оставалась `pending` навсегда.

## Что стало

### Новый сервис `src/services/task-scheduler.ts`

- 60-секундный tick-цикл через `setInterval` (как у `WorkflowScheduler`).
- Метод `tick()` выбирает просроченные задачи через `TaskStore.getDueTasks()` и пропускает те, чьи зависимости ещё не завершены.
- In-memory `runningTaskIds` защищает от перекрытий внутри одного процесса; ошибки исполнителя логируются и не валят цикл.
- Метод `start()/stop()` интегрирован в `TeletonApp` рядом с workflow-планировщиком.

### Атомарный `claimTask` в `TaskStore`

Чтобы исключить двойной запуск, когда **и** Saved Messages триггер, **и** tick-цикл сработают на одной задаче, добавлен атомарный `UPDATE … WHERE status = 'pending'`. Только один вызывающий получает `true` и продолжает исполнение.

### Единое ядро `executeTaskRecord` в `src/index.ts`

Логика исполнения (claim → подготовка контекста → `executeScheduledTask` → `agent.processMessage` → `completeTask` → fire dependents → reschedule recurring) вынесена в один приватный метод и используется обоими путями: `handleScheduledTask` (Saved Messages) и `executeScheduledTaskFromScheduler` (DB tick).

### Запуск/остановка в `TeletonApp`

- `startAgent`: создаёт `TaskScheduler` сразу после `WorkflowScheduler` и запускает.
- `stopAgent`: останавливает `TaskScheduler` рядом с `WorkflowScheduler`.

## Совместимость

- Существующий путь Saved Messages → `[TASK:uuid]` сохраняется и продолжает работать (теперь через `executeTaskRecord`).
- `claimTask` обеспечивает корректность при гонке двух путей.
- Никаких изменений схемы БД.

## Тесты

Новый файл `src/services/__tests__/task-scheduler.test.ts` (10 тестов):

- `TaskStore.claimTask` — атомарный переход pending → in_progress, отказ при повторном вызове, отказ для терминальных и несуществующих задач.
- `TaskStore.getDueTasks` — фильтрация по `scheduled_for <= now`, исключение задач без расписания, сортировка по приоритету.
- `TaskScheduler.tick()` — запуск всех просроченных задач, пропуск будущих, пропуск задач с невыполненными зависимостями, перехват ошибок исполнителя.
- `TaskScheduler.start()/stop()` — таймер реально вызывает tick по расписанию и корректно очищается.

Прогон всего набора тестов: ✅ **3697 / 3697 passed**.

## План проверки

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx vitest run` (3697 passed)
- [x] `npx vitest run src/services/__tests__/task-scheduler.test.ts` (10 passed)
- [ ] Smoke-test: создать задачу через `telegram_create_scheduled_task` с `scheduleDate = now + 5s`, перезапустить агент, убедиться, что задача переходит в `done` в течение 60 секунд **без** триггера из Saved Messages.

## Связанные issue/PR

- Issue #143 — оригинальный feature request (закрыт без реализации).
- Issue #401 — аудит, подтверждающий проблему (закрыт документацией, PR #399).
- Issue #459 — связанный баг про scheduled_message и tool execution.