### PR TITLE
fix(memory): повторять удаление удалённых векторов

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-11T18:09:24.262Z for PR creation at branch issue-590-a377c05fec9a for issue https://github.com/xlabtg/teleton-agent/issues/590

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-11T18:09:24.262Z for PR creation at branch issue-590-a377c05fec9a for issue https://github.com/xlabtg/teleton-agent/issues/590

--- a/src/memory/__tests__/prioritization.test.ts
+++ b/src/memory/__tests__/prioritization.test.ts
@@ -4,6 +4,7 @@ import { ensureSchema } from "../schema.js";
 import { MemoryScorer } from "../scoring.js";
 import { MemoryRetentionService } from "../retention.js";
 import { MemoryGraphStore } from "../graph-store.js";
+import type { SemanticVectorStore } from "../vector-store.js";
 
 function createDb(): InstanceType<typeof Database> {
   const db = new Database(":memory:");
@@ -24,6 +25,23 @@ function insertKnowledge(
     VALUES (?, 'memory', ?, ?, ?, ?)
   `
   ).run(id, text, `hash-${id}`, createdAt, createdAt);
+}
+
+function createSemanticVectorStore(
+  deleteRemote: (ids: string[]) => Promise<void>
+): SemanticVectorStore {
+  return {
+    isConfigured: true,
+    namespace: "test-namespace",
+    healthCheck: vi.fn(async () => ({ mode: "online" })),
+    logStatus: vi.fn(async () => ({ mode: "online" })),
+    searchKnowledge: vi.fn(async () => []),
+    searchMessages: vi.fn(async () => []),
+    upsertKnowledge: vi.fn(async () => undefined),
+    upsertMessages: vi.fn(async () => undefined),
+    delete: deleteRemote,
+    deleteMessages: vi.fn(async () => undefined),
+  };
 }
 
 describe("memory prioritization", () => {
@@ -51,6 +69,7 @@ describe("memory prioritization", () => {
 
     expect(names).toContain("memory_scores");
     expect(names).toContain("memory_archive");
+    expect(names).toContain("pending_remote_vector_deletions");
     expect(names).toContain("memory_cleanup_history");
   });
 
@@ -138,5 +157,42 @@ describe("memory prioritization", () => {
     expect(
       db.prepare("SELECT memory_id FROM memory_archive WHERE memory_id = 'old-low'").get()
     ).toBeDefined();
+  });
+
+  it("persists and retries failed remote vector deletes after archive", async () => {
+    const old = Math.floor(Date.now() / 1000) - 120 * 24 * 60 * 60;
+    insertKnowledge(db, "remote-stale", "stale semantic memory", old);
+
+    const deleteRemote = vi
+      .fn<(ids: string[]) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValue(undefined);
+    const vectorStore = createSemanticVectorStore(deleteRemote);
+
+    const retention = new MemoryRetentionService(
+      db,
+      {
+        min_score: 0.95,
+        max_age_days: 90,
+        max_entries: 100,
+        archive_days: 14,
+      },
+      undefined,
+      vectorStore
+    );
+
+    const cleanup = await retention.cleanup({ dryRun: false });
+
+    expect(cleanup.archived).toBe(1);
+    expect(deleteRemote).toHaveBeenCalledWith(["remote-stale"]);
+    expect(retention.getPendingRemoteVectorDeletions().map((entry) => entry.memoryId)).toContain(
+      "remote-stale"
+    );
+
+    await retention.cleanup({ dryRun: false });
+
+    expect(deleteRemote).toHaveBeenCalledTimes(2);
+    expect(deleteRemote).toHaveBeenLastCalledWith(["remote-stale"]);
+    expect(retention.getPendingRemoteVectorDeletions()).toHaveLength(0);
   });
 });

--- a/src/memory/__tests__/schema.test.ts
+++ b/src/memory/__tests__/schema.test.ts
@@ -214,6 +214,7 @@ describe("Memory Schema", () => {
       expect(tableNames).toContain("integrations");
       expect(tableNames).toContain("integration_credentials");
       expect(tableNames).toContain("integration_usage");
+      expect(tableNames).toContain("pending_remote_vector_deletions");
       expect(tableNames).toContain("journal");
       expect(tableNames).toContain("temporal_metadata");
       expect(tableNames).toContain("time_patterns");
@@ -1493,7 +1494,7 @@ describe("Memory Schema", () => {
     });
 
     it("CURRENT_SCHEMA_VERSION is set to expected value", () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe("1.37.0");
+      expect(CURRENT_SCHEMA_VERSION).toBe("1.38.0");
     });
   });
 
@@ -1637,6 +1638,25 @@ describe("Memory Schema", () => {
 
       const store = getAutonomousTaskStore(db);
       expect(store.cleanOldCheckpoints(7)).toBe(1);
+    });
+
+    it("runMigrations from version 1.37.0 adds pending remote vector deletion queue", () => {
+      ensureSchema(db);
+      db.exec("DROP TABLE pending_remote_vector_deletions");
+      setSchemaVersion(db, "1.37.0");
+
+      runMigrations(db);
+
+      const table = db
+        .prepare(
+          `
+          SELECT name FROM sqlite_master
+          WHERE type='table' AND name='pending_remote_vector_deletions'
+        `
+        )
+        .get() as { name: string } | undefined;
+      expect(table).toBeDefined();
+      expect(getSchemaVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
     });
   });
 

--- a/src/memory/retention.ts
+++ b/src/memory/retention.ts
@@ -53,6 +53,15 @@ export interface MemoryCleanupHistoryEntry {
   createdAt: number;
 }
 
+export interface PendingRemoteVectorDeletion {
+  memoryId: string;
+  namespace: string;
+  attempts: number;
+  lastError: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
 interface RetentionOptions {
   minScore: number;
   maxAgeDays: number;
@@ -91,6 +100,15 @@ interface CleanupHistoryRow {
   protected: number;
   reason: string | null;
   created_at: number;
+}
+
+interface PendingRemoteVectorDeletionRow {
+  memory_id: string;
+  namespace: string;
+  attempts: number;
+  last_error: string | null;
+  created_at: number;
+  updated_at: number;
 }
 
 const DEFAULT_RETENTION: RetentionOptions = {
@@ -134,6 +152,22 @@ function rowToHistory(row: CleanupHistoryRow): MemoryCleanupHistoryEntry {
     reason: row.reason,
     createdAt: row.created_at,
   };
+}
+
+function rowToPendingDeletion(row: PendingRemoteVectorDeletionRow): PendingRemoteVectorDeletion {
+  return {
+    memoryId: row.memory_id,
+    namespace: row.namespace,
+    attempts: row.attempts,
+    lastError: row.last_error,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
 }
 
 export class MemoryRetentionService {
@@ -216,6 +250,9 @@ export class MemoryRetentionService {
       .filter((row): row is MemoryRetentionRow => !!row);
     const deleteAfter = now + this.options.archiveDays * SECONDS_PER_DAY;
     const hasKnowledgeVec = this.tableExists("knowledge_vec");
+    const remoteVectorNamespace = this.vectorStore?.isConfigured
+      ? this.vectorStore.namespace
+      : null;
 
     const archived = this.db.transaction(() => {
       const archive = this.db.prepare(
@@ -242,6 +279,21 @@ export class MemoryRetentionService {
       const deleteKnowledge = this.db.prepare(`DELETE FROM knowledge WHERE id = ?`);
       const deleteVector = hasKnowledgeVec
         ? this.db.prepare(`DELETE FROM knowledge_vec WHERE id = ?`)
+        : null;
+      const enqueueRemoteVectorDeletion = remoteVectorNamespace
+        ? this.db.prepare(
+            `
+            INSERT INTO pending_remote_vector_deletions (
+              memory_id,
+              namespace,
+              created_at,
+              updated_at
+            )
+            VALUES (?, ?, unixepoch(), unixepoch())
+            ON CONFLICT(memory_id, namespace) DO UPDATE SET
+              updated_at = excluded.updated_at
+          `
+          )
         : null;
 
       let count = 0;
@@ -272,6 +324,9 @@ export class MemoryRetentionService {
           now,
           deleteAfter
         );
+        if (enqueueRemoteVectorDeletion && remoteVectorNamespace) {
+          enqueueRemoteVectorDeletion.run(row.id, remoteVectorNamespace);
+        }
         deleteVector?.run(row.id);
         deleteKnowledge.run(row.id);
         count++;
@@ -279,13 +334,7 @@ export class MemoryRetentionService {
       return count;
     })();
 
-    if (archived > 0 && this.vectorStore?.isConfigured) {
-      try {
-        await this.vectorStore.delete(ids);
-      } catch (error) {
-        log.warn({ err: error }, "Semantic vector cleanup failed after memory archive");
-      }
-    }
+    await this.retryPendingRemoteVectorDeletions();
 
     const deleted = this.pruneExpiredArchive(now);
     this.recordHistory({
@@ -379,6 +428,56 @@ export class MemoryRetentionService {
     return rows.map(rowToHistory);
   }
 
+  getPendingRemoteVectorDeletions(limit = 100): PendingRemoteVectorDeletion[] {
+    const safeLimit = Math.max(1, Math.min(1000, Math.floor(limit)));
+    const rows = this.db
+      .prepare(
+        `
+        SELECT *
+        FROM pending_remote_vector_deletions
+        ORDER BY updated_at ASC, memory_id ASC
+        LIMIT ?
+      `
+      )
+      .all(safeLimit) as PendingRemoteVectorDeletionRow[];
+    return rows.map(rowToPendingDeletion);
+  }
+
+  async retryPendingRemoteVectorDeletions(limit = 1000): Promise<number> {
+    if (!this.vectorStore?.isConfigured) return 0;
+
+    const safeLimit = Math.max(1, Math.min(1000, Math.floor(limit)));
+    const namespace = this.vectorStore.namespace;
+    const rows = this.db
+      .prepare(
+        `
+        SELECT *
+        FROM pending_remote_vector_deletions
+        WHERE namespace = ?
+        ORDER BY updated_at ASC, memory_id ASC
+        LIMIT ?
+      `
+      )
+      .all(namespace, safeLimit) as PendingRemoteVectorDeletionRow[];
+
+    if (rows.length === 0) return 0;
+
+    const ids = rows.map((row) => row.memory_id);
+    try {
+      await this.vectorStore.delete(ids);
+    } catch (error) {
+      this.markRemoteVectorDeleteFailed(namespace, ids, errorMessage(error));
+      log.warn(
+        { err: error, namespace, pending: ids.length },
+        "Semantic vector cleanup failed; queued for retry"
+      );
+      return 0;
+    }
+
+    this.clearPendingRemoteVectorDeletions(namespace, ids);
+    return ids.length;
+  }
+
   pruneExpiredArchive(now = Math.floor(Date.now() / 1000)): number {
     const result = this.db.prepare(`DELETE FROM memory_archive WHERE delete_after <= ?`).run(now);
     const deleted = result.changes;
@@ -462,6 +561,39 @@ export class MemoryRetentionService {
       .prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`)
       .get(name) as { name: string } | undefined;
     return !!row;
+  }
+
+  private markRemoteVectorDeleteFailed(namespace: string, ids: string[], message: string): void {
+    const update = this.db.prepare(
+      `
+      UPDATE pending_remote_vector_deletions
+      SET attempts = attempts + 1,
+          last_error = ?,
+          updated_at = unixepoch()
+      WHERE namespace = ? AND memory_id = ?
+    `
+    );
+    const markFailed = this.db.transaction((memoryIds: string[]) => {
+      for (const id of memoryIds) {
+        update.run(message, namespace, id);
+      }
+    });
+    markFailed(ids);
+  }
+
+  private clearPendingRemoteVectorDeletions(namespace: string, ids: string[]): void {
+    const remove = this.db.prepare(
+      `
+      DELETE FROM pending_remote_vector_deletions
+      WHERE namespace = ? AND memory_id = ?
+    `
+    );
+    const clear = this.db.transaction((memoryIds: string[]) => {
+      for (const id of memoryIds) {
+        remove.run(namespace, id);
+      }
+    });
+    clear(ids);
   }
 
   private recordHistory(input: {

--- a/src/memory/schema.ts
+++ b/src/memory/schema.ts
@@ -229,6 +229,19 @@ export function ensureSchema(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_memory_archive_memory_id ON memory_archive(memory_id);
     CREATE INDEX IF NOT EXISTS idx_memory_archive_delete_after ON memory_archive(delete_after);
 
+    CREATE TABLE IF NOT EXISTS pending_remote_vector_deletions (
+      memory_id TEXT NOT NULL,
+      namespace TEXT NOT NULL,
+      attempts INTEGER NOT NULL DEFAULT 0 CHECK(attempts >= 0),
+      last_error TEXT,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      PRIMARY KEY (memory_id, namespace)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_pending_remote_vector_deletions_namespace_updated
+      ON pending_remote_vector_deletions(namespace, updated_at);
+
     CREATE TABLE IF NOT EXISTS memory_cleanup_history (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       mode TEXT NOT NULL CHECK(mode IN ('dry_run', 'archive', 'prune_archive')),
@@ -1091,7 +1104,7 @@ function repairAutonomousTaskChildForeignKeys(db: Database.Database): number {
   return tablesToRepair.length;
 }
 
-export const CURRENT_SCHEMA_VERSION = "1.37.0";
+export const CURRENT_SCHEMA_VERSION = "1.38.0";
 
 export function runMigrations(db: Database.Database): void {
   const currentVersion = getSchemaVersion(db);
@@ -2272,6 +2285,30 @@ export function runMigrations(db: Database.Database): void {
       );
     } catch (error) {
       log.error({ err: error }, "Migration 1.37.0 failed");
+      throw error;
+    }
+  }
+
+  if (!currentVersion || versionLessThan(currentVersion, "1.38.0")) {
+    log.info("Running migration 1.38.0: Add pending remote vector deletion queue");
+    try {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS pending_remote_vector_deletions (
+          memory_id TEXT NOT NULL,
+          namespace TEXT NOT NULL,
+          attempts INTEGER NOT NULL DEFAULT 0 CHECK(attempts >= 0),
+          last_error TEXT,
+          created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          PRIMARY KEY (memory_id, namespace)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_pending_remote_vector_deletions_namespace_updated
+          ON pending_remote_vector_deletions(namespace, updated_at);
+      `);
+      log.info("Migration 1.38.0 complete: pending remote vector deletion queue created");
+    } catch (error) {
+      log.error({ err: error }, "Migration 1.38.0 failed");
       throw error;
     }
   }


### PR DESCRIPTION
## Что изменено

- Добавлена durable-очередь `pending_remote_vector_deletions` и миграция схемы `1.38.0`.
- Retention теперь записывает id удаляемого remote knowledge-вектора в очередь в той же SQLite-транзакции, где архивирует локальную memory-запись.
- Удаление из semantic vector store выполняется после commit, но при ошибке запись остаётся в очереди с `attempts` и `last_error`; очередь очищается только после успешного `vectorStore.delete`.
- `cleanup({ dryRun: false })` повторяет pending remote deletes даже если новых cleanup-кандидатов уже нет; также добавлен явный `retryPendingRemoteVectorDeletions()`.

## Как воспроизвести

1. Настроить remote semantic vector store и memory-запись с вектором.
2. Заставить `vectorStore.delete` временно падать во время retention cleanup.
3. Запустить `cleanup({ dryRun: false })`.

Раньше локальная запись уже удалялась, а remote id терялся после warning-лога. Теперь id остаётся в `pending_remote_vector_deletions` и удаляется при следующем успешном retry.

## Проверка

- `npx vitest run src/memory/__tests__/prioritization.test.ts src/memory/__tests__/schema.test.ts`
- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test` — 231 test files, 3710 tests passed

Fixes xlabtg/teleton-agent#590
