### PR TITLE
fix(provider): включить native tools для NVIDIA GLM-5.1

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-14T21:27:06.743Z for PR creation at branch issue-626-7612f0c6618c for issue https://github.com/xlabtg/teleton-agent/issues/626

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-14T21:27:06.743Z for PR creation at branch issue-626-7612f0c6618c for issue https://github.com/xlabtg/teleton-agent/issues/626

--- a/src/agent/__tests__/runtime-utils.test.ts
+++ b/src/agent/__tests__/runtime-utils.test.ts
@@ -391,7 +391,7 @@ describe("getEmptyResponseDiagnostic", () => {
     });
 
     expect(result).toContain("NVIDIA NIM z-ai/glm-5.1");
-    expect(result).toContain("text-only");
+    expect(result).toContain("native tools enabled");
     expect(result).toContain("Public API Endpoints");
   });
 

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -80,136 +80,11 @@ export async function registerCocoonModels(httpPort: number): Promise<string[]> 
 }
 
 const NVIDIA_BASE_URL = "https://integrate.api.nvidia.com/v1";
-const NVIDIA_TEXT_ONLY_MODELS = new Set(["z-ai/glm-5.1"]);
-
-export function supportsNativeToolCalling(provider: SupportedProvider, modelId: string): boolean {
-  if (provider === "nvidia" && NVIDIA_TEXT_ONLY_MODELS.has(modelId.toLowerCase())) {
-    return false;
-  }
-  return true;
-}
-
-interface TextOnlyMessageSegment {
-  role: "user" | "assistant";
-  text: string;
-  timestamp: number;
-}
-
-function stringifyToolArguments(args: Record<string, unknown>): string {
-  try {
-    return JSON.stringify(args);
-  } catch {
-    return "{}";
-  }
-}
-
-function userMessageToText(message: Extract<Message, { role: "user" }>): string {
-  if (typeof message.content === "string") return message.content;
-
-  return message.content
-    .map((block) => (block.type === "text" ? block.text : "[Image omitted]"))
-    .filter(Boolean)
-    .join("\n");
-}
-
-function assistantMessageToText(message: AssistantMessage): string {
-  const parts: string[] = [];
-  for (const block of message.content) {
-    if (block.type === "text" && block.text.trim()) {
-      parts.push(block.text);
-    } else if (block.type === "toolCall") {
-      parts.push(
-        `[Assistant requested tool: ${block.name} ${stringifyToolArguments(block.arguments)}]`
-      );
-    }
-  }
-  return parts.join("\n\n");
-}
-
-function toolResultMessageToText(message: Extract<Message, { role: "toolResult" }>): string {
-  const body = message.content
-    .map((block) => (block.type === "text" ? block.text : "[Image omitted]"))
-    .filter(Boolean)
-    .join("\n");
-  const status = message.isError ? "ERROR" : "OK";
-  return `[Tool result: ${message.toolName} - ${status}]\n${body}`;
-}
-
-function pushTextOnlySegment(
-  segments: TextOnlyMessageSegment[],
-  role: TextOnlyMessageSegment["role"],
-  text: string,
-  timestamp: number
-): void {
-  const trimmed = text.trim();
-  if (!trimmed) return;
-
-  const previous = segments[segments.length - 1];
-  if (previous?.role === role) {
-    previous.text += `\n\n${trimmed}`;
-    previous.timestamp = timestamp;
-    return;
-  }
-
-  segments.push({ role, text: trimmed, timestamp });
-}
-
-function textOnlyAssistantMessage(
-  segment: TextOnlyMessageSegment,
-  model: Model<Api>
-): AssistantMessage {
-  return {
-    role: "assistant",
-    content: [{ type: "text", text: segment.text }],
-    api: model.api,
-    provider: model.provider,
-    model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
-    stopReason: "stop",
-    timestamp: segment.timestamp,
-  };
-}
-
-function normalizeTextOnlyContext(context: Context, model: Model<Api>): Context {
-  const segments: TextOnlyMessageSegment[] = [];
-
-  // NVIDIA GLM-5.1 rejects native tool payloads, including old tool history.
-  for (const message of context.messages) {
-    if (message.role === "user") {
-      pushTextOnlySegment(segments, "user", userMessageToText(message), message.timestamp);
-    } else if (message.role === "assistant") {
-      pushTextOnlySegment(
-        segments,
-        "assistant",
-        assistantMessageToText(message),
-        message.timestamp
-      );
-    } else if (message.role === "toolResult") {
-      pushTextOnlySegment(segments, "user", toolResultMessageToText(message), message.timestamp);
-    }
-  }
-
-  return {
-    ...context,
-    tools: undefined,
-    messages: segments.map((segment) =>
-      segment.role === "user"
-        ? { role: "user", content: segment.text, timestamp: segment.timestamp }
-        : textOnlyAssistantMessage(segment, model)
-    ),
-  };
-}
+const NVIDIA_DISABLE_STREAMING_USAGE_MODELS = new Set(["z-ai/glm-5.1"]);
 
 /** Build a NVIDIA NIM model object on demand (OpenAI-compatible, fixed base URL) */
 function buildNvidiaModel(modelId: string): Model<"openai-completions"> {
-  const isTextOnlyModel = NVIDIA_TEXT_ONLY_MODELS.has(modelId.toLowerCase());
+  const disablesStreamingUsage = NVIDIA_DISABLE_STREAMING_USAGE_MODELS.has(modelId.toLowerCase());
   return {
     id: modelId,
     name: modelId,
@@ -227,7 +102,7 @@ function buildNvidiaModel(modelId: string): Model<"openai-completions"> {
       supportsReasoningEffort: false,
       supportsStrictMode: false,
       maxTokensField: "max_tokens",
-      ...(isTextOnlyModel ? { supportsUsageInStreaming: false } : {}),
+      ...(disablesStreamingUsage ? { supportsUsageInStreaming: false } : {}),
     },
   };
 }
@@ -395,12 +270,6 @@ export async function chatWithContext(
 
   let tools =
     provider === "google" && options.tools ? sanitizeToolsForGemini(options.tools) : options.tools;
-  if (tools?.length && !supportsNativeToolCalling(provider, config.model)) {
-    log.warn(
-      `Native tool calling disabled for ${provider}/${config.model}; sending text-only chat request`
-    );
-    tools = undefined;
-  }
 
   // Cocoon: disable thinking mode + inject tools into system prompt
   let systemPrompt = options.systemPrompt || options.context.systemPrompt || "";
@@ -420,9 +289,6 @@ export async function chatWithContext(
     systemPrompt,
     tools,
   };
-  const requestContext = supportsNativeToolCalling(provider, config.model)
-    ? context
-    : normalizeTextOnlyContext(context, model);
 
   const temperature = options.temperature ?? config.temperature;
 
@@ -439,7 +305,7 @@ export async function chatWithContext(
     completeOptions.onPayload = stripCocoonPayload;
   }
 
-  let response = await complete(model, requestContext, completeOptions as ProviderStreamOptions);
+  let response = await complete(model, context, completeOptions as ProviderStreamOptions);
 
   // Claude Code provider: retry once on 401/Unauthorized by refreshing credentials
   // Use precise patterns to avoid false positives from upstream bodies that happen to contain "401"
@@ -453,7 +319,7 @@ export async function chatWithContext(
     const refreshedKey = await refreshClaudeCodeApiKey();
     if (refreshedKey) {
       completeOptions.apiKey = refreshedKey;
-      response = await complete(model, requestContext, completeOptions as ProviderStreamOptions);
+      response = await complete(model, context, completeOptions as ProviderStreamOptions);
     }
   }
 

--- a/src/agent/runtime-utils.ts
+++ b/src/agent/runtime-utils.ts
@@ -112,10 +112,10 @@ export function getEmptyResponseDiagnostic(input: EmptyResponseDiagnosticInput):
   if (input.provider.toLowerCase() === "nvidia" && input.model.toLowerCase() === "z-ai/glm-5.1") {
     return (
       "NVIDIA NIM z-ai/glm-5.1 returned an empty streaming response with zero token usage. " +
-      "Teleton sends this model as text-only because NVIDIA does not list tool-calling " +
-      "parameters for it. If the same model works in the NVIDIA web UI but not through the API, " +
-      "verify that the nvapi key's organization has Public API Endpoints access, or switch to a " +
-      "tool-capable NVIDIA model such as meta/llama-3.1-8b-instruct or deepseek-ai/deepseek-v3.1."
+      "Teleton sends this model through NVIDIA's OpenAI-compatible Chat Completions endpoint " +
+      "with native tools enabled. If the same model works in the NVIDIA web UI but not through " +
+      "the API, verify that the nvapi key's organization has Public API Endpoints access and " +
+      "that z-ai/glm-5.1 is available for that key."
     );
   }
 

--- a/src/config/model-catalog.ts
+++ b/src/config/model-catalog.ts
@@ -442,7 +442,7 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
     {
       value: "z-ai/glm-5.1",
       name: "GLM-5.1",
-      description: "Text-only NVIDIA hosted chat model; native tool calling is disabled",
+      description: "NVIDIA hosted agentic chat model with native tool calling",
     },
     {
       value: "minimaxai/minimax-m2.7",

--- a/src/providers/__tests__/nvidia-glm-tools.test.ts
+++ b/src/providers/__tests__/nvidia-glm-tools.test.ts
@@ -105,7 +105,7 @@ beforeEach(() => {
 });
 
 describe("NVIDIA GLM-5.1 tool compatibility", () => {
-  it("omits native tools for z-ai/glm-5.1 text-only chat requests", async () => {
+  it("sends native tools for z-ai/glm-5.1 chat requests", async () => {
     const { chatWithContext } = await import("../../agent/client.js");
 
     await chatWithContext(agentConfig("z-ai/glm-5.1"), {
@@ -115,10 +115,10 @@ describe("NVIDIA GLM-5.1 tool compatibility", () => {
 
     expect(mockComplete).toHaveBeenCalledTimes(1);
     const [, context] = mockComplete.mock.calls[0] as [unknown, { tools?: Tool[] }];
-    expect(context.tools).toBeUndefined();
+    expect(context.tools).toEqual([sampleTool]);
   });
 
-  it("converts old native tool history into alternating text-only GLM-5.1 messages", async () => {
+  it("preserves native tool history for GLM-5.1 follow-up requests", async () => {
     const { chatWithContext } = await import("../../agent/client.js");
     const history: Message[] = [
       { role: "user", content: "Check status", timestamp: Date.now() },
@@ -136,17 +136,21 @@ describe("NVIDIA GLM-5.1 tool compatibility", () => {
       unknown,
       { messages: Message[]; tools?: Tool[] },
     ];
-    expect(context.tools).toBeUndefined();
-    expect(context.messages.every((message) => message.role !== "toolResult")).toBe(true);
+    expect(context.tools).toEqual([sampleTool]);
+    expect(context.messages).toEqual(history);
+    expect(context.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "user",
+    ]);
     expect(
-      context.messages.every(
+      context.messages.some(
         (message) =>
-          message.role !== "assistant" ||
-          message.content.every((block) => block.type !== "toolCall")
+          message.role === "assistant" && message.content.some((block) => block.type === "toolCall")
       )
     ).toBe(true);
-    expect(context.messages.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
-    expect(JSON.stringify(context.messages)).toContain("[Tool result: test_lookup - OK]");
+    expect(context.messages.some((message) => message.role === "toolResult")).toBe(true);
   });
 
   it("keeps native tools for NVIDIA models with tool-calling parameters", async () => {

--- a/src/providers/__tests__/nvidia-provider.test.ts
+++ b/src/providers/__tests__/nvidia-provider.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { getProviderMetadata, validateApiKeyFormat } from "../../config/providers.js";
 import { AgentConfigSchema } from "../../config/schema.js";
 import { getModelsForProvider } from "../../config/model-catalog.js";
-import { getProviderModel, supportsNativeToolCalling } from "../../agent/client.js";
+import { getProviderModel } from "../../agent/client.js";
 
 describe("NVIDIA provider registration", () => {
   it("is registered in the provider registry", () => {
@@ -43,10 +43,10 @@ describe("NVIDIA model routing", () => {
     expect("compat" in model && model.compat?.supportsStrictMode).toBe(false);
   });
 
-  it("marks GLM-5.1 as a text-only NVIDIA endpoint", () => {
+  it("keeps GLM-5.1 on the OpenAI-compatible NVIDIA endpoint", () => {
     const model = getProviderModel("nvidia", "z-ai/glm-5.1");
 
-    expect(supportsNativeToolCalling("nvidia", "z-ai/glm-5.1")).toBe(false);
+    expect(model.api).toBe("openai-completions");
     expect("compat" in model && model.compat?.supportsUsageInStreaming).toBe(false);
   });
 });


### PR DESCRIPTION
### 🎯 Objective
Исправить поддержку `nvidia/z-ai/glm-5.1`: модель снова получает native `tools`, а история `toolCall`/`toolResult` передаётся в OpenAI-compatible формате между итерациями агентного цикла.

Fixes #626

### 🔬 Changes Breakdown
- Удалён GLM-5.1 text-only bypass в NVIDIA provider path, который обнулял `tools` и сворачивал tool history в текст.
- `z-ai/glm-5.1` теперь получает `tools` в `chatWithContext`, а follow-up история сохраняет `assistant` `toolCall` и `toolResult` сообщения.
- Сохранён отдельный compatibility override `supportsUsageInStreaming: false` для GLM-5.1, чтобы не возвращать `stream_options.include_usage` вместе с исправлением tools.
- Обновлены описание модели в каталоге и диагностика пустого ответа, чтобы они больше не утверждали, что GLM-5.1 работает в text-only режиме.

### 🛡️ Testing & Edge Cases
- Красный TDD-прогон до исправления подтверждал регрессию: `context.tools` был `undefined`, а `supportsNativeToolCalling("nvidia", "z-ai/glm-5.1")` возвращал `false`.
- `npx vitest run src/providers/__tests__/nvidia-glm-tools.test.ts src/providers/__tests__/nvidia-provider.test.ts src/agent/__tests__/runtime-utils.test.ts`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck` после `npm run build:sdk`
- `npm test`
- `npm run build` после установки web dependencies через `cd web && npm ci`

### ⚠️ Breaking Changes / Migration Notes
None.

### 🔄 Rollback Plan
Revert `5fa8776`; NVIDIA GLM-5.1 вернётся к прежнему text-only поведению.
