### PR TITLE
[AUDIT/V5] Запрет fallback-ключа для credentials интеграций

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-11T17:15:21.681Z for PR creation at branch issue-586-4980cdd5cd60 for issue https://github.com/xlabtg/teleton-agent/issues/586

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-11T17:15:21.681Z for PR creation at branch issue-586-4980cdd5cd60 for issue https://github.com/xlabtg/teleton-agent/issues/586

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ## Current Fork Status
 
-Current fork version: `0.8.40`.
+Current fork version: `0.8.41`.
 
 This README reflects the `xlabtg/teleton-agent` fork through merged PR [#480](https://github.com/xlabtg/teleton-agent/pull/480) / closed issue [#479](https://github.com/xlabtg/teleton-agent/issues/479). It was refreshed from the closed work history available at issue [#481](https://github.com/xlabtg/teleton-agent/issues/481): 236 closed issues and the 200 most recent merged pull requests as of the latest analyzed run.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -439,7 +439,7 @@ Unified external integration registry settings. Individual integrations and encr
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `integrations.enabled` | `boolean` | `true` | Enable the integration registry. |
-| `integrations.credential_key` | `string` | *generated* | Optional key material for AES-256-GCM credential encryption. When omitted, Teleton creates a local key in the security settings table. |
+| `integrations.credential_key` | `string` | *none* | Key material for AES-256-GCM credential encryption. Required before credentials can be stored or read; can also be supplied with `TELETON_INTEGRATIONS_KEY`. |
 | `integrations.health_check_interval_minutes` | `number` | `5` | Default interval for future background health checks. |
 | `integrations.global_rate_limit.requests_per_minute` | `number` | *optional* | Global outbound integration request limit per minute. |
 | `integrations.global_rate_limit.requests_per_hour` | `number` | *optional* | Global outbound integration request limit per hour. |
@@ -449,6 +449,7 @@ Unified external integration registry settings. Individual integrations and encr
 ```yaml
 integrations:
   enabled: true
+  credential_key: "64-character-hex-or-high-entropy-secret"
   global_rate_limit:
     requests_per_minute: 120
     requests_per_hour: 5000
@@ -643,6 +644,7 @@ Environment variables override values set in `config.yaml`. They are applied aft
 | `TELETON_TAVILY_API_KEY` | `tavily_api_key` | Tavily API key for web search tools. |
 | `TELETON_TONAPI_KEY` | `tonapi_key` | TonAPI key for blockchain queries. |
 | `TELETON_TONCENTER_API_KEY` | `toncenter_api_key` | TonCenter API key for RPC endpoint. |
+| `TELETON_INTEGRATIONS_KEY` | `integrations.credential_key` | Integration credential encryption key. Required before credentials can be stored or read. |
 
 ### LLM Provider API Keys
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -624,8 +624,8 @@ const _IntegrationsObject = z.object({
     .string()
     .optional()
     .describe(
-      "Optional key material for encrypting integration credentials. " +
-        "If omitted, Teleton generates a local key in the security settings table."
+      "Key material for encrypting integration credentials. Required before credentials can " +
+        "be stored or read; may also be supplied via TELETON_INTEGRATIONS_KEY."
     ),
   health_check_interval_minutes: z
     .number()

--- a/src/services/integrations/__tests__/auth.test.ts
+++ b/src/services/integrations/__tests__/auth.test.ts
@@ -52,6 +52,39 @@ describe("IntegrationAuthManager — WORK4-003 regression", () => {
     expect(row).toBeUndefined();
   });
 
+  it("refuses to create credentials when no encryption key is configured", () => {
+    const manager = new IntegrationAuthManager(db);
+
+    expect(() =>
+      manager.createCredential({
+        integrationId: "svc",
+        authType: "api_key",
+        credentials: { apiKey: "shared-secret" },
+      })
+    ).toThrow(/TELETON_INTEGRATIONS_KEY|integrations\.credential_key/i);
+
+    const row = db.prepare("SELECT id FROM integration_credentials").get();
+    expect(row).toBeUndefined();
+  });
+
+  it("refuses to read stored credentials when no encryption key is configured", () => {
+    const writer = new IntegrationAuthManager(db, "a".repeat(64));
+    const credential = writer.createCredential({
+      integrationId: "svc",
+      authType: "api_key",
+      credentials: { apiKey: "shared-secret" },
+    });
+
+    const reader = new IntegrationAuthManager(db);
+
+    expect(() => reader.getCredential(credential.id)).toThrow(
+      /TELETON_INTEGRATIONS_KEY|integrations\.credential_key/i
+    );
+    expect(() => reader.listCredentials("svc")).toThrow(
+      /TELETON_INTEGRATIONS_KEY|integrations\.credential_key/i
+    );
+  });
+
   it("encrypts and decrypts credentials using an explicit key", () => {
     const key = "a".repeat(64);
     const manager = new IntegrationAuthManager(db, key);
@@ -80,19 +113,5 @@ describe("IntegrationAuthManager — WORK4-003 regression", () => {
     const retrieved = manager.getCredential(cred.id);
     expect(retrieved).not.toBeNull();
     expect(retrieved!.credentials.apiKey).toBe("env-secret");
-  });
-
-  it("two managers without explicit key share the same fallback key and can decrypt each other's data", () => {
-    const mgr1 = new IntegrationAuthManager(db);
-    const cred = mgr1.createCredential({
-      integrationId: "svc",
-      authType: "api_key",
-      credentials: { apiKey: "shared-secret" },
-    });
-
-    const mgr2 = new IntegrationAuthManager(db);
-    const retrieved = mgr2.getCredential(cred.id);
-    expect(retrieved).not.toBeNull();
-    expect(retrieved!.credentials.apiKey).toBe("shared-secret");
   });
 });

--- a/src/services/integrations/auth.ts
+++ b/src/services/integrations/auth.ts
@@ -58,6 +58,10 @@ const SECRET_KEYS = new Set([
   "value",
 ]);
 
+const MISSING_CREDENTIAL_KEY_ERROR =
+  "Integration credential encryption key is required. Set TELETON_INTEGRATIONS_KEY " +
+  "or integrations.credential_key before storing or reading integration credentials.";
+
 function nowSeconds(): number {
   return Math.floor(Date.now() / 1000);
 }
@@ -71,8 +75,7 @@ function deriveKey(material: string): Buffer {
 
 function warnNoKey(): void {
   log.warn(
-    "TELETON_INTEGRATIONS_KEY is not set. Integration credentials are NOT encrypted at rest. " +
-      "Set TELETON_INTEGRATIONS_KEY to a 64-character hex string to enable encryption."
+    `${MISSING_CREDENTIAL_KEY_ERROR} Credential storage and reads are disabled until a key is configured.`
   );
 }
 
@@ -135,19 +138,27 @@ function maskCredentials(credentials: Record<string, unknown>): Record<string, u
 
 export class IntegrationAuthManager {
   private readonly db: Database.Database;
-  private readonly key: Buffer;
+  private readonly key: Buffer | null;
 
   constructor(db: Database.Database, keyMaterial?: string) {
     ensureIntegrationTables(db);
     this.db = db;
     const material = keyMaterial || process.env.TELETON_INTEGRATIONS_KEY || "";
-    if (!material) {
+    this.key = material ? deriveKey(material) : null;
+    if (!this.key) {
       warnNoKey();
     }
-    this.key = deriveKey(material || "default-insecure-key-set-TELETON_INTEGRATIONS_KEY");
+  }
+
+  private requireKey(): Buffer {
+    if (!this.key) {
+      throw new Error(MISSING_CREDENTIAL_KEY_ERROR);
+    }
+    return this.key;
   }
 
   createCredential(input: CreateCredentialInput): IntegrationCredential {
+    const key = this.requireKey();
     if (!isIntegrationAuthType(input.authType)) {
       throw new Error(`Unsupported auth type: ${String(input.authType)}`);
     }
@@ -163,7 +174,7 @@ export class IntegrationAuthManager {
         id,
         input.integrationId,
         input.authType,
-        encryptJson(input.credentials, this.key),
+        encryptJson(input.credentials, key),
         input.expiresAt ?? null,
         now,
         now
@@ -174,20 +185,22 @@ export class IntegrationAuthManager {
   }
 
   getCredential(id: string): IntegrationCredential | null {
+    const key = this.requireKey();
     const row = this.db.prepare("SELECT * FROM integration_credentials WHERE id = ?").get(id) as
       | CredentialRow
       | undefined;
-    return row ? rowToCredential(row, this.key) : null;
+    return row ? rowToCredential(row, key) : null;
   }
 
   listCredentials(integrationId: string): IntegrationCredential[] {
+    const key = this.requireKey();
     const rows = this.db
       .prepare(
         "SELECT * FROM integration_credentials WHERE integration_id = ? ORDER BY created_at DESC"
       )
       .all(integrationId) as CredentialRow[];
     return rows.map((row) => {
-      const credential = rowToCredential(row, this.key);
+      const credential = rowToCredential(row, key);
       return { ...credential, credentials: maskCredentials(credential.credentials) };
     });
   }
@@ -257,6 +270,7 @@ export class IntegrationAuthManager {
       scope: token.scope ?? existing.credentials.scope,
     };
     const now = nowSeconds();
+    const key = this.requireKey();
     this.db
       .prepare(
         `UPDATE integration_credentials SET
@@ -266,7 +280,7 @@ export class IntegrationAuthManager {
          WHERE id = ?`
       )
       .run(
-        encryptJson(nextCredentials, this.key),
+        encryptJson(nextCredentials, key),
         token.expiresIn ? now + token.expiresIn : existing.expiresAt,
         now,
         id

--- a/src/webui/__tests__/integrations-routes.test.ts
+++ b/src/webui/__tests__/integrations-routes.test.ts
@@ -13,11 +13,21 @@ vi.mock("../../utils/logger.js", () => ({
   })),
 }));
 
-function createApp(db: Database.Database): Hono {
+function createApp(db: Database.Database, credentialKey?: string): Hono {
   const deps = {
     memory: { db },
     bridge: { isAvailable: () => true },
     mcpServers: () => [],
+    marketplace: credentialKey
+      ? {
+          config: {
+            integrations: {
+              credential_key: credentialKey,
+              global_rate_limit: {},
+            },
+          },
+        }
+      : undefined,
   } as unknown as WebUIServerDeps;
 
   const app = new Hono();
@@ -71,6 +81,8 @@ describe("Integrations routes", () => {
   });
 
   it("creates masked credentials without leaking the plaintext value", async () => {
+    app = createApp(db, "route-test-master-key");
+
     await app.request("/api/integrations", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -100,6 +112,36 @@ describe("Integrations routes", () => {
       credentials_encrypted: string;
     };
     expect(raw.credentials_encrypted).not.toContain("ghp_plaintext_secret");
+  });
+
+  it("refuses to create credentials when no encryption key is configured", async () => {
+    await app.request("/api/integrations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "github-main",
+        name: "GitHub Main",
+        type: "api",
+        provider: "github",
+        config: { baseUrl: "https://api.github.com" },
+      }),
+    });
+
+    const credentialRes = await app.request("/api/integrations/github-main/credentials", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        authType: "api_key",
+        credentials: { apiKey: "ghp_plaintext_secret", headerName: "Authorization" },
+      }),
+    });
+
+    expect(credentialRes.status).toBe(500);
+    const body = await credentialRes.json();
+    expect(body.error).toMatch(/TELETON_INTEGRATIONS_KEY|integrations\.credential_key/i);
+
+    const row = db.prepare("SELECT id FROM integration_credentials").get();
+    expect(row).toBeUndefined();
   });
 
   it("validates unsupported integration types", async () => {


### PR DESCRIPTION
Fixes xlabtg/teleton-agent#586

## Что изменено

- Убран hardcoded fallback-ключ `default-insecure-key-set-TELETON_INTEGRATIONS_KEY` из `IntegrationAuthManager`.
- При отсутствии `keyMaterial`, `TELETON_INTEGRATIONS_KEY` и `integrations.credential_key` операции создания и чтения credentials теперь завершаются явной ошибкой вместо записи ciphertext под публичным ключом.
- Сохранены сценарии, где реестр интеграций нужен без credentials: каталог, создание/обновление интеграций и OAuth authorization URL не требуют ключ.
- Добавлены регрессионные тесты для отказа `createCredential`, `getCredential`, `listCredentials` и WebUI POST `/credentials` без ключа.
- Обновлена документация и описание config schema: ключ больше не считается generated/default и должен быть задан через config или `TELETON_INTEGRATIONS_KEY` перед работой с credentials.
- Обновлена строка версии fork в README с `0.8.40` до `0.8.41`, потому что свежий CI падал на существующем README version assertion после release bump.

## Как воспроизвести

1. Запустить Teleton без `TELETON_INTEGRATIONS_KEY` и без `integrations.credential_key`.
2. Попробовать создать credential для интеграции.
3. До исправления credential сохранялся под публичным fallback-ключом. После исправления операция падает с ошибкой про обязательный ключ, строка в `integration_credentials` не создается.

## Проверки

- `npm ci`
- `npm run build:sdk`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npx vitest run src/services/integrations/__tests__/auth.test.ts`
- `npx vitest run src/webui/__tests__/integrations-routes.test.ts`
- `npx vitest run src/docs/__tests__/readme.test.ts`
- `node improvements/work5/validation/reproduce-findings.mjs` показывает `WORK5-002: not detected`; команда ожидаемо выходит с кодом 1 из-за остальных независимых WORK5 findings.

Полный локальный `npm test` после `npm run build:sdk` сейчас падает на 1 проверке, не связанной с этой правкой:

- `src/agents/__tests__/service.test.ts > ManagedAgentService > starts bot-mode managed agents with explicit bot runtime env`: ожидает `managed-mode=bot` в логе, фактический лог содержит только строки создания и запуска managed agent.
