### PR TITLE
fix(memory): восстановить tool_config.scope_level (issue #631)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T10:49:29.934Z for PR creation at branch issue-631-327e5bc9daf6 for issue https://github.com/xlabtg/teleton-agent/issues/631

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T10:49:29.934Z for PR creation at branch issue-631-327e5bc9daf6 for issue https://github.com/xlabtg/teleton-agent/issues/631

--- a/experiments/repro-issue-631-scope-level.ts
+++ b/experiments/repro-issue-631-scope-level.ts
@@ -1,0 +1,58 @@
+/**
+ * Reproduction for issue #631 — "no such column: scope_level" at agent startup.
+ *
+ * Replays the exact DB bootstrap the app performs (ensureSchema + runMigrations)
+ * and then exercises the two code paths that the lost migrations broke:
+ *   1. loadAllToolConfigs() — the call in the crash stack trace.
+ *   2. initializeToolConfig()/saveToolConfig() — the seeding step that runs
+ *      immediately after and writes scope='open', which the stale `scope`
+ *      CHECK constraint also rejects.
+ *
+ * Run with: npx tsx experiments/repro-issue-631-scope-level.ts
+ */
+import Database from "better-sqlite3";
+import { ensureSchema, runMigrations } from "../src/memory/schema.js";
+import {
+  loadAllToolConfigs,
+  initializeToolConfig,
+  saveToolConfig,
+} from "../src/memory/tool-config.js";
+
+function bootstrap(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  // Mirrors MemoryDatabase.initialize() for a fresh database.
+  ensureSchema(db);
+  runMigrations(db);
+  return db;
+}
+
+function describe(label: string, fn: () => void): void {
+  try {
+    fn();
+    console.log(`  ✅ ${label}: OK`);
+  } catch (error) {
+    console.log(`  ❌ ${label}: ${(error as Error).message}`);
+  }
+}
+
+console.log("Bug 1 — loadAllToolConfigs() reads tool_config.scope_level");
+{
+  const db = bootstrap();
+  describe("loadAllToolConfigs()", () => {
+    loadAllToolConfigs(db);
+  });
+  db.close();
+}
+
+console.log("Bug 2 — seeding writes scope='open' (levelToScope('all'))");
+{
+  const db = bootstrap();
+  describe("initializeToolConfig(level='all')", () => {
+    initializeToolConfig(db, "bash", "all");
+  });
+  describe("saveToolConfig(level='off')", () => {
+    saveToolConfig(db, "bash", "off");
+  });
+  db.close();
+}

--- a/src/memory/__tests__/schema.test.ts
+++ b/src/memory/__tests__/schema.test.ts
@@ -9,6 +9,7 @@ import {
   CURRENT_SCHEMA_VERSION,
 } from "../schema.js";
 import { getAutonomousTaskStore } from "../agent/autonomous-tasks.js";
+import { loadAllToolConfigs, initializeToolConfig, saveToolConfig } from "../tool-config.js";
 
 describe("Memory Schema", () => {
   let db: InstanceType<typeof Database>;
@@ -1494,7 +1495,7 @@ describe("Memory Schema", () => {
     });
 
     it("CURRENT_SCHEMA_VERSION is set to expected value", () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe("1.38.0");
+      expect(CURRENT_SCHEMA_VERSION).toBe("1.39.0");
     });
   });
 
@@ -1873,5 +1874,238 @@ describe("Memory Schema", () => {
       };
       expect(row.enabled).toBe(1);
     });
+
+    describe("scope_level migration 1.39.0 (issue #631 regression)", () => {
+      // Re-creates the tool_config schema exactly as it existed on databases
+      // produced before this fix: the fork-sync (PRs #625/#630) merged the
+      // consuming code but dropped the migrations that add scope_level and
+      // widen the scope CHECK, so older databases lack the column entirely.
+      function createLegacyToolConfig(opts?: { scopeCheck?: boolean }): void {
+        db.exec(`DROP TABLE IF EXISTS tool_config;`);
+        const scopeColumn =
+          opts?.scopeCheck === false
+            ? "scope TEXT,"
+            : "scope TEXT CHECK(scope IN ('always', 'dm-only', 'group-only', 'admin-only')),";
+        db.exec(`
+          CREATE TABLE tool_config (
+            tool_name TEXT PRIMARY KEY,
+            enabled INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
+            ${scopeColumn}
+            updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+            updated_by INTEGER
+          );
+        `);
+      }
+
+      function hasColumn(table: string, column: string): boolean {
+        const columns = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+        return columns.some((col) => col.name === column);
+      }
+
+      it("a fresh database has tool_config.scope_level after migrations", () => {
+        ensureSchema(db);
+        runMigrations(db);
+
+        expect(hasColumn("tool_config", "scope_level")).toBe(true);
+      });
+
+      it("loadAllToolConfigs() no longer throws 'no such column: scope_level'", () => {
+        ensureSchema(db);
+        runMigrations(db);
+
+        // This is the exact call from the crash stack trace in the issue.
+        expect(() => loadAllToolConfigs(db)).not.toThrow();
+        expect(loadAllToolConfigs(db).size).toBe(0);
+      });
+
+      it("seeding tool config writes the widened scope values without error", () => {
+        ensureSchema(db);
+        runMigrations(db);
+
+        // initializeToolConfig/saveToolConfig persist levelToScope() values
+        // ('open', 'disabled', ...) that the legacy narrow CHECK rejected.
+        expect(() => initializeToolConfig(db, "bash", "all")).not.toThrow();
+        expect(() => saveToolConfig(db, "bash", "off")).not.toThrow();
+        expect(() => saveToolConfig(db, "read", "allowlist")).not.toThrow();
+        expect(() => saveToolConfig(db, "write", "admin")).not.toThrow();
+
+        const config = loadAllToolConfigs(db);
+        expect(config.get("bash")?.level).toBe("off");
+        expect(config.get("read")?.level).toBe("allowlist");
+        expect(config.get("write")?.level).toBe("admin");
+      });
+
+      it("upgrading a 1.38.0 database adds scope_level and backfills from legacy columns", () => {
+        ensureSchema(db);
+        createLegacyToolConfig();
+        // Cover the common backfill branches with realistic legacy rows.
+        const insert = db.prepare(
+          `INSERT INTO tool_config (tool_name, enabled, scope) VALUES (?, ?, ?)`
+        );
+        insert.run("disabled_tool", 0, "always"); // enabled=0 → off
+        insert.run("admin_tool", 1, "admin-only"); // scope=admin-only → admin
+        insert.run("open_tool", 1, "always"); // default → all
+        setSchemaVersion(db, "1.38.0");
+
+        runMigrations(db);
+
+        expect(hasColumn("tool_config", "scope_level")).toBe(true);
+        const rows = db.prepare(`SELECT tool_name, scope_level FROM tool_config`).all() as Array<{
+          tool_name: string;
+          scope_level: string;
+        }>;
+        const byName = Object.fromEntries(rows.map((r) => [r.tool_name, r.scope_level]));
+        expect(byName["disabled_tool"]).toBe("off");
+        expect(byName["admin_tool"]).toBe("admin");
+        expect(byName["open_tool"]).toBe("all");
+      });
+
+      it("backfill maps every legacy scope value to the correct access level", () => {
+        ensureSchema(db);
+        // A CHECK-free legacy table lets us insert the full range of scope
+        // values an upstream database could carry into the backfill CASE.
+        createLegacyToolConfig({ scopeCheck: false });
+        const insert = db.prepare(
+          `INSERT INTO tool_config (tool_name, enabled, scope) VALUES (?, ?, ?)`
+        );
+        insert.run("t_off_enabled0", 0, "open"); // enabled=0 wins → off
+        insert.run("t_admin", 1, "admin-only"); // → admin
+        insert.run("t_allowlist", 1, "allowlist"); // → allowlist
+        insert.run("t_disabled", 1, "disabled"); // → off
+        insert.run("t_open", 1, "open"); // → all
+        insert.run("t_null", 1, null); // → all
+        setSchemaVersion(db, "1.38.0");
+
+        runMigrations(db);
+
+        const rows = db.prepare(`SELECT tool_name, scope_level FROM tool_config`).all() as Array<{
+          tool_name: string;
+          scope_level: string;
+        }>;
+        const byName = Object.fromEntries(rows.map((r) => [r.tool_name, r.scope_level]));
+        expect(byName["t_off_enabled0"]).toBe("off");
+        expect(byName["t_admin"]).toBe("admin");
+        expect(byName["t_allowlist"]).toBe("allowlist");
+        expect(byName["t_disabled"]).toBe("off");
+        expect(byName["t_open"]).toBe("all");
+        expect(byName["t_null"]).toBe("all");
+      });
+
+      it("preserves an existing scope_level column instead of clobbering it", () => {
+        ensureSchema(db);
+        // Simulate a database created by the original upstream code that
+        // already has scope_level populated with explicit access levels.
+        db.exec(`DROP TABLE IF EXISTS tool_config;`);
+        db.exec(`
+          CREATE TABLE tool_config (
+            tool_name TEXT PRIMARY KEY,
+            enabled INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
+            scope TEXT,
+            scope_level TEXT NOT NULL DEFAULT 'all',
+            updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+            updated_by INTEGER
+          );
+        `);
+        // enabled=0 but scope_level explicitly 'admin' — the CASE backfill
+        // would have produced 'off', so this proves the column is preserved.
+        db.prepare(
+          `INSERT INTO tool_config (tool_name, enabled, scope, scope_level) VALUES (?, ?, ?, ?)`
+        ).run("explicit", 0, "always", "admin");
+        setSchemaVersion(db, "1.38.0");
+
+        runMigrations(db);
+
+        const row = db
+          .prepare(`SELECT scope_level FROM tool_config WHERE tool_name = 'explicit'`)
+          .get() as { scope_level: string };
+        expect(row.scope_level).toBe("admin");
+      });
+
+      it("scope CHECK constraint accepts the widened scope values", () => {
+        ensureSchema(db);
+        runMigrations(db);
+
+        const widenedScopes = ["open", "allowlist", "disabled"];
+        for (const scope of widenedScopes) {
+          expect(() =>
+            db
+              .prepare(`INSERT INTO tool_config (tool_name, scope) VALUES (?, ?)`)
+              .run(`tool-${scope}`, scope)
+          ).not.toThrow();
+        }
+        expect(() =>
+          db.prepare(`INSERT INTO tool_config (tool_name, scope) VALUES ('bad', 'nonsense')`).run()
+        ).toThrow();
+      });
+
+      it("scope_level CHECK constraint rejects invalid access levels", () => {
+        ensureSchema(db);
+        runMigrations(db);
+
+        for (const level of ["all", "allowlist", "admin", "off"]) {
+          expect(() =>
+            db
+              .prepare(`INSERT INTO tool_config (tool_name, scope_level) VALUES (?, ?)`)
+              .run(`lvl-${level}`, level)
+          ).not.toThrow();
+        }
+        expect(() =>
+          db
+            .prepare(`INSERT INTO tool_config (tool_name, scope_level) VALUES ('bad', 'nope')`)
+            .run()
+        ).toThrow();
+      });
+
+      it("scope_level defaults to 'all'", () => {
+        ensureSchema(db);
+        runMigrations(db);
+
+        db.prepare(`INSERT INTO tool_config (tool_name) VALUES ('defaulted')`).run();
+        const row = db
+          .prepare(`SELECT scope_level FROM tool_config WHERE tool_name = 'defaulted'`)
+          .get() as { scope_level: string };
+        expect(row.scope_level).toBe("all");
+      });
+
+      it("migration 1.39.0 is idempotent", () => {
+        ensureSchema(db);
+        createLegacyToolConfig();
+        db.prepare(`INSERT INTO tool_config (tool_name, enabled, scope) VALUES (?, ?, ?)`).run(
+          "tool",
+          1,
+          "admin-only"
+        );
+        setSchemaVersion(db, "1.38.0");
+
+        runMigrations(db);
+        // Second run must not throw and must leave data intact.
+        expect(() => runMigrations(db)).not.toThrow();
+
+        const row = db
+          .prepare(`SELECT scope_level FROM tool_config WHERE tool_name = 'tool'`)
+          .get() as { scope_level: string };
+        expect(row.scope_level).toBe("admin");
+      });
+
+      it("migrations stamp the schema version to at least 1.39.0", () => {
+        ensureSchema(db);
+        runMigrations(db);
+
+        expect(getSchemaVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
+        expect(versionAtLeast(CURRENT_SCHEMA_VERSION, "1.39.0")).toBe(true);
+      });
+    });
   });
 });
+
+// Local semver helper for the assertion above (the schema module keeps its own
+// comparison private). Returns true when `version` >= `minimum`.
+function versionAtLeast(version: string, minimum: string): boolean {
+  const a = version.split(".").map(Number);
+  const b = minimum.split(".").map(Number);
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const diff = (a[i] ?? 0) - (b[i] ?? 0);
+    if (diff !== 0) return diff > 0;
+  }
+  return true;
+}

--- a/src/memory/schema.ts
+++ b/src/memory/schema.ts
@@ -1104,7 +1104,7 @@ function repairAutonomousTaskChildForeignKeys(db: Database.Database): number {
   return tablesToRepair.length;
 }
 
-export const CURRENT_SCHEMA_VERSION = "1.38.0";
+export const CURRENT_SCHEMA_VERSION = "1.39.0";
 
 export function runMigrations(db: Database.Database): void {
   const currentVersion = getSchemaVersion(db);
@@ -2309,6 +2309,81 @@ export function runMigrations(db: Database.Database): void {
       log.info("Migration 1.38.0 complete: pending remote vector deletion queue created");
     } catch (error) {
       log.error({ err: error }, "Migration 1.38.0 failed");
+      throw error;
+    }
+  }
+
+  if (!currentVersion || versionLessThan(currentVersion, "1.39.0")) {
+    // Restores the tool_config schema the fork-sync (PRs #625/#630) dropped: the
+    // runtime (tool-config.ts / ToolRegistry) reads and writes a `scope_level`
+    // column and stores levelToScope() values ('open', 'allowlist', 'disabled')
+    // that the original narrow `scope` CHECK never allowed. Without this the
+    // agent crashes on startup with "no such column: scope_level" (issue #631).
+    log.info(
+      "Running migration 1.39.0: Add tool_config.scope_level and widen scope CHECK constraint"
+    );
+    try {
+      const toolConfigExists = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='tool_config'")
+        .get();
+
+      if (toolConfigExists) {
+        const columns = db.prepare(`PRAGMA table_info(tool_config)`).all() as Array<{
+          name: string;
+        }>;
+        const hasScopeLevel = columns.some((col) => col.name === "scope_level");
+        // Preserve an already-present scope_level (DBs created by the original
+        // upstream code) so we never clobber explicit access levels; otherwise
+        // derive it from the legacy enabled/scope columns.
+        const scopeLevelExpr = hasScopeLevel
+          ? "scope_level"
+          : `CASE
+               WHEN enabled = 0 THEN 'off'
+               WHEN scope = 'admin-only' THEN 'admin'
+               WHEN scope = 'allowlist' THEN 'allowlist'
+               WHEN scope = 'disabled' THEN 'off'
+               ELSE 'all'
+             END`;
+
+        // SQLite cannot ALTER a CHECK constraint in place, so rebuild the table.
+        db.transaction(() => {
+          db.exec(`
+            CREATE TABLE tool_config_new (
+              tool_name TEXT PRIMARY KEY,
+              enabled INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
+              scope TEXT CHECK(scope IN ('always', 'open', 'dm-only', 'group-only', 'admin-only', 'allowlist', 'disabled')),
+              scope_level TEXT NOT NULL DEFAULT 'all' CHECK(scope_level IN ('all', 'allowlist', 'admin', 'off')),
+              updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+              updated_by INTEGER
+            );
+          `);
+          db.exec(`
+            INSERT INTO tool_config_new (tool_name, enabled, scope, scope_level, updated_at, updated_by)
+            SELECT tool_name, enabled, scope, ${scopeLevelExpr}, updated_at, updated_by
+            FROM tool_config;
+          `);
+          db.exec(`DROP TABLE tool_config;`);
+          db.exec(`ALTER TABLE tool_config_new RENAME TO tool_config;`);
+        })();
+      } else {
+        // Defensive: tool_config should already exist from migration 1.10.0, but
+        // create it with the full schema if a database somehow lacks it.
+        db.exec(`
+          CREATE TABLE IF NOT EXISTS tool_config (
+            tool_name TEXT PRIMARY KEY,
+            enabled INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
+            scope TEXT CHECK(scope IN ('always', 'open', 'dm-only', 'group-only', 'admin-only', 'allowlist', 'disabled')),
+            scope_level TEXT NOT NULL DEFAULT 'all' CHECK(scope_level IN ('all', 'allowlist', 'admin', 'off')),
+            updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+            updated_by INTEGER
+          );
+        `);
+      }
+      log.info(
+        "Migration 1.39.0 complete: tool_config.scope_level restored and scope CHECK widened"
+      );
+    } catch (error) {
+      log.error({ err: error }, "Migration 1.39.0 failed");
       throw error;
     }
   }


### PR DESCRIPTION
## Суть проблемы

Агент падал при старте с ошибкой:

```
SqliteError: no such column: scope_level
    at loadAllToolConfigs (src/memory/tool-config.ts)
    at ToolRegistry.loadConfigFromDB (src/agent/tools/registry.ts)
    at PluginOrchestrator.loadAll (...)
```

### Корневая причина

Синхронизация форка с оригинальным репозиторием (PR #625 и #630) внесла **код**, который читает и пишет колонку `tool_config.scope_level` (`src/memory/tool-config.ts`, `ToolRegistry`), но **потеряла миграции**, которые эту колонку добавляют и расширяют `CHECK`-ограничение для `scope`. В результате на существующих базах данных (со `schema_version = 1.38.0`) колонки `scope_level` нет, и первое же обращение `loadAllToolConfigs` валит запуск.

Обнаружена и вторая, скрытая ошибка: после сидинга `ToolRegistry` вызывает `saveToolConfig`/`initializeToolConfig`, которые пишут в `scope` значения из `levelToScope()` — `'open'`, `'allowlist'`, `'disabled'`. Старый узкий `CHECK(scope IN ('always','dm-only','group-only','admin-only'))` их отвергал, так что даже после добавления одной только колонки сидинг всё равно упал бы.

## Решение

Добавлена идемпотентная миграция **1.39.0**, которая перестраивает таблицу `tool_config` (SQLite не умеет менять `CHECK` через `ALTER`):

- добавляет колонку `scope_level TEXT NOT NULL DEFAULT 'all' CHECK(scope_level IN ('all','allowlist','admin','off'))`;
- расширяет `CHECK` у `scope` значениями `'open'`, `'allowlist'`, `'disabled'`;
- бэкфиллит `scope_level` из legacy-колонок `enabled`/`scope` по тому же отображению, что использует рантайм (`enabled=0 → off`, `admin-only → admin`, `allowlist → allowlist`, `disabled → off`, иначе `all`);
- если колонка `scope_level` уже существует (БД, созданные оригинальным upstream), её значение **сохраняется**, а не перетирается.

`CURRENT_SCHEMA_VERSION` поднят до `1.39.0` — иначе на базах, помеченных `1.38.0`, миграции вообще не запускаются.

> Версия npm-пакета намеренно **не** меняется вручную: релизы управляются release-please на основе Conventional Commits, и префикс `fix:` сам поднимет patch-версию. `1.39.0` здесь — это внутренняя версия схемы БД, она не связана с версией пакета.

## Как воспроизвести

```bash
npx tsx experiments/repro-issue-631-scope-level.ts
```

До фикса скрипт печатает `❌ no such column: scope_level`, после — `✅ OK` для всех трёх путей (`loadAllToolConfigs`, `initializeToolConfig`, `saveToolConfig`).

## Тесты

В `src/memory/__tests__/schema.test.ts` добавлен блок `scope_level migration 1.39.0 (issue #631 regression)`, который покрывает:

- наличие колонки `scope_level` после миграций на свежей БД;
- `loadAllToolConfigs()` больше не бросает исключение (точный путь из стектрейса);
- сидинг записывает расширенные значения `scope` без ошибок;
- апгрейд БД со `schema_version = 1.38.0` добавляет колонку и корректно бэкфиллит;
- полное отображение всех legacy-значений `scope` в уровни доступа;
- сохранение уже существующей колонки `scope_level`;
- `CHECK` у `scope` принимает `'open'`/`'allowlist'`/`'disabled'` и отвергает мусор;
- `CHECK` у `scope_level` отвергает невалидные уровни, дефолт `'all'`;
- идемпотентность повторного запуска миграций;
- штамповка `schema_version` в `1.39.0`.

## Проверки

- `npx tsc --noEmit` — без ошибок
- `npm run lint` — без ошибок и предупреждений
- `prettier --check` — без замечаний
- `npx vitest run` — **3702 теста проходят** (234 файла)

Fixes #631
