### PR TITLE
Защитить MCP URL от DNS rebinding

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-11T20:08:18.516Z for PR creation at branch issue-588-63d20c332706 for issue https://github.com/xlabtg/teleton-agent/issues/588

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-11T20:08:18.516Z for PR creation at branch issue-588-63d20c332706 for issue https://github.com/xlabtg/teleton-agent/issues/588

--- a/src/agent/tools/__tests__/mcp-loader-security.test.ts
+++ b/src/agent/tools/__tests__/mcp-loader-security.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadMcpServers } from "../mcp-loader.js";
+import type { McpConfig } from "../../../config/schema.js";
+
+const dnsMocks = vi.hoisted(() => ({
+  lookup: vi.fn(),
+}));
+
+const sdkMocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  clients: [] as Array<{
+    close: ReturnType<typeof vi.fn>;
+    transport?: { close?: () => Promise<void> };
+  }>,
+  streamableTransports: [] as Array<{
+    url: URL;
+    opts?: { fetch?: typeof fetch };
+    close: ReturnType<typeof vi.fn>;
+    originalClose: ReturnType<typeof vi.fn>;
+  }>,
+  sseTransports: [] as Array<{
+    url: URL;
+    opts?: { fetch?: typeof fetch };
+    close: ReturnType<typeof vi.fn>;
+    originalClose: ReturnType<typeof vi.fn>;
+  }>,
+}));
+
+vi.mock("node:dns/promises", () => dnsMocks);
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn(function () {
+    const client = {
+      transport: undefined as { close?: () => Promise<void> } | undefined,
+      connect: vi.fn(async (transport: { close?: () => Promise<void> }) => {
+        client.transport = transport;
+        await sdkMocks.connect(transport);
+      }),
+      close: vi.fn(async () => {
+        await client.transport?.close?.();
+      }),
+    };
+    sdkMocks.clients.push(client);
+    return client;
+  }),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
+  StreamableHTTPClientTransport: class StreamableHTTPClientTransport {
+    originalClose = vi.fn();
+    close = this.originalClose;
+
+    constructor(
+      public readonly url: URL,
+      public readonly opts?: { fetch?: typeof fetch }
+    ) {
+      sdkMocks.streamableTransports.push(this);
+    }
+  },
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: class SSEClientTransport {
+    originalClose = vi.fn();
+    close = this.originalClose;
+
+    constructor(
+      public readonly url: URL,
+      public readonly opts?: { fetch?: typeof fetch }
+    ) {
+      sdkMocks.sseTransports.push(this);
+    }
+  },
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: class StdioClientTransport {},
+}));
+
+vi.mock("../../../utils/logger.js", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+function remoteMcpConfig(url: string): McpConfig {
+  return {
+    servers: {
+      remote: {
+        url,
+        scope: "always",
+        enabled: true,
+      },
+    },
+  };
+}
+
+describe("loadMcpServers remote URL security", () => {
+  beforeEach(() => {
+    sdkMocks.connect.mockReset();
+    sdkMocks.connect.mockResolvedValue(undefined);
+    sdkMocks.clients.length = 0;
+    sdkMocks.streamableTransports.length = 0;
+    sdkMocks.sseTransports.length = 0;
+    dnsMocks.lookup.mockReset();
+    dnsMocks.lookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects a remote MCP hostname that resolves to a metadata IP", async () => {
+    dnsMocks.lookup.mockResolvedValueOnce([{ address: "169.254.169.254", family: 4 }]);
+
+    const connections = await loadMcpServers(remoteMcpConfig("https://rebind.example.com/mcp"));
+
+    expect(connections).toEqual([]);
+    expect(sdkMocks.streamableTransports).toHaveLength(0);
+    expect(sdkMocks.connect).not.toHaveBeenCalled();
+  });
+
+  it("passes a pinned fetch to the Streamable HTTP transport", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const connections = await loadMcpServers(remoteMcpConfig("https://mcp.example.com/api"));
+
+    expect(connections).toHaveLength(1);
+    expect(sdkMocks.streamableTransports).toHaveLength(1);
+    const transport = sdkMocks.streamableTransports[0];
+    expect(transport.opts?.fetch).toEqual(expect.any(Function));
+
+    await transport.opts?.fetch?.(new URL("https://mcp.example.com/api"), { method: "GET" });
+
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit & { dispatcher?: unknown }];
+    expect(init.dispatcher).toBeDefined();
+    expect(init.redirect).toBe("manual");
+
+    await expect(transport.opts?.fetch?.("https://other.example.com/api")).rejects.toThrow(
+      /unvalidated origin/i
+    );
+
+    await connections[0].client.close();
+    expect(transport.originalClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agent/tools/mcp-loader.ts
+++ b/src/agent/tools/mcp-loader.ts
@@ -9,6 +9,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { Ajv, type ErrorObject } from "ajv";
 import { TOOL_EXECUTION_TIMEOUT_MS } from "../../constants/timeouts.js";
 import { sanitizeForContext } from "../../utils/sanitize.js";
@@ -17,7 +18,7 @@ import type { ToolRegistry } from "./registry.js";
 import type { McpConfig, McpServerConfig } from "../../config/schema.js";
 import { getErrorMessage } from "../../utils/errors.js";
 import { createLogger } from "../../utils/logger.js";
-import { BLOCKED_MCP_ENV_KEYS, validateMcpServerUrl } from "../../config/mcp-security.js";
+import { BLOCKED_MCP_ENV_KEYS, createPinnedMcpServerFetch } from "../../config/mcp-security.js";
 
 /**
  * Built-in tool name prefixes that MCP tools must not shadow.
@@ -117,11 +118,7 @@ export async function loadMcpServers(config: McpConfig): Promise<McpConnection[]
           stderr: "pipe",
         });
       } else if (serverConfig.url) {
-        const urlError = validateMcpServerUrl(serverConfig.url);
-        if (urlError) {
-          throw new Error(`MCP server "${name}": ${urlError}`);
-        }
-        transport = new StreamableHTTPClientTransport(new URL(serverConfig.url));
+        transport = await createStreamableHttpTransport(serverConfig.url);
       } else {
         throw new Error(`MCP server "${name}": needs 'command' or 'url'`);
       }
@@ -146,7 +143,7 @@ export async function loadMcpServers(config: McpConfig): Promise<McpConnection[]
         if (serverConfig.url && transport instanceof StreamableHTTPClientTransport) {
           await client.close().catch(() => {});
           log.info({ server: name }, "Streamable HTTP failed, falling back to SSE");
-          transport = new SSEClientTransport(new URL(serverConfig.url));
+          transport = await createSseTransport(serverConfig.url);
           const fallbackClient = new Client({ name: `teleton-${name}`, version: "1.0.0" });
           await Promise.race([
             fallbackClient.connect(transport),
@@ -189,6 +186,44 @@ export async function loadMcpServers(config: McpConfig): Promise<McpConnection[]
   }
 
   return connections;
+}
+
+async function createStreamableHttpTransport(
+  rawUrl: string
+): Promise<StreamableHTTPClientTransport> {
+  const target = await createPinnedMcpServerFetch(rawUrl);
+  return withPinnedFetchCleanup(
+    new StreamableHTTPClientTransport(target.url, { fetch: target.fetch }),
+    target.close
+  );
+}
+
+async function createSseTransport(rawUrl: string): Promise<SSEClientTransport> {
+  const target = await createPinnedMcpServerFetch(rawUrl);
+  return withPinnedFetchCleanup(
+    new SSEClientTransport(target.url, { fetch: target.fetch }),
+    target.close
+  );
+}
+
+function withPinnedFetchCleanup<TTransport extends Transport>(
+  transport: TTransport,
+  cleanup: () => Promise<void>
+): TTransport {
+  const closeTransport = transport.close.bind(transport);
+  let closed = false;
+
+  transport.close = async () => {
+    if (closed) return;
+    closed = true;
+    try {
+      await closeTransport();
+    } finally {
+      await cleanup();
+    }
+  };
+
+  return transport;
 }
 
 /**

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -57,7 +57,7 @@ export async function mcpAddCommand(
 
   if (options.url) {
     // Treat pkg as a URL
-    const urlError = validateMcpServerUrl(pkg);
+    const urlError = await validateMcpServerUrl(pkg);
     if (urlError) {
       console.error(`❌ ${urlError}`);
       process.exit(1);

--- a/src/config/__tests__/mcp-security.test.ts
+++ b/src/config/__tests__/mcp-security.test.ts
@@ -30,7 +30,10 @@ describe("MCP security", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const target = await createPinnedMcpServerFetch("https://mcp.example.com/api");
-    await target.fetch(new URL("https://mcp.example.com/api"), { method: "POST" });
+    await target.fetch(new URL("https://mcp.example.com/api"), {
+      method: "POST",
+      redirect: "follow",
+    });
 
     expect(fetchMock).toHaveBeenCalledOnce();
     const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit & { dispatcher?: unknown }];

--- a/src/config/__tests__/mcp-security.test.ts
+++ b/src/config/__tests__/mcp-security.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinnedMcpServerFetch, validateMcpServerUrl } from "../mcp-security.js";
+
+const dnsMocks = vi.hoisted(() => ({
+  lookup: vi.fn(),
+}));
+
+vi.mock("node:dns/promises", () => dnsMocks);
+
+describe("MCP security", () => {
+  beforeEach(() => {
+    dnsMocks.lookup.mockReset();
+    dnsMocks.lookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects an MCP URL whose hostname resolves to a metadata IP", async () => {
+    dnsMocks.lookup.mockResolvedValueOnce([{ address: "169.254.169.254", family: 4 }]);
+
+    await expect(validateMcpServerUrl("https://rebind.example.com/mcp")).resolves.toMatch(
+      /private|loopback|metadata|not allowed/i
+    );
+  });
+
+  it("creates a pinned fetch for the validated MCP origin", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const target = await createPinnedMcpServerFetch("https://mcp.example.com/api");
+    await target.fetch(new URL("https://mcp.example.com/api"), { method: "POST" });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit & { dispatcher?: unknown }];
+    expect(init.dispatcher).toBeDefined();
+    expect(init.redirect).toBe("manual");
+
+    await expect(target.fetch("https://other.example.com/api")).rejects.toThrow(
+      /unvalidated origin/i
+    );
+
+    await target.close();
+  });
+});

--- a/src/config/mcp-security.ts
+++ b/src/config/mcp-security.ts
@@ -1,4 +1,9 @@
-import { BlockList, isIP } from "node:net";
+import {
+  createPinnedOutboundFetch,
+  validateOutboundUrl,
+  validateResolvedOutboundUrl,
+  type PinnedOutboundFetch,
+} from "../services/outbound-url-guard.js";
 
 export const SAFE_MCP_PACKAGE_RE = /^[@a-zA-Z0-9._/-]+$/;
 export const SAFE_MCP_ARG_RE = /^[a-zA-Z0-9._/:=@-]+$/;
@@ -13,52 +18,38 @@ export const BLOCKED_MCP_ENV_KEYS = new Set([
   "ELECTRON_RUN_AS_NODE",
 ]);
 
-const BLOCKED_MCP_HOSTNAMES = new Set(["localhost", "metadata", "metadata.google.internal"]);
+const MCP_SERVER_URL_GUARD = {
+  allowedProtocols: ["http:", "https:"] as const,
+  label: "MCP server URL",
+};
 
-const blockedIpRanges = new BlockList();
-blockedIpRanges.addSubnet("0.0.0.0", 8, "ipv4");
-blockedIpRanges.addSubnet("10.0.0.0", 8, "ipv4");
-blockedIpRanges.addSubnet("100.64.0.0", 10, "ipv4");
-blockedIpRanges.addSubnet("127.0.0.0", 8, "ipv4");
-blockedIpRanges.addSubnet("169.254.0.0", 16, "ipv4");
-blockedIpRanges.addSubnet("172.16.0.0", 12, "ipv4");
-blockedIpRanges.addSubnet("192.168.0.0", 16, "ipv4");
-blockedIpRanges.addSubnet("198.18.0.0", 15, "ipv4");
-blockedIpRanges.addSubnet("224.0.0.0", 4, "ipv4");
-blockedIpRanges.addSubnet("240.0.0.0", 4, "ipv4");
-blockedIpRanges.addAddress("255.255.255.255", "ipv4");
-blockedIpRanges.addAddress("::", "ipv6");
-blockedIpRanges.addAddress("::1", "ipv6");
-blockedIpRanges.addSubnet("fc00::", 7, "ipv6");
-blockedIpRanges.addSubnet("fe80::", 10, "ipv6");
-blockedIpRanges.addSubnet("ff00::", 8, "ipv6");
+export type PinnedMcpServerFetch = PinnedOutboundFetch;
 
-export function validateMcpServerUrl(rawUrl: string): string | undefined {
-  let parsed: URL;
+export function validateMcpServerUrl(rawUrl: string): Promise<string | undefined>;
+export function validateMcpServerUrl(
+  rawUrl: string,
+  options: { resolve: false }
+): string | undefined;
+export function validateMcpServerUrl(
+  rawUrl: string,
+  options?: { resolve?: boolean }
+): Promise<string | undefined> | string | undefined {
   try {
-    parsed = new URL(rawUrl);
-  } catch {
-    return "Invalid MCP server URL";
-  }
+    if (options?.resolve === false) {
+      validateOutboundUrl(rawUrl, MCP_SERVER_URL_GUARD);
+      return undefined;
+    }
 
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    return "MCP server URL must use http:// or https://";
+    return validateResolvedOutboundUrl(rawUrl, MCP_SERVER_URL_GUARD)
+      .then(() => undefined)
+      .catch(getErrorText);
+  } catch (error) {
+    return getErrorText(error);
   }
+}
 
-  const hostname = normalizeHostname(parsed.hostname);
-  if (!hostname) {
-    return "MCP server URL must include a host";
-  }
-
-  if (isBlockedMcpHostname(hostname)) {
-    return "MCP server URL host must not be localhost or an internal metadata host";
-  }
-
-  if (isBlockedMcpIp(hostname)) {
-    return "MCP server URL must not point at private, loopback, link-local, or metadata IP addresses";
-  }
-
-  return undefined;
+export async function createPinnedMcpServerFetch(rawUrl: string): Promise<PinnedMcpServerFetch> {
+  return createPinnedOutboundFetch(rawUrl, MCP_SERVER_URL_GUARD);
 }
 
 export function validateMcpEnv(env: unknown): string | undefined {
@@ -85,39 +76,6 @@ export function validateMcpEnv(env: unknown): string | undefined {
   return undefined;
 }
 
-function normalizeHostname(hostname: string): string {
-  return hostname
-    .trim()
-    .toLowerCase()
-    .replace(/^\[(.*)\]$/, "$1")
-    .replace(/\.$/, "");
-}
-
-function isBlockedMcpHostname(hostname: string): boolean {
-  return BLOCKED_MCP_HOSTNAMES.has(hostname) || hostname.endsWith(".localhost");
-}
-
-function isBlockedMcpIp(hostname: string): boolean {
-  const ipVersion = isIP(hostname);
-  if (ipVersion === 4) return blockedIpRanges.check(hostname, "ipv4");
-  if (ipVersion === 6) {
-    const mappedIpv4 = getMappedIpv4(hostname);
-    if (mappedIpv4) {
-      return blockedIpRanges.check(mappedIpv4, "ipv4");
-    }
-    return blockedIpRanges.check(hostname, "ipv6");
-  }
-  return false;
-}
-
-function getMappedIpv4(hostname: string): string | undefined {
-  const dotted = hostname.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
-  if (dotted) return dotted[1];
-
-  const hex = hostname.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
-  if (!hex) return undefined;
-
-  const high = Number.parseInt(hex[1], 16);
-  const low = Number.parseInt(hex[2], 16);
-  return [high >> 8, high & 0xff, low >> 8, low & 0xff].join(".");
+function getErrorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/src/services/outbound-url-guard.ts
+++ b/src/services/outbound-url-guard.ts
@@ -16,6 +16,11 @@ export interface ResolvedOutboundUrl {
   addresses: LookupAddress[];
 }
 
+export interface PinnedOutboundFetch extends ResolvedOutboundUrl {
+  fetch: typeof fetch;
+  close: () => Promise<void>;
+}
+
 export interface OutboundFetchResponse {
   ok: boolean;
   status: number;
@@ -142,6 +147,34 @@ export async function fetchValidatedOutboundUrl(
   }
 }
 
+export async function createPinnedOutboundFetch(
+  raw: string,
+  options: OutboundUrlGuardOptions
+): Promise<PinnedOutboundFetch> {
+  const target = await resolveOutboundUrl(raw, options);
+  const dispatcher = createPinnedDispatcher(target, options.label);
+  let closed = false;
+
+  return {
+    ...target,
+    fetch: async (input, init) => {
+      assertPinnedFetchTarget(input, target, options.label);
+      if (closed) throw new Error(`${options.label} pinned fetch is already closed`);
+
+      return fetch(input, {
+        ...init,
+        redirect: init?.redirect ?? "manual",
+        dispatcher,
+      } as FetchInitWithDispatcher);
+    },
+    close: async () => {
+      if (closed) return;
+      closed = true;
+      await dispatcher.close();
+    },
+  };
+}
+
 function normalizeHostname(hostname: string): string {
   return hostname
     .trim()
@@ -257,4 +290,22 @@ function selectPinnedAddresses(
     return addresses.filter((address) => address.family === family);
   }
   return addresses;
+}
+
+function assertPinnedFetchTarget(
+  input: RequestInfo | URL,
+  target: ResolvedOutboundUrl,
+  label: string
+): void {
+  const rawUrl = input instanceof Request ? input.url : input instanceof URL ? input.href : input;
+  let requestedUrl: URL;
+  try {
+    requestedUrl = new URL(rawUrl);
+  } catch {
+    throw new Error(`${label} attempted fetch to a non-absolute URL: ${rawUrl}`);
+  }
+
+  if (requestedUrl.origin !== target.url.origin) {
+    throw new Error(`${label} attempted fetch to unvalidated origin: ${requestedUrl.origin}`);
+  }
 }

--- a/src/services/outbound-url-guard.ts
+++ b/src/services/outbound-url-guard.ts
@@ -163,7 +163,7 @@ export async function createPinnedOutboundFetch(
 
       return fetch(input, {
         ...init,
-        redirect: init?.redirect ?? "manual",
+        redirect: "manual",
         dispatcher,
       } as FetchInitWithDispatcher);
     },

--- a/src/webui/__tests__/mcp-routes.test.ts
+++ b/src/webui/__tests__/mcp-routes.test.ts
@@ -3,10 +3,16 @@ import { Hono } from "hono";
 import { createMcpRoutes } from "../routes/mcp.js";
 import type { WebUIServerDeps } from "../types.js";
 
+const dnsMocks = vi.hoisted(() => ({
+  lookup: vi.fn(),
+}));
+
 const configMocks = vi.hoisted(() => ({
   readRawConfig: vi.fn(),
   writeRawConfig: vi.fn(),
 }));
+
+vi.mock("node:dns/promises", () => dnsMocks);
 
 vi.mock("../../config/configurable-keys.js", () => ({
   readRawConfig: configMocks.readRawConfig,
@@ -39,6 +45,8 @@ describe("MCP routes", () => {
     app = createApp();
     configMocks.readRawConfig.mockReturnValue({ mcp: { servers: {} } });
     configMocks.writeRawConfig.mockClear();
+    dnsMocks.lookup.mockReset();
+    dnsMocks.lookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
   });
 
   it("rejects MCP server urls pointing at metadata addresses", async () => {
@@ -74,6 +82,21 @@ describe("MCP routes", () => {
 
     expect(res.status).toBe(400);
     expect(json.success).toBe(false);
+    expect(configMocks.writeRawConfig).not.toHaveBeenCalled();
+  });
+
+  it("rejects MCP server urls whose hostnames resolve to metadata addresses", async () => {
+    dnsMocks.lookup.mockResolvedValueOnce([{ address: "169.254.169.254", family: 4 }]);
+
+    const res = await postMcp(app, {
+      name: "rebind",
+      url: "https://rebind.example.com/mcp",
+    });
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.success).toBe(false);
+    expect(json.error).toMatch(/private|loopback|metadata|not allowed/i);
     expect(configMocks.writeRawConfig).not.toHaveBeenCalled();
   });
 

--- a/src/webui/routes/mcp.ts
+++ b/src/webui/routes/mcp.ts
@@ -65,7 +65,7 @@ export function createMcpRoutes(deps: WebUIServerDeps) {
         }
       }
       if (body.url) {
-        const urlError = validateMcpServerUrl(body.url);
+        const urlError = await validateMcpServerUrl(body.url);
         if (urlError) {
           return c.json({ success: false, error: urlError } as APIResponse<never>, 400);
         }


### PR DESCRIPTION
## Что изменено

Fixes xlabtg/teleton-agent#588

- MCP URL validation переведена на общий `outbound-url-guard`: hostname теперь резолвится через `dns.lookup({ all: true, verbatim: true })`, и любой private/loopback/link-local/metadata address отклоняется.
- Remote MCP loader создаёт pinned fetch поверх undici `Agent.lookup`, поэтому Streamable HTTP и SSE fallback подключаются только к уже проверенному origin/IP и не следуют автоматическим redirect.
- WebUI и CLI `mcp add --url` теперь выполняют DNS-aware проверку перед сохранением URL.
- Удалён служебный `.gitkeep` из initial PR commit, чтобы итоговый diff был только по задаче.

## Как воспроизвести исходную проблему

1. Настроить remote MCP server URL `https://rebind.example.com/mcp`.
2. Сделать так, чтобы `rebind.example.com` резолвился в `169.254.169.254`, `127.0.0.1` или RFC1918 адрес.
3. До исправления `validateMcpServerUrl` проверял только строку hostname и IP-literal, поэтому домен проходил validation и transport подключался к внутреннему адресу.

## Проверка

- `npx vitest run src/config/__tests__/mcp-security.test.ts src/webui/__tests__/mcp-routes.test.ts src/agent/tools/__tests__/mcp-loader-security.test.ts`
- `npm run lint`
- `npm run build:sdk`
- `npm run typecheck`
- `npm test`
- `npm run build:backend`

## Тесты

Добавлены регрессионные тесты:

- `src/config/__tests__/mcp-security.test.ts` проверяет отказ для hostname → metadata IP и наличие pinned fetch/dispatcher.
- `src/webui/__tests__/mcp-routes.test.ts` проверяет отказ WebUI route до записи config.
- `src/agent/tools/__tests__/mcp-loader-security.test.ts` проверяет, что loader не создаёт transport для DNS SSRF и передаёт pinned fetch в Streamable HTTP transport.
