### PR TITLE
[AUDIT/V5] Сделать retry backoff AgentRuntime прерываемым

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-11T18:28:39.182Z for PR creation at branch issue-591-94da18fe4a95 for issue https://github.com/xlabtg/teleton-agent/issues/591

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-11T18:28:39.182Z for PR creation at branch issue-591-94da18fe4a95 for issue https://github.com/xlabtg/teleton-agent/issues/591

--- a/src/agent/__tests__/runtime-retry.test.ts
+++ b/src/agent/__tests__/runtime-retry.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ConfigSchema, type Config } from "../../config/schema.js";
+import type { ChatResponse } from "../client.js";
+
+const chatWithContextMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+vi.mock("../../services/prometheus.js", () => ({
+  recordLlmRequest: vi.fn(),
+}));
+
+vi.mock("../client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../client.js")>();
+  return {
+    ...actual,
+    chatWithContext: chatWithContextMock,
+  };
+});
+
+let cleanup: (() => void) | undefined;
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+function makeConfig(overrides: Partial<Config["agent"]> = {}): Config {
+  return ConfigSchema.parse({
+    agent: {
+      provider: "anthropic",
+      api_key: "sk-test",
+      model: "claude-opus-4-6",
+      max_tokens: 128,
+      temperature: 0,
+      max_agentic_iterations: 1,
+      compaction: { enabled: false },
+      session_reset_policy: {
+        daily_reset_enabled: false,
+        idle_expiry_enabled: false,
+      },
+      ...overrides,
+    },
+    telegram: {
+      api_id: 1,
+      api_hash: "hash",
+      phone: "+10000000000",
+      session_name: "test",
+      admin_ids: [1001],
+      owner_id: 1001,
+      owner_name: "Owner",
+    },
+    embedding: { provider: "none" },
+    vector_memory: {},
+    audit_trail: { enabled: false },
+    temporal_context: { enabled: false },
+    self_correction: { enabled: false },
+    autonomous: {},
+    deals: { enabled: false },
+    webui: { enabled: false },
+    logging: { level: "error", pretty: false },
+    dev: {},
+    marketplace: {},
+    tool_rag: { enabled: false },
+    cache: { enabled: false },
+    capabilities: {},
+    integrations: { enabled: false },
+    event_bus: { enabled: false },
+    webhooks: { enabled: false },
+    network: { enabled: false },
+    ton_proxy: { enabled: false },
+    heartbeat: { enabled: false },
+    predictions: { enabled: false },
+    feedback: { enabled: false },
+    adaptive_prompting: { enabled: false },
+    anomaly_detection: { enabled: false },
+    mtproto: { enabled: false, proxies: [] },
+    mcp: { servers: {} },
+  });
+}
+
+function assistantResponse(text: string): ChatResponse {
+  return {
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text }],
+      stopReason: "endTurn",
+      usage: { input: 1, output: 1 },
+      timestamp: Date.now(),
+    },
+    text,
+    context: { messages: [] },
+  };
+}
+
+function errorResponse(errorMessage: string): ChatResponse {
+  return {
+    message: {
+      role: "assistant",
+      content: [],
+      stopReason: "error",
+      errorMessage,
+      usage: { input: 0, output: 0 },
+      timestamp: Date.now(),
+    },
+    text: "",
+    context: { messages: [] },
+  };
+}
+
+async function flushMicrotasks(turns = 10): Promise<void> {
+  for (let i = 0; i < turns; i++) {
+    await Promise.resolve();
+  }
+}
+
+async function createRuntime(config = makeConfig()) {
+  vi.resetModules();
+  chatWithContextMock.mockReset();
+
+  const home = mkdtempSync(join(tmpdir(), "teleton-runtime-retry-"));
+  const previousHome = process.env.TELETON_HOME;
+  process.env.TELETON_HOME = home;
+
+  const { getDatabase, closeDatabase } = await import("../../memory/database.js");
+  getDatabase({
+    path: join(home, "memory.db"),
+    enableVectorSearch: false,
+  });
+
+  const { AgentRuntime } = await import("../runtime.js");
+  const runtime = new AgentRuntime(config, "Test soul");
+
+  cleanup = () => {
+    closeDatabase();
+    rmSync(home, { recursive: true, force: true });
+    if (previousHome === undefined) {
+      delete process.env.TELETON_HOME;
+    } else {
+      process.env.TELETON_HOME = previousHome;
+    }
+  };
+
+  return runtime;
+}
+
+describe("AgentRuntime retry backoff", () => {
+  it("does not count a rate-limit retry against max_agentic_iterations", async () => {
+    vi.useFakeTimers();
+    const runtime = await createRuntime();
+    chatWithContextMock
+      .mockResolvedValueOnce(errorResponse("429 Too Many Requests"))
+      .mockResolvedValueOnce(assistantResponse("ok after retry"));
+
+    const resultPromise = runtime.processMessage({
+      chatId: "1001",
+      userMessage: "hello",
+      userName: "Owner",
+      toolContext: {
+        senderId: 1001,
+        config: makeConfig(),
+      },
+    });
+
+    await flushMicrotasks();
+    expect(chatWithContextMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    await expect(resultPromise).resolves.toMatchObject({
+      content: "ok after retry",
+      toolCalls: [],
+    });
+    expect(chatWithContextMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops a pending rate-limit backoff when the signal is aborted", async () => {
+    vi.useFakeTimers();
+    const runtime = await createRuntime();
+    const controller = new AbortController();
+    chatWithContextMock
+      .mockResolvedValueOnce(errorResponse("429 Too Many Requests"))
+      .mockResolvedValueOnce(assistantResponse("should not run"));
+
+    const resultPromise = runtime.processMessage({
+      chatId: "1001",
+      userMessage: "hello",
+      userName: "Owner",
+      signal: controller.signal,
+      toolContext: {
+        senderId: 1001,
+        config: makeConfig(),
+      },
+    });
+
+    await flushMicrotasks();
+    expect(chatWithContextMock).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(1);
+
+    controller.abort(new Error("cancelled"));
+
+    await expect(resultPromise).resolves.toMatchObject({
+      content: "",
+      toolCalls: [],
+    });
+    expect(chatWithContextMock).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/agent/__tests__/runtime-utils.test.ts
+++ b/src/agent/__tests__/runtime-utils.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import {
   isContextOverflowError,
   isTrivialMessage,
   parseRetryAfterMs,
+  sleepWithAbort,
   isNetworkError,
   isNetworkErrorMessage,
   getEmptyResponseDiagnostic,
@@ -10,6 +11,10 @@ import {
   LoopStallDetector,
 } from "../../agent/runtime-utils.js";
 import { AgentConfigSchema } from "../../config/schema.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 // ─── T10: isContextOverflowError ────────────────────────────────
 
@@ -214,6 +219,39 @@ describe("parseRetryAfterMs", () => {
 
   it("T12f: returns null for unrelated error messages", () => {
     expect(parseRetryAfterMs("Internal server error 500")).toBeNull();
+  });
+});
+
+describe("sleepWithAbort", () => {
+  it("rejects immediately when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("cancelled"));
+
+    await expect(sleepWithAbort(60_000, controller.signal)).rejects.toThrow("cancelled");
+  });
+
+  it("rejects and clears the timer when aborted during the wait", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const promise = sleepWithAbort(60_000, controller.signal);
+
+    expect(vi.getTimerCount()).toBe(1);
+
+    controller.abort(new Error("cancelled"));
+
+    await expect(promise).rejects.toThrow("cancelled");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("resolves after the requested delay when not aborted", async () => {
+    vi.useFakeTimers();
+    const promise = sleepWithAbort(250);
+
+    await vi.advanceTimersByTimeAsync(249);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(promise).resolves.toBeUndefined();
   });
 });
 

--- a/src/agent/runtime-utils.ts
+++ b/src/agent/runtime-utils.ts
@@ -24,6 +24,43 @@ export function parseRetryAfterMs(errorMessage: string): number | null {
   return match ? Number(match[1]) * 1000 : null;
 }
 
+function getAbortError(signal: AbortSignal): Error {
+  if (signal.reason instanceof Error) return signal.reason;
+  return new Error(signal.reason ? String(signal.reason) : "Operation aborted");
+}
+
+export function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(getAbortError(signal));
+  }
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    let onAbort: (() => void) | undefined;
+    const cleanup = () => {
+      if (signal && onAbort) {
+        signal.removeEventListener("abort", onAbort);
+      }
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    timer.unref?.();
+
+    if (signal) {
+      onAbort = () => {
+        clearTimeout(timer);
+        cleanup();
+        reject(getAbortError(signal));
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+}
+
 /**
  * Returns true for errors thrown by the provider library that indicate a
  * transient network-level failure (e.g. "Unhandled stop reason: network_error").

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -88,6 +88,7 @@ import {
   getEmptyResponseDiagnostic,
   trimRagContext,
   LoopStallDetector,
+  sleepWithAbort,
 } from "./runtime-utils.js";
 import { truncateToolResult } from "./tool-result-truncator.js";
 import { accumulateTokenUsage } from "./token-usage.js";
@@ -171,6 +172,16 @@ function addUsage(accumulator: UsageAccumulator, usage?: SelfCorrectionUsage): v
   accumulator.cacheRead += usage.cacheRead ?? 0;
   accumulator.cacheWrite += usage.cacheWrite ?? 0;
   accumulator.totalCost += usage.cost?.total ?? 0;
+}
+
+async function waitForRetryBackoff(delay: number, signal?: AbortSignal): Promise<boolean> {
+  try {
+    await sleepWithAbort(delay, signal);
+    return true;
+  } catch (error) {
+    if (signal?.aborted) return false;
+    throw error;
+  }
 }
 
 export interface ProcessMessageOptions {
@@ -915,7 +926,7 @@ export class AgentRuntime {
               log.warn(
                 `🌐 Network error, retrying in ${delay}ms (attempt ${networkErrorRetries}/${NETWORK_ERROR_MAX_RETRIES})...`
               );
-              await new Promise((r) => setTimeout(r, delay));
+              if (!(await waitForRetryBackoff(delay, signal))) break;
               iteration--;
               continue;
             }
@@ -1032,7 +1043,8 @@ export class AgentRuntime {
               log.warn(
                 `🚫 Rate limited, retrying in ${delay}ms (attempt ${rateLimitRetries}/${RATE_LIMIT_MAX_RETRIES})...`
               );
-              await new Promise((r) => setTimeout(r, delay));
+              if (!(await waitForRetryBackoff(delay, signal))) break;
+              iteration--;
               continue;
             }
             log.error(`🚫 Rate limited after ${RATE_LIMIT_MAX_RETRIES} retries: ${errorMsg}`);
@@ -1054,7 +1066,7 @@ export class AgentRuntime {
               log.warn(
                 `🔄 Server error, retrying in ${delay}ms (attempt ${serverErrorRetries}/${SERVER_ERROR_MAX_RETRIES})...`
               );
-              await new Promise((r) => setTimeout(r, delay));
+              if (!(await waitForRetryBackoff(delay, signal))) break;
               iteration--;
               continue;
             }
@@ -1069,7 +1081,7 @@ export class AgentRuntime {
               log.warn(
                 `🌐 Network error, retrying in ${delay}ms (attempt ${networkErrorRetries}/${NETWORK_ERROR_MAX_RETRIES})...`
               );
-              await new Promise((r) => setTimeout(r, delay));
+              if (!(await waitForRetryBackoff(delay, signal))) break;
               iteration--;
               continue;
             }
@@ -1104,7 +1116,7 @@ export class AgentRuntime {
               log.warn(
                 `⚠️ Empty response with zero tokens - retrying in ${delay}ms (attempt ${emptyResponseRetries}/${EMPTY_RESPONSE_MAX_RETRIES})...`
               );
-              await new Promise((r) => setTimeout(r, delay));
+              if (!(await waitForRetryBackoff(delay, signal))) break;
               iteration--;
               continue;
             }


### PR DESCRIPTION
## Что изменено

- Добавлен `sleepWithAbort`, который очищает таймер и завершается сразу при `AbortSignal`.
- Все retry backoff ожидания в `AgentRuntime` переведены на abort-aware ожидание: network, rate-limit, server error и empty response retry.
- Rate-limit retry теперь возвращает итерацию через `iteration--`, как остальные retry-классы, поэтому `429` не расходует `max_agentic_iterations`.
- Добавлены unit/integration тесты на retry accounting и abort во время backoff.

Fixes xlabtg/teleton-agent#591

## Как воспроизвести

1. Настроить `max_agentic_iterations: 1`.
2. Вернуть от провайдера первый ответ `429 Too Many Requests`.
3. Вернуть вторым ответом успешный текст.

До исправления rate-limit retry расходовал единственную итерацию и runtime возвращал `Internal error: Agent loop failed to produce a response.`. Также abort во время retry-sleep не прерывал ожидание таймера.

## Проверка

- `npm test -- src/agent/__tests__/runtime-retry.test.ts src/agent/__tests__/runtime-utils.test.ts`
- `npm run build:sdk && npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run test:coverage`
- `npm run build`
- `npm run audit:ci`
- `npm run generate:openapi && git diff --quiet -- docs/api-reference && npm run lint:openapi`
- `cd web && npm run check:i18n`
- `node dist/cli/index.js --help`

`npm run lint:openapi` проходит с существующими предупреждениями Redocly `no-ambiguous-paths`.
