### PR TITLE
fix(provider): исправить параметры NVIDIA GLM-5.1

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T16:05:14.268Z for PR creation at branch issue-633-a9daa360169c for issue https://github.com/xlabtg/teleton-agent/issues/633

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T16:05:14.268Z for PR creation at branch issue-633-a9daa360169c for issue https://github.com/xlabtg/teleton-agent/issues/633

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -81,6 +81,17 @@ export async function registerCocoonModels(httpPort: number): Promise<string[]> 
 
 const NVIDIA_BASE_URL = "https://integrate.api.nvidia.com/v1";
 const NVIDIA_DISABLE_STREAMING_USAGE_MODELS = new Set(["z-ai/glm-5.1"]);
+const NVIDIA_CACHE_RETENTION = "none";
+const DEFAULT_CACHE_RETENTION = "long";
+const NVIDIA_MAX_TEMPERATURE = 1;
+
+function normalizeProviderTemperature(provider: SupportedProvider, temperature: number): number {
+  if (provider !== "nvidia" || !Number.isFinite(temperature)) {
+    return temperature;
+  }
+
+  return Math.min(Math.max(temperature, 0), NVIDIA_MAX_TEMPERATURE);
+}
 
 /** Build a NVIDIA NIM model object on demand (OpenAI-compatible, fixed base URL) */
 function buildNvidiaModel(modelId: string): Model<"openai-completions"> {
@@ -101,6 +112,7 @@ function buildNvidiaModel(modelId: string): Model<"openai-completions"> {
       supportsDeveloperRole: false,
       supportsReasoningEffort: false,
       supportsStrictMode: false,
+      supportsLongCacheRetention: false,
       maxTokensField: "max_tokens",
       ...(disablesStreamingUsage ? { supportsUsageInStreaming: false } : {}),
     },
@@ -290,14 +302,17 @@ export async function chatWithContext(
     tools,
   };
 
-  const temperature = options.temperature ?? config.temperature;
+  const temperature = normalizeProviderTemperature(
+    provider,
+    options.temperature ?? config.temperature
+  );
 
   const completeOptions: Record<string, unknown> = {
     apiKey: getEffectiveApiKey(provider, config.api_key),
     maxTokens: options.maxTokens ?? config.max_tokens,
     temperature,
     sessionId: options.sessionId,
-    cacheRetention: "long",
+    cacheRetention: provider === "nvidia" ? NVIDIA_CACHE_RETENTION : DEFAULT_CACHE_RETENTION,
     signal: AbortSignal.timeout(LLM_REQUEST_TIMEOUT_MS),
   };
   if (isCocoon) {

--- a/src/providers/__tests__/nvidia-glm-tools.test.ts
+++ b/src/providers/__tests__/nvidia-glm-tools.test.ts
@@ -99,6 +99,17 @@ function makeToolResultMessage(): ToolResultMessage {
   };
 }
 
+type CapturedCompleteOptions = {
+  cacheRetention?: unknown;
+  sessionId?: unknown;
+  temperature?: unknown;
+};
+
+function getCapturedCompleteOptions(): CapturedCompleteOptions {
+  const [, , options] = mockComplete.mock.calls[0] as [unknown, unknown, CapturedCompleteOptions];
+  return options;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockComplete.mockResolvedValue(makeAssistantMessage("ok"));
@@ -116,6 +127,35 @@ describe("NVIDIA GLM-5.1 tool compatibility", () => {
     expect(mockComplete).toHaveBeenCalledTimes(1);
     const [, context] = mockComplete.mock.calls[0] as [unknown, { tools?: Tool[] }];
     expect(context.tools).toEqual([sampleTool]);
+  });
+
+  it("does not request prompt cache retention for GLM-5.1 chat requests", async () => {
+    const { chatWithContext } = await import("../../agent/client.js");
+
+    await chatWithContext(agentConfig("z-ai/glm-5.1"), {
+      context: { messages: [], systemPrompt: "test" },
+      sessionId: "glm-session",
+      tools: [sampleTool],
+    });
+
+    expect(getCapturedCompleteOptions()).toMatchObject({
+      cacheRetention: "none",
+      sessionId: "glm-session",
+    });
+  });
+
+  it("caps GLM-5.1 temperature at NVIDIA API maximum", async () => {
+    const { chatWithContext } = await import("../../agent/client.js");
+
+    await chatWithContext(
+      { ...agentConfig("z-ai/glm-5.1"), temperature: 1.7 },
+      {
+        context: { messages: [], systemPrompt: "test" },
+        tools: [sampleTool],
+      }
+    );
+
+    expect(getCapturedCompleteOptions().temperature).toBe(1);
   });
 
   it("preserves native tool history for GLM-5.1 follow-up requests", async () => {

--- a/src/providers/__tests__/nvidia-provider.test.ts
+++ b/src/providers/__tests__/nvidia-provider.test.ts
@@ -41,6 +41,7 @@ describe("NVIDIA model routing", () => {
 
     expect("compat" in model && model.compat?.maxTokensField).toBe("max_tokens");
     expect("compat" in model && model.compat?.supportsStrictMode).toBe(false);
+    expect("compat" in model && model.compat?.supportsLongCacheRetention).toBe(false);
   });
 
   it("keeps GLM-5.1 on the OpenAI-compatible NVIDIA endpoint", () => {


### PR DESCRIPTION
## Что исправлено

Closes #633.

GLM-5.1 через NVIDIA NIM получал OpenAI-specific параметры prompt cache retention из-за общего `cacheRetention: "long"`. Для NVIDIA endpoint эти поля не поддерживаются и могут приводить к `400 status code (no body)`.

## Изменения

- Отключил long prompt cache retention для NVIDIA-моделей в compat и в параметрах вызова `complete`.
- Ограничил температуру NVIDIA-запросов максимумом `1`, который указан в схеме NVIDIA Chat Completions для GLM-5.1.
- Сохранил native tool calling для GLM-5.1, добавленный в #627.
- Добавил регрессионные тесты на GLM-5.1: tools остаются native, cache retention не запрашивается, температура нормализуется.

## Проверка

- `npm test -- src/providers/__tests__/nvidia-glm-tools.test.ts src/providers/__tests__/nvidia-provider.test.ts`
- `npm run format:check`
- `npm run lint`
- `npm run build:sdk && npm run typecheck`
- `npm run build:sdk && npm test`