### PR TITLE
fix(memory): исправить синхронизацию tg_messages FTS при upsert

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T18:06:43.504Z for PR creation at branch issue-608-0f1839e9d5d7 for issue https://github.com/xlabtg/teleton-agent/issues/608

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T18:06:43.504Z for PR creation at branch issue-608-0f1839e9d5d7 for issue https://github.com/xlabtg/teleton-agent/issues/608

--- a/package-lock.json
+++ b/package-lock.json
@@ -3946,9 +3946,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
@@ -3964,12 +3964,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -12787,24 +12781,23 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
-      "integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     },
     "path-to-regexp": ">=8.4.0",
     "picomatch": ">=4.0.4",
+    "protobufjs": "7.6.4",
     "smol-toml": ">=1.6.1",
     "vite": "^7.3.2"
   }

--- a/src/memory/__tests__/database-fts-rebuild.test.ts
+++ b/src/memory/__tests__/database-fts-rebuild.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { MemoryDatabase } from "../database.js";
+
+describe("MemoryDatabase FTS rebuild", () => {
+  let tempDir: string | undefined;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  function createMemoryDatabase(): MemoryDatabase {
+    tempDir = mkdtempSync(join(tmpdir(), "teleton-fts-"));
+    return new MemoryDatabase({
+      path: join(tempDir, "memory.sqlite"),
+      enableVectorSearch: false,
+    });
+  }
+
+  it("rebuildFtsIndexes removes stale tg_messages postings left by legacy REPLACE upserts", () => {
+    const memoryDb = createMemoryDatabase();
+    try {
+      const db = memoryDb.getDb();
+      db.prepare(`INSERT INTO tg_chats (id, type) VALUES ('chat1', 'dm')`).run();
+      db.prepare(
+        `INSERT INTO tg_messages (id, chat_id, text, timestamp)
+         VALUES ('msg1', 'chat1', 'oldtoken message', 1000)`
+      ).run();
+      db.prepare(
+        `INSERT OR REPLACE INTO tg_messages (id, chat_id, text, timestamp)
+         VALUES ('msg1', 'chat1', 'newtoken message', 2000)`
+      ).run();
+
+      const staleBefore = db
+        .prepare(
+          `
+          SELECT mf.rowid AS fts_rowid, m.id
+          FROM tg_messages_fts mf
+          LEFT JOIN tg_messages m ON m.rowid = mf.rowid
+          WHERE tg_messages_fts MATCH 'oldtoken'
+        `
+        )
+        .all();
+
+      expect(staleBefore).toHaveLength(1);
+
+      const result = memoryDb.rebuildFtsIndexes();
+
+      const staleAfter = db
+        .prepare(
+          `
+          SELECT mf.rowid AS fts_rowid, m.id
+          FROM tg_messages_fts mf
+          LEFT JOIN tg_messages m ON m.rowid = mf.rowid
+          WHERE tg_messages_fts MATCH 'oldtoken'
+        `
+        )
+        .all();
+      const freshAfter = db
+        .prepare(
+          `
+          SELECT m.id, m.text
+          FROM tg_messages_fts mf
+          JOIN tg_messages m ON m.rowid = mf.rowid
+          WHERE tg_messages_fts MATCH 'newtoken'
+        `
+        )
+        .all();
+
+      expect(result).toEqual({ knowledge: 0, messages: 1 });
+      expect(staleAfter).toHaveLength(0);
+      expect(freshAfter).toEqual([{ id: "msg1", text: "newtoken message" }]);
+    } finally {
+      memoryDb.close();
+    }
+  });
+});

--- a/src/memory/__tests__/feed-messages.test.ts
+++ b/src/memory/__tests__/feed-messages.test.ts
@@ -181,7 +181,7 @@ describe("MessageStore", () => {
       expect(chat.last_message_at).toBe(ts);
     });
 
-    it("replaces an existing message with same id (INSERT OR REPLACE)", async () => {
+    it("updates an existing message with same id", async () => {
       await store.storeMessage(makeMessage({ id: "dup-msg", text: "First version" }));
       await store.storeMessage(makeMessage({ id: "dup-msg", text: "Updated version" }));
 
@@ -190,6 +190,43 @@ describe("MessageStore", () => {
       }[];
       expect(rows).toHaveLength(1);
       expect(rows[0].text).toBe("Updated version");
+    });
+
+    it("keeps tg_messages_fts in sync when a message is updated", async () => {
+      await store.storeMessage(makeMessage({ id: "dup-fts", text: "oldtoken message" }));
+      const before = db.prepare("SELECT rowid FROM tg_messages WHERE id = ?").get("dup-fts") as {
+        rowid: number;
+      };
+
+      await store.storeMessage(makeMessage({ id: "dup-fts", text: "newtoken message" }));
+      const after = db.prepare("SELECT rowid FROM tg_messages WHERE id = ?").get("dup-fts") as {
+        rowid: number;
+      };
+
+      const oldMatches = db
+        .prepare(
+          `
+          SELECT mf.rowid AS fts_rowid, m.id, m.text
+          FROM tg_messages_fts mf
+          LEFT JOIN tg_messages m ON m.rowid = mf.rowid
+          WHERE tg_messages_fts MATCH ?
+        `
+        )
+        .all("oldtoken");
+      const newMatches = db
+        .prepare(
+          `
+          SELECT m.id, m.text
+          FROM tg_messages_fts mf
+          JOIN tg_messages m ON m.rowid = mf.rowid
+          WHERE tg_messages_fts MATCH ?
+        `
+        )
+        .all("newtoken") as Array<{ id: string; text: string }>;
+
+      expect(after.rowid).toBe(before.rowid);
+      expect(oldMatches).toHaveLength(0);
+      expect(newMatches).toEqual([{ id: "dup-fts", text: "newtoken message" }]);
     });
 
     it("does not call embedder when vectorEnabled is false", async () => {

--- a/src/memory/__tests__/schema.test.ts
+++ b/src/memory/__tests__/schema.test.ts
@@ -1495,7 +1495,7 @@ describe("Memory Schema", () => {
     });
 
     it("CURRENT_SCHEMA_VERSION is set to expected value", () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe("1.39.0");
+      expect(CURRENT_SCHEMA_VERSION).toBe("1.40.0");
     });
   });
 
@@ -1657,6 +1657,92 @@ describe("Memory Schema", () => {
         )
         .get() as { name: string } | undefined;
       expect(table).toBeDefined();
+      expect(getSchemaVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
+    });
+
+    it("runMigrations from version 1.39.0 rebuilds stale tg_messages_fts postings", () => {
+      ensureSchema(db);
+      db.prepare(`INSERT INTO tg_chats (id, type) VALUES ('chat1', 'dm')`).run();
+      db.prepare(
+        `INSERT INTO tg_messages (id, chat_id, text, timestamp)
+         VALUES ('msg1', 'chat1', 'oldtoken message', 1000)`
+      ).run();
+      const first = db.prepare(`SELECT rowid FROM tg_messages WHERE id = 'msg1'`).get() as {
+        rowid: number;
+      };
+
+      db.prepare(
+        `INSERT OR REPLACE INTO tg_messages (id, chat_id, text, timestamp)
+         VALUES ('msg1', 'chat1', 'newtoken message', 2000)`
+      ).run();
+      const second = db.prepare(`SELECT rowid FROM tg_messages WHERE id = 'msg1'`).get() as {
+        rowid: number;
+      };
+      const staleBefore = db
+        .prepare(
+          `
+          SELECT mf.rowid AS fts_rowid, m.id
+          FROM tg_messages_fts mf
+          LEFT JOIN tg_messages m ON m.rowid = mf.rowid
+          WHERE tg_messages_fts MATCH 'oldtoken'
+        `
+        )
+        .all();
+
+      expect(second.rowid).not.toBe(first.rowid);
+      expect(staleBefore).toHaveLength(1);
+
+      setSchemaVersion(db, "1.39.0");
+      runMigrations(db);
+
+      const staleAfter = db
+        .prepare(
+          `
+          SELECT mf.rowid AS fts_rowid, m.id
+          FROM tg_messages_fts mf
+          LEFT JOIN tg_messages m ON m.rowid = mf.rowid
+          WHERE tg_messages_fts MATCH 'oldtoken'
+        `
+        )
+        .all();
+      const freshAfter = db
+        .prepare(
+          `
+          SELECT m.id, m.text
+          FROM tg_messages_fts mf
+          JOIN tg_messages m ON m.rowid = mf.rowid
+          WHERE tg_messages_fts MATCH 'newtoken'
+        `
+        )
+        .all();
+
+      expect(staleAfter).toHaveLength(0);
+      expect(freshAfter).toEqual([{ id: "msg1", text: "newtoken message" }]);
+
+      db.prepare(`UPDATE tg_messages SET text = 'finaltoken message' WHERE id = 'msg1'`).run();
+      const replacedAfterMigration = db
+        .prepare(
+          `
+          SELECT m.id, m.text
+          FROM tg_messages_fts mf
+          JOIN tg_messages m ON m.rowid = mf.rowid
+          WHERE tg_messages_fts MATCH 'newtoken'
+        `
+        )
+        .all();
+      const updatedAfterMigration = db
+        .prepare(
+          `
+          SELECT m.id, m.text
+          FROM tg_messages_fts mf
+          JOIN tg_messages m ON m.rowid = mf.rowid
+          WHERE tg_messages_fts MATCH 'finaltoken'
+        `
+        )
+        .all();
+
+      expect(replacedAfterMigration).toHaveLength(0);
+      expect(updatedAfterMigration).toEqual([{ id: "msg1", text: "finaltoken message" }]);
       expect(getSchemaVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
     });
   });
@@ -2087,12 +2173,12 @@ describe("Memory Schema", () => {
         expect(row.scope_level).toBe("admin");
       });
 
-      it("migrations stamp the schema version to at least 1.39.0", () => {
+      it("migrations stamp the schema version to at least 1.40.0", () => {
         ensureSchema(db);
         runMigrations(db);
 
         expect(getSchemaVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
-        expect(versionAtLeast(CURRENT_SCHEMA_VERSION, "1.39.0")).toBe(true);
+        expect(versionAtLeast(CURRENT_SCHEMA_VERSION, "1.40.0")).toBe(true);
       });
     });
   });

--- a/src/memory/database.ts
+++ b/src/memory/database.ts
@@ -186,46 +186,21 @@ export class MemoryDatabase {
    * Call this if FTS triggers didn't fire correctly.
    */
   rebuildFtsIndexes(): { knowledge: number; messages: number } {
-    this.db.exec(`DELETE FROM knowledge_fts`);
-    const knowledgeRows = this.db
-      .prepare(`SELECT rowid, text, id, path, source FROM knowledge`)
-      .all() as Array<{
-      rowid: number;
-      text: string;
-      id: string;
-      path: string | null;
-      source: string;
-    }>;
+    const knowledgeCount = (
+      this.db.prepare(`SELECT COUNT(*) AS count FROM knowledge`).get() as { count: number }
+    ).count;
+    const messageCount = (
+      this.db.prepare(`SELECT COUNT(*) AS count FROM tg_messages WHERE text IS NOT NULL`).get() as {
+        count: number;
+      }
+    ).count;
 
-    const insertKnowledge = this.db.prepare(
-      `INSERT INTO knowledge_fts(rowid, text, id, path, source) VALUES (?, ?, ?, ?, ?)`
-    );
-    for (const row of knowledgeRows) {
-      insertKnowledge.run(row.rowid, row.text, row.id, row.path, row.source);
-    }
+    this.db.exec(`
+      INSERT INTO knowledge_fts(knowledge_fts) VALUES ('rebuild');
+      INSERT INTO tg_messages_fts(tg_messages_fts) VALUES ('rebuild');
+    `);
 
-    this.db.exec(`DELETE FROM tg_messages_fts`);
-    const messageRows = this.db
-      .prepare(
-        `SELECT rowid, text, id, chat_id, sender_id, timestamp FROM tg_messages WHERE text IS NOT NULL`
-      )
-      .all() as Array<{
-      rowid: number;
-      text: string;
-      id: string;
-      chat_id: string;
-      sender_id: string | null;
-      timestamp: number;
-    }>;
-
-    const insertMessage = this.db.prepare(
-      `INSERT INTO tg_messages_fts(rowid, text, id, chat_id, sender_id, timestamp) VALUES (?, ?, ?, ?, ?, ?)`
-    );
-    for (const row of messageRows) {
-      insertMessage.run(row.rowid, row.text, row.id, row.chat_id, row.sender_id, row.timestamp);
-    }
-
-    return { knowledge: knowledgeRows.length, messages: messageRows.length };
+    return { knowledge: knowledgeCount, messages: messageCount };
   }
 
   close(): void {

--- a/src/memory/feed/messages.ts
+++ b/src/memory/feed/messages.ts
@@ -86,10 +86,21 @@ export class MessageStore {
       this.db
         .prepare(
           `
-        INSERT OR REPLACE INTO tg_messages (
+        INSERT INTO tg_messages (
           id, chat_id, sender_id, text, embedding, reply_to_id,
           is_from_agent, has_media, media_type, timestamp
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          chat_id = excluded.chat_id,
+          sender_id = excluded.sender_id,
+          text = excluded.text,
+          embedding = excluded.embedding,
+          reply_to_id = excluded.reply_to_id,
+          is_from_agent = excluded.is_from_agent,
+          has_media = excluded.has_media,
+          media_type = excluded.media_type,
+          timestamp = excluded.timestamp,
+          indexed_at = unixepoch()
       `
         )
         .run(

--- a/src/memory/schema.ts
+++ b/src/memory/schema.ts
@@ -676,11 +676,13 @@ export function ensureSchema(db: Database.Database): void {
     END;
 
     CREATE TRIGGER IF NOT EXISTS tg_messages_fts_delete AFTER DELETE ON tg_messages BEGIN
-      DELETE FROM tg_messages_fts WHERE rowid = old.rowid;
+      INSERT INTO tg_messages_fts(tg_messages_fts, rowid, text, id, chat_id, sender_id, timestamp)
+      VALUES ('delete', old.rowid, old.text, old.id, old.chat_id, old.sender_id, old.timestamp);
     END;
 
     CREATE TRIGGER IF NOT EXISTS tg_messages_fts_update AFTER UPDATE ON tg_messages BEGIN
-      DELETE FROM tg_messages_fts WHERE rowid = old.rowid;
+      INSERT INTO tg_messages_fts(tg_messages_fts, rowid, text, id, chat_id, sender_id, timestamp)
+      VALUES ('delete', old.rowid, old.text, old.id, old.chat_id, old.sender_id, old.timestamp);
       INSERT INTO tg_messages_fts(rowid, text, id, chat_id, sender_id, timestamp)
       VALUES (new.rowid, new.text, new.id, new.chat_id, new.sender_id, new.timestamp);
     END;
@@ -1104,7 +1106,7 @@ function repairAutonomousTaskChildForeignKeys(db: Database.Database): number {
   return tablesToRepair.length;
 }
 
-export const CURRENT_SCHEMA_VERSION = "1.39.0";
+export const CURRENT_SCHEMA_VERSION = "1.40.0";
 
 export function runMigrations(db: Database.Database): void {
   const currentVersion = getSchemaVersion(db);
@@ -2384,6 +2386,41 @@ export function runMigrations(db: Database.Database): void {
       );
     } catch (error) {
       log.error({ err: error }, "Migration 1.39.0 failed");
+      throw error;
+    }
+  }
+
+  if (!currentVersion || versionLessThan(currentVersion, "1.40.0")) {
+    log.info("Running migration 1.40.0: Repair and rebuild tg_messages_fts");
+    try {
+      if (tableExists(db, "tg_messages") && tableExists(db, "tg_messages_fts")) {
+        db.exec(`
+          DROP TRIGGER IF EXISTS tg_messages_fts_insert;
+          DROP TRIGGER IF EXISTS tg_messages_fts_delete;
+          DROP TRIGGER IF EXISTS tg_messages_fts_update;
+
+          CREATE TRIGGER tg_messages_fts_insert AFTER INSERT ON tg_messages BEGIN
+            INSERT INTO tg_messages_fts(rowid, text, id, chat_id, sender_id, timestamp)
+            VALUES (new.rowid, new.text, new.id, new.chat_id, new.sender_id, new.timestamp);
+          END;
+
+          CREATE TRIGGER tg_messages_fts_delete AFTER DELETE ON tg_messages BEGIN
+            INSERT INTO tg_messages_fts(tg_messages_fts, rowid, text, id, chat_id, sender_id, timestamp)
+            VALUES ('delete', old.rowid, old.text, old.id, old.chat_id, old.sender_id, old.timestamp);
+          END;
+
+          CREATE TRIGGER tg_messages_fts_update AFTER UPDATE ON tg_messages BEGIN
+            INSERT INTO tg_messages_fts(tg_messages_fts, rowid, text, id, chat_id, sender_id, timestamp)
+            VALUES ('delete', old.rowid, old.text, old.id, old.chat_id, old.sender_id, old.timestamp);
+            INSERT INTO tg_messages_fts(rowid, text, id, chat_id, sender_id, timestamp)
+            VALUES (new.rowid, new.text, new.id, new.chat_id, new.sender_id, new.timestamp);
+          END;
+        `);
+        db.prepare(`INSERT INTO tg_messages_fts(tg_messages_fts) VALUES ('rebuild')`).run();
+      }
+      log.info("Migration 1.40.0 complete: tg_messages_fts triggers repaired and index rebuilt");
+    } catch (error) {
+      log.error({ err: error }, "Migration 1.40.0 failed");
       throw error;
     }
   }


### PR DESCRIPTION
## Что исправлено

- Заменен `INSERT OR REPLACE` для `tg_messages` на upsert через `ON CONFLICT(id) DO UPDATE`, чтобы SQLite сохранял `rowid` сообщения.
- Исправлены FTS5 external-content триггеры `tg_messages_fts_delete` и `tg_messages_fts_update`: удаление старых токенов теперь выполняется через FTS5 delete-command.
- Добавлена миграция `1.40.0`, которая пересоздает триггеры и rebuild'ит `tg_messages_fts` для очистки stale/orphan postings.
- `MemoryDatabase.rebuildFtsIndexes()` теперь использует официальный FTS5 `rebuild` вместо ручного заполнения external-content индексов.
- Обновлен transitive `protobufjs` до `7.6.4` через existing `overrides`, чтобы свежий Security audit на ветке проходил без `GHSA-wcpc-wj8m-hjx6`.

Fixes xlabtg/teleton-agent#608

## Как воспроизводилось

- Новый регрессионный тест `src/memory/__tests__/feed-messages.test.ts` до фикса показывал, что повторный save менял `rowid` и оставлял старый токен в `tg_messages_fts`.
- Новый migration-тест `src/memory/__tests__/schema.test.ts` до фикса показывал, что stale FTS postings переживают миграции.
- Новый тест `src/memory/__tests__/database-fts-rebuild.test.ts` проверяет rebuild FTS индексов через публичный helper.

## Проверка

- `npm ci`
- `npm run build:sdk`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run audit:ci`
- `npm test`
