### PR TITLE
[AUDIT/V5] Изолировать rate limit plugin inline/callback по пользователям

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-11T18:55:45.766Z for PR creation at branch issue-592-dcf2efd17ab0 for issue https://github.com/xlabtg/teleton-agent/issues/592

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-11T18:55:45.766Z for PR creation at branch issue-592-dcf2efd17ab0 for issue https://github.com/xlabtg/teleton-agent/issues/592

--- a/src/bot/__tests__/rate-limiter.test.ts
+++ b/src/bot/__tests__/rate-limiter.test.ts
@@ -59,4 +59,30 @@ describe("PluginRateLimiter", () => {
     // callback is unaffected
     expect(() => limiter.check("cats", "callback", 5)).not.toThrow();
   });
+
+  it("tracks users independently", () => {
+    for (let i = 0; i < 5; i++) {
+      limiter.check("cats", "inline", 5, 60_000, "userA");
+    }
+
+    expect(() => limiter.check("cats", "inline", 5, 60_000, "userA")).toThrow();
+    expect(() => limiter.check("cats", "inline", 5, 60_000, "userB")).not.toThrow();
+  });
+
+  it("prunes expired windows for inactive users during checks", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+
+    try {
+      limiter.check("cats", "inline", 5, 1000, "userA");
+      expect((limiter as unknown as { windows: Map<string, unknown> }).windows.size).toBe(1);
+
+      vi.advanceTimersByTime(1001);
+      limiter.check("dogs", "inline", 5, 1000, "userB");
+
+      expect((limiter as unknown as { windows: Map<string, unknown> }).windows.size).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/bot/rate-limiter.ts
+++ b/src/bot/rate-limiter.ts
@@ -3,8 +3,15 @@
  * In-memory, per-plugin, no external dependencies.
  */
 
+type RateLimitUserId = number | string;
+
+interface RateLimitWindow {
+  timestamps: number[];
+  windowMs: number;
+}
+
 export class PluginRateLimiter {
-  private windows = new Map<string, number[]>();
+  private windows = new Map<string, RateLimitWindow>();
 
   /**
    * Check if an action is allowed under the rate limit.
@@ -14,33 +21,65 @@ export class PluginRateLimiter {
    * @param action - Action type (e.g. "inline", "callback")
    * @param limit - Max actions per window
    * @param windowMs - Window duration in ms (default: 60000)
+   * @param userId - Requesting Telegram user id; omitted callers share a global bucket
    */
-  check(pluginName: string, action: string, limit: number, windowMs = 60_000): void {
-    const key = `${pluginName}:${action}`;
+  check(
+    pluginName: string,
+    action: string,
+    limit: number,
+    windowMs = 60_000,
+    userId?: RateLimitUserId
+  ): void {
+    const key = this.keyFor(pluginName, action, userId);
     const now = Date.now();
-    const cutoff = now - windowMs;
 
-    let timestamps = this.windows.get(key);
-    if (!timestamps) {
-      timestamps = [];
-      this.windows.set(key, timestamps);
+    this.pruneExpiredWindows(now, key);
+
+    let bucket = this.windows.get(key);
+    if (!bucket) {
+      bucket = { timestamps: [], windowMs };
+      this.windows.set(key, bucket);
+    } else {
+      bucket.windowMs = windowMs;
+      this.pruneWindow(bucket, now);
     }
 
-    // Remove expired entries
+    if (bucket.timestamps.length >= limit) {
+      const userScope = userId === undefined ? "" : ` user "${userId}"`;
+      throw new Error(
+        `Rate limit exceeded for plugin "${pluginName}" action "${action}"${userScope}: ${limit} per ${
+          windowMs / 1000
+        }s`
+      );
+    }
+
+    bucket.timestamps.push(now);
+  }
+
+  private keyFor(pluginName: string, action: string, userId: RateLimitUserId | undefined): string {
+    return `${pluginName}:${action}:${userId ?? "global"}`;
+  }
+
+  private pruneExpiredWindows(now: number, skipKey: string): void {
+    for (const [key, bucket] of this.windows) {
+      if (key === skipKey) continue;
+
+      this.pruneWindow(bucket, now);
+      if (bucket.timestamps.length === 0) {
+        this.windows.delete(key);
+      }
+    }
+  }
+
+  private pruneWindow(bucket: RateLimitWindow, now: number): void {
+    const cutoff = now - bucket.windowMs;
+    const { timestamps } = bucket;
     const firstValid = timestamps.findIndex((t) => t > cutoff);
     if (firstValid > 0) {
       timestamps.splice(0, firstValid);
     } else if (firstValid === -1) {
       timestamps.length = 0;
     }
-
-    if (timestamps.length >= limit) {
-      throw new Error(
-        `Rate limit exceeded for plugin "${pluginName}" action "${action}": ${limit} per ${windowMs / 1000}s`
-      );
-    }
-
-    timestamps.push(now);
   }
 
   /** Clear all rate limit windows (for testing) */

--- a/src/sdk/__tests__/bot.test.ts
+++ b/src/sdk/__tests__/bot.test.ts
@@ -166,7 +166,7 @@ describe("createBotSDK", () => {
       from: { id: 1, isBot: false },
     });
 
-    expect(limiter.check).toHaveBeenCalledWith("cats", "inline", 30);
+    expect(limiter.check).toHaveBeenCalledWith("cats", "inline", 30, 60_000, 1);
     expect(handler).toHaveBeenCalled();
   });
 
@@ -186,7 +186,7 @@ describe("createBotSDK", () => {
       editMessage: vi.fn(),
     });
 
-    expect(limiter.check).toHaveBeenCalledWith("cats", "callback", 60);
+    expect(limiter.check).toHaveBeenCalledWith("cats", "callback", 60, 60_000, 1);
   });
 
   it("uses custom rate limits from manifest", async () => {
@@ -208,7 +208,7 @@ describe("createBotSDK", () => {
       from: { id: 1, isBot: false },
     });
 
-    expect(limiter.check).toHaveBeenCalledWith("cats", "inline", 10);
+    expect(limiter.check).toHaveBeenCalledWith("cats", "inline", 10, 60_000, 1);
   });
 
   it("username returns empty when bot is null", () => {

--- a/src/sdk/bot.ts
+++ b/src/sdk/bot.ts
@@ -12,6 +12,8 @@ import { toTLMarkup, toGrammyKeyboard, prefixButtons } from "../bot/services/sty
 import { stripCustomEmoji, parseHtml } from "../bot/services/html-parser.js";
 import { compileGlob } from "../bot/inline-router.js";
 
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
 export function createBotSDK(
   router: InlineRouter | null,
   gramjsBot: GramJSBotClient | null,
@@ -55,7 +57,7 @@ export function createBotSDK(
       }
       handlers.onInlineQuery = async (ctx) => {
         if (rateLimiter) {
-          rateLimiter.check(pluginName, "inline", inlineLimit);
+          rateLimiter.check(pluginName, "inline", inlineLimit, RATE_LIMIT_WINDOW_MS, ctx.userId);
         }
         return handler(ctx);
       };
@@ -71,7 +73,13 @@ export function createBotSDK(
         regex: compileGlob(pattern),
         handler: async (ctx) => {
           if (rateLimiter) {
-            rateLimiter.check(pluginName, "callback", callbackLimit);
+            rateLimiter.check(
+              pluginName,
+              "callback",
+              callbackLimit,
+              RATE_LIMIT_WINDOW_MS,
+              ctx.userId
+            );
           }
           return handler(ctx);
         },


### PR DESCRIPTION
## Что изменено

- `PluginRateLimiter.check` теперь принимает необязательный `userId` и ключует окна по `plugin/action/user`, сохраняя global bucket для старых вызовов без `userId`.
- Bot SDK передает `ctx.userId` в limiter для inline query и callback handlers, поэтому один Telegram user больше не расходует quota всех остальных.
- Лимитер при `check` очищает истекшие timestamps и удаляет пустые окна неактивных buckets, чтобы `windows` не рос бесконечно после истечения окна.
- Добавлены регрессионные тесты на per-user isolation и pruning истекших окон.

Fixes xlabtg/teleton-agent#592

## Как воспроизвести

1. Зарегистрировать plugin с inline handler и лимитом `N` запросов в минуту.
2. От user A отправить `N` inline queries за минуту.
3. От user B отправить один inline query в тот же plugin.

До исправления user B попадал в общий bucket `plugin:action` и блокировался вместе с user A. После исправления user B использует отдельный bucket и проходит rate limit самостоятельно.

## Проверка

- `npm ci`
- `npx vitest run src/bot/__tests__/rate-limiter.test.ts src/sdk/__tests__/bot.test.ts`
- `npm run lint`
- `npm run format:check`
- `npm run build:sdk`
- `npm run typecheck`
- `npm test`
- `npm run build:backend`
