### PR TITLE
fix(web): предотвратить сохранение Soul-буфера в другую вкладку

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T18:51:05.807Z for PR creation at branch issue-609-b2a1a723c3b3 for issue https://github.com/xlabtg/teleton-agent/issues/609

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T18:51:05.807Z for PR creation at branch issue-609-b2a1a723c3b3 for issue https://github.com/xlabtg/teleton-agent/issues/609

--- a/e2e/fixtures/mock-backend.ts
+++ b/e2e/fixtures/mock-backend.ts
@@ -45,6 +45,12 @@ export interface MockBackendOptions {
   sources?: MemorySourceFixture[];
   /** Initial security settings returned by GET /api/security/settings. */
   securitySettings?: SecuritySettingsFixture;
+  /** Seed Soul editor files returned by GET /api/soul/:file. */
+  soulFiles?: Record<string, string>;
+  /** Artificial GET delays for specific Soul files, in milliseconds. */
+  soulLoadDelayMs?: Record<string, number>;
+  /** Observe Soul editor PUT requests. */
+  onSoulUpdate?: (filename: string, content: string) => void;
 }
 
 const NOW = Date.UTC(2026, 0, 1, 12, 0, 0); // fixed clock for determinism
@@ -118,6 +124,18 @@ const DEFAULT_SECURITY: SecuritySettingsFixture = {
   rate_limit_rpm: 120,
 };
 
+const DEFAULT_SOUL_FILES: Record<string, string> = {
+  "SOUL.md": "# SOUL\n\nInitial soul content.",
+  "SECURITY.md": "# SECURITY\n\nInitial security content.",
+  "STRATEGY.md": "# STRATEGY\n\nInitial strategy content.",
+  "MEMORY.md": "# MEMORY\n\nInitial memory content.",
+  "HEARTBEAT.md": "# HEARTBEAT\n\nInitial heartbeat content.",
+};
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /**
  * Install the mock backend on a page. Call this BEFORE page.goto().
  */
@@ -133,6 +151,7 @@ export async function setupMockBackend(
   const sources = options.sources ?? DEFAULT_SOURCES;
   let security: SecuritySettingsFixture = { ...(options.securitySettings ?? DEFAULT_SECURITY) };
   const pipelines: unknown[] = [];
+  const soulFiles: Record<string, string> = { ...DEFAULT_SOUL_FILES, ...options.soulFiles };
 
   await page.route("**/*", async (route) => {
     const request = route.request();
@@ -309,6 +328,26 @@ export async function setupMockBackend(
     // ── Memory ─────────────────────────────────────────────────────────
     if (path === "/api/memory/sources") {
       return json(route, ok(sources));
+    }
+
+    // ── Soul editor ────────────────────────────────────────────────────
+    const soulFileMatch = path.match(/^\/api\/soul\/([^/]+)$/);
+    if (soulFileMatch) {
+      const filename = decodeURIComponent(soulFileMatch[1]);
+      if (method === "GET") {
+        const loadDelayMs = options.soulLoadDelayMs?.[filename] ?? 0;
+        if (loadDelayMs > 0) {
+          await delay(loadDelayMs);
+        }
+        return json(route, ok({ content: soulFiles[filename] ?? "" }));
+      }
+      if (method === "PUT") {
+        const payload = JSON.parse(request.postData() || "{}") as { content?: string };
+        const content = payload.content ?? "";
+        soulFiles[filename] = content;
+        options.onSoulUpdate?.(filename, content);
+        return json(route, ok({ message: `${filename} saved` }));
+      }
     }
 
     // ── Pipelines ──────────────────────────────────────────────────────

--- a/e2e/soul.spec.ts
+++ b/e2e/soul.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+import { setupMockBackend } from "./fixtures/mock-backend";
+
+test("discarding one Soul tab cannot save its content into another tab", async ({ page }) => {
+  const updates: Array<{ filename: string; content: string }> = [];
+  const originalStrategy = "# STRATEGY\n\nOriginal strategy content.";
+  const discardedSoul = "# SOUL\n\nDiscarded local edit.";
+
+  await setupMockBackend(page, {
+    soulFiles: {
+      "SOUL.md": "# SOUL\n\nOriginal soul content.",
+      "STRATEGY.md": originalStrategy,
+    },
+    soulLoadDelayMs: { "STRATEGY.md": 1_000 },
+    onSoulUpdate: (filename, content) => {
+      updates.push({ filename, content });
+    },
+  });
+
+  await page.goto("/soul");
+  await expect(page.getByRole("heading", { name: "Soul Editor", exact: true })).toBeVisible();
+  await expect(page.getByText("Original soul content.")).toBeVisible();
+
+  await page.locator(".cm-content").click();
+  await page.keyboard.press("Control+A");
+  await page.keyboard.type(discardedSoul);
+  await expect(page.getByText("Unsaved changes")).toBeVisible();
+
+  await page.getByRole("button", { name: "STRATEGY.md" }).click();
+  await page.getByRole("button", { name: "Discard" }).click();
+  await expect(page.getByText("Loading...")).toBeVisible();
+
+  await page.keyboard.press("Control+S");
+  await page.waitForTimeout(250);
+
+  expect(updates).not.toContainEqual({ filename: "STRATEGY.md", content: discardedSoul });
+
+  await expect(page.getByText("Original strategy content.")).toBeVisible();
+  expect(updates).not.toContainEqual({ filename: "STRATEGY.md", content: discardedSoul });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -3946,9 +3946,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
@@ -3964,12 +3964,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -12787,24 +12781,23 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
-      "integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     },
     "path-to-regexp": ">=8.4.0",
     "picomatch": ">=4.0.4",
+    "protobufjs": "7.6.4",
     "smol-toml": ">=1.6.1",
     "vite": "^7.3.2"
   }

--- a/web/e2e/mock-api.ts
+++ b/web/e2e/mock-api.ts
@@ -26,6 +26,8 @@ const OBJECT_RESPONSES: Record<string, unknown> = {
     platform: "linux",
   },
   "/agent/status": { state: "stopped", uptime: 0, error: null },
+  "/agents": { agents: [] },
+  "/agents/archetypes": { archetypes: [] },
   "/memory/stats": { knowledge: 0, sessions: 0, messages: 0, chats: 0 },
   "/tools/rag": {
     enabled: false,
@@ -79,6 +81,15 @@ async function fulfilJson(route: Route, body: unknown): Promise<void> {
   });
 }
 
+async function fulfilEventStream(route: Route): Promise<void> {
+  await route.fulfill({
+    status: 200,
+    contentType: "text/event-stream",
+    headers: { "Cache-Control": "no-cache", Connection: "keep-alive" },
+    body: "",
+  });
+}
+
 /**
  * Install request interception so the WebUI renders against mock data.
  * Call before navigating.
@@ -98,12 +109,7 @@ export async function mockBackend(page: Page): Promise<void> {
   // Log stream (EventSource) — return an empty, immediately-closing stream so
   // the page doesn't hang waiting for events.
   await page.route("**/api/logs/stream", (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: "text/event-stream",
-      headers: { "Cache-Control": "no-cache", Connection: "keep-alive" },
-      body: "",
-    }),
+    fulfilEventStream(route),
   );
 
   // Everything else under /api.
@@ -111,6 +117,14 @@ export async function mockBackend(page: Page): Promise<void> {
     const url = new URL(route.request().url());
     const path = url.pathname.replace(/^\/api/, "");
     const method = route.request().method();
+    if (
+      path === "/logs/stream" ||
+      path === "/notifications/stream" ||
+      path === "/agent/events" ||
+      path === "/events/stream"
+    ) {
+      return fulfilEventStream(route);
+    }
     if (method !== "GET") {
       // Mutations succeed with an empty success envelope.
       return fulfilJson(route, { success: true, data: {} });

--- a/web/src/components/MarkdownEditor.tsx
+++ b/web/src/components/MarkdownEditor.tsx
@@ -182,7 +182,10 @@ export function MarkdownEditor({ value, onChange, onSave, placeholder }: Markdow
             onChangeRef.current(update.state.doc.toString());
           }
         }),
-        EditorView.contentAttributes.of({ 'aria-placeholder': placeholder ?? '' }),
+        EditorView.contentAttributes.of({
+          'aria-label': 'Markdown editor',
+          'aria-placeholder': placeholder ?? '',
+        }),
         EditorView.lineWrapping,
       ],
     });

--- a/web/src/components/Select.tsx
+++ b/web/src/components/Select.tsx
@@ -8,9 +8,10 @@ interface SelectProps {
   onChange: (value: string) => void;
   style?: React.CSSProperties;
   disabled?: boolean;
+  ariaLabel?: string;
 }
 
-export function Select({ value, options, labels, onChange, style, disabled }: SelectProps) {
+export function Select({ value, options, labels, onChange, style, disabled, ariaLabel }: SelectProps) {
   const [open, setOpen] = useState(false);
   const [focusIdx, setFocusIdx] = useState(-1);
   const [menuPos, setMenuPos] = useState<{ top: number; left: number; width: number } | null>(null);
@@ -99,6 +100,7 @@ export function Select({ value, options, labels, onChange, style, disabled }: Se
   }, [open, focusIdx, options, onChange]);
 
   const menuId = `select-menu-${idRef.current}`;
+  const selectedLabel = labels ? labels[options.indexOf(value)] ?? value : value;
 
   return (
     <div ref={ref} className="custom-select" style={style}>
@@ -111,8 +113,9 @@ export function Select({ value, options, labels, onChange, style, disabled }: Se
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={open ? menuId : undefined}
+        aria-label={(ariaLabel ?? selectedLabel) || 'Select option'}
       >
-        <span>{labels ? labels[options.indexOf(value)] ?? value : value}</span>
+        <span>{selectedLabel}</span>
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <path d="M6 9l6 6 6-6" />
         </svg>

--- a/web/src/components/widgets/DashboardGrid.tsx
+++ b/web/src/components/widgets/DashboardGrid.tsx
@@ -863,6 +863,7 @@ function InnerGrid(props: DashboardGridProps & { width: number }) {
       <div className="dashboard-toolbar">
         <select
           className="dashboard-profile-select"
+          aria-label="Dashboard"
           value={selectedDashboard?.id ?? ""}
           onChange={(event) => {
             setSelectedDashboardId(event.target.value);
@@ -900,6 +901,7 @@ function InnerGrid(props: DashboardGridProps & { width: number }) {
             </button>
             <select
               className="dashboard-template-select"
+              aria-label="Create dashboard from template"
               value=""
               disabled={saving}
               onChange={(event) => createFromTemplate(event.target.value)}
@@ -913,6 +915,7 @@ function InnerGrid(props: DashboardGridProps & { width: number }) {
             </select>
             <select
               className="dashboard-template-select"
+              aria-label="Add widget"
               value=""
               disabled={saving || !selectedDashboard}
               onChange={(event) => {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -92,8 +92,8 @@
 
   /* ── Text ── */
   --text: rgba(0, 0, 0, 0.88);
-  --text-secondary: rgba(0, 0, 0, 0.50);
-  --text-tertiary: rgba(0, 0, 0, 0.40);
+  --text-secondary: rgba(0, 0, 0, 0.68);
+  --text-tertiary: rgba(0, 0, 0, 0.58);
   --text-on-accent: #ffffff;
 
   /* ── Accent ── */
@@ -102,11 +102,11 @@
   --accent-text: #0060D3;
 
   /* ── Semantic ── */
-  --green: #34C759;
+  --green: #1F7A3A;
   --green-dim: rgba(52, 199, 89, 0.12);
-  --orange: rgba(0, 0, 0, 0.50);
+  --orange: #8A5200;
   --orange-dim: rgba(0, 0, 0, 0.04);
-  --red: #FF3B30;
+  --red: #C01B1B;
   --red-dim: rgba(255, 59, 48, 0.12);
   --purple: #AF52DE;
   --purple-dim: rgba(175, 82, 222, 0.12);
@@ -1900,7 +1900,7 @@ button.btn-sm {
 
 .step-description {
   font-size: var(--font-md);
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--text-secondary);
   margin-bottom: var(--space-lg);
 }
 
@@ -3614,8 +3614,13 @@ button.btn-lg {
   gap: 4px;
   font-size: 11px;
   color: var(--text-tertiary);
+  background: transparent;
+  border: 0;
   padding: 4px 8px;
   cursor: pointer;
+}
+.cmd-k-hint:hover {
+  background: var(--surface-hover);
 }
 .cmd-k-hint kbd {
   display: inline-block;

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -320,7 +320,11 @@ function FormFields({
           value={form.name}
           onChange={(e) => setForm((current) => ({ ...current, name: e.target.value }))}
         />
-        <select value={form.type} onChange={(e) => applyArchetype(e.target.value)}>
+        <select
+          aria-label="Agent archetype"
+          value={form.type}
+          onChange={(e) => applyArchetype(e.target.value)}
+        >
           <option value="CustomAgent">Custom agent</option>
           {archetypes.map((archetype) => (
             <option key={archetype.type} value={archetype.type}>
@@ -337,6 +341,7 @@ function FormFields({
           />
         )}
         <select
+          aria-label="Agent mode"
           value={form.mode}
           disabled={!showCloneSource}
           onChange={(e) =>
@@ -350,6 +355,7 @@ function FormFields({
           <option value="bot">Bot mode</option>
         </select>
         <select
+          aria-label="Memory policy"
           value={form.memoryPolicy}
           onChange={(e) =>
             setForm((current) => ({

--- a/web/src/pages/Autonomous.tsx
+++ b/web/src/pages/Autonomous.tsx
@@ -900,6 +900,7 @@ export function Autonomous() {
               onClick={toggleAutonomous}
               role="switch"
               aria-checked={autonomousEnabled}
+              aria-label="Autonomous mode"
               tabIndex={0}
               onKeyDown={(e) => {
                 if (e.key === " " || e.key === "Enter") {

--- a/web/src/pages/Memory.tsx
+++ b/web/src/pages/Memory.tsx
@@ -215,14 +215,14 @@ export function Memory() {
               onClick={syncVectorMemory}
               disabled={syncLoading}
               title="Synchronize memory files with vector memory"
-              style={{ padding: "4px 12px", fontSize: "12px", opacity: syncLoading ? 0.5 : 0.7 }}
+              style={{ padding: "4px 12px", fontSize: "12px", opacity: syncLoading ? 0.5 : 1 }}
             >
               {syncLoading ? "Syncing..." : "Sync Vector"}
             </button>
             <button
               onClick={loadSources}
               disabled={loading}
-              style={{ padding: "4px 12px", fontSize: "12px", opacity: 0.7 }}
+              style={{ padding: "4px 12px", fontSize: "12px" }}
             >
               {loading ? "Loading..." : "Refresh"}
             </button>

--- a/web/src/pages/SelfImprove.tsx
+++ b/web/src/pages/SelfImprove.tsx
@@ -37,7 +37,7 @@ function timeAgo(ms: number): string {
 
 const SEVERITY_COLORS: Record<string, string> = {
   critical: "#dc2626",
-  high: "#d97706",
+  high: "#8A5200",
   medium: "#2563eb",
   low: "#6b7280",
 };
@@ -66,7 +66,7 @@ function SeverityBadge({ priority }: { priority: string }) {
 // ── Status badge ──────────────────────────────────────────────────────────────
 
 const STATUS_COLORS: Record<string, string> = {
-  pending: "#d97706",
+  pending: "#8A5200",
   created: "#16a34a",
   dismissed: "#6b7280",
 };
@@ -228,7 +228,9 @@ function ExpandableHelp({
         }}
       >
         <span>📖 {title}</span>
-        <span style={{ fontSize: "11px", opacity: 0.6 }}>{open ? "▲ Collapse" : "▼ Expand"}</span>
+        <span style={{ fontSize: "11px", color: "var(--text-secondary)" }}>
+          {open ? "▲ Collapse" : "▼ Expand"}
+        </span>
       </button>
       {open && (
         <div
@@ -391,6 +393,7 @@ function SettingsPanel({
       <div>
         <label style={labelStyle}>Executor Plugin</label>
         <select
+          aria-label="Executor plugin"
           value={draft.selected_plugin}
           onChange={(e) => setDraft({ ...draft, selected_plugin: e.target.value })}
           style={inputStyle}
@@ -468,6 +471,7 @@ function SettingsPanel({
           <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
             <label style={{ fontSize: "13px", whiteSpace: "nowrap" }}>Run every</label>
             <select
+              aria-label="Schedule interval"
               value={draft.schedule_interval_hours}
               onChange={(e) =>
                 setDraft({ ...draft, schedule_interval_hours: Number(e.target.value) })
@@ -554,9 +558,9 @@ function QuickStats({
             padding: "10px 14px",
             borderRadius: "6px",
             background: "#fef3c711",
-            border: "1px solid #d97706",
+            border: "1px solid #8A5200",
             fontSize: "13px",
-            color: "#d97706",
+            color: "#8A5200",
           }}
         >
           ⚠ No self-improvement history found. Run an analysis to populate these tabs.
@@ -571,7 +575,7 @@ function QuickStats({
       >
         {[
           { label: "Critical", value: critical, color: "#dc2626" },
-          { label: "High", value: high, color: "#d97706" },
+          { label: "High", value: high, color: "#8A5200" },
           { label: "Medium", value: medium, color: "#2563eb" },
           { label: "Pending Tasks", value: pendingTasks, color: "#7c3aed" },
         ].map((s) => (
@@ -595,7 +599,7 @@ function QuickStats({
             borderRadius: "8px",
           }}
         >
-          <div style={{ fontSize: "12px", fontWeight: 600, opacity: 0.6, marginBottom: "4px" }}>
+          <div style={{ fontSize: "12px", fontWeight: 600, color: "var(--text-secondary)", marginBottom: "4px" }}>
             LAST SCAN
           </div>
           <div style={{ fontSize: "13px" }}>
@@ -614,7 +618,7 @@ function QuickStats({
             borderRadius: "8px",
           }}
         >
-          <div style={{ fontSize: "12px", fontWeight: 600, opacity: 0.6, marginBottom: "4px" }}>
+          <div style={{ fontSize: "12px", fontWeight: 600, color: "var(--text-secondary)", marginBottom: "4px" }}>
             TOTAL SCANS
           </div>
           <div style={{ fontSize: "24px", fontWeight: 700 }}>{totalScans}</div>
@@ -705,7 +709,7 @@ function OverviewTab({
         )}
 
         {!hasPlugin && (
-          <span style={{ fontSize: "13px", color: "#d97706" }}>
+          <span style={{ fontSize: "13px", color: "#8A5200" }}>
             ⚠ No plugin selected — configure one in the Settings section below.
           </span>
         )}
@@ -1378,6 +1382,7 @@ function AnalyticsTab({
             <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
               <label style={{ fontSize: "11px", fontWeight: 600, opacity: 0.6 }}>REPOSITORY</label>
               <select
+                aria-label="Repository filter"
                 value={selectedRepo}
                 onChange={(e) => {
                   setSelectedRepo(e.target.value);
@@ -1395,6 +1400,7 @@ function AnalyticsTab({
             <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
               <label style={{ fontSize: "11px", fontWeight: 600, opacity: 0.6 }}>SCAN</label>
               <select
+                aria-label="Scan filter"
                 value={selectedScanId === "all" ? "all" : String(selectedScanId)}
                 onChange={(e) =>
                   setSelectedScanId(e.target.value === "all" ? "all" : Number(e.target.value))

--- a/web/src/pages/Soul.tsx
+++ b/web/src/pages/Soul.tsx
@@ -368,6 +368,7 @@ export function Soul() {
   const [activeTab, setActiveTab] = useState<string>(SOUL_FILES[0]);
   const [content, setContent] = useState('');
   const [savedContent, setSavedContent] = useState('');
+  const [contentFile, setContentFile] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
@@ -386,8 +387,37 @@ export function Soul() {
 
   // Auto-save draft ref
   const autoSaveRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const loadRequestRef = useRef(0);
+  const activeTabRef = useRef(activeTab);
+  const contentRef = useRef(content);
+  const savedContentRef = useRef(savedContent);
+  const contentFileRef = useRef<string | null>(contentFile);
+  const loadingRef = useRef(loading);
+  const savingRef = useRef(saving);
 
-  const dirty = content !== savedContent;
+  activeTabRef.current = activeTab;
+  contentRef.current = content;
+  savedContentRef.current = savedContent;
+  contentFileRef.current = contentFile;
+  loadingRef.current = loading;
+  savingRef.current = saving;
+
+  const dirty = contentFile === activeTab && content !== savedContent;
+  const canSave = dirty && !loading && !saving;
+
+  const setEditorBuffer = useCallback((filename: string | null, nextContent: string, nextSavedContent: string) => {
+    contentFileRef.current = filename;
+    contentRef.current = nextContent;
+    savedContentRef.current = nextSavedContent;
+    setContentFile(filename);
+    setContent(nextContent);
+    setSavedContent(nextSavedContent);
+  }, []);
+
+  const handleContentChange = useCallback((nextContent: string) => {
+    contentRef.current = nextContent;
+    setContent(nextContent);
+  }, []);
 
   const handleViewMode = (mode: ViewMode) => {
     setViewMode(mode);
@@ -410,10 +440,15 @@ export function Soul() {
   }, []);
 
   const loadFile = useCallback(async (filename: string) => {
+    const requestId = ++loadRequestRef.current;
+    loadingRef.current = true;
     setLoading(true);
     setMessage(null);
+    setEditorBuffer(null, '', '');
     try {
       const res = await api.getSoulFile(filename);
+      if (loadRequestRef.current !== requestId) return;
+
       const serverContent = res.data.content;
 
       // Check for a newer draft in localStorage
@@ -428,9 +463,9 @@ export function Soul() {
               variant: "warning",
               confirmText: "Restore",
             });
+            if (loadRequestRef.current !== requestId) return;
             if (restore) {
-              setContent(draft.content);
-              setSavedContent(serverContent);
+              setEditorBuffer(filename, draft.content, serverContent);
               return;
             } else {
               clearDraft(filename);
@@ -443,49 +478,85 @@ export function Soul() {
         // Ignore draft errors
       }
 
-      setContent(serverContent);
-      setSavedContent(serverContent);
+      setEditorBuffer(filename, serverContent, serverContent);
     } catch (err) {
-      setMessage({ type: 'error', text: err instanceof Error ? err.message : String(err) });
+      if (loadRequestRef.current === requestId) {
+        setMessage({ type: 'error', text: err instanceof Error ? err.message : String(err) });
+      }
     } finally {
-      setLoading(false);
+      if (loadRequestRef.current === requestId) {
+        loadingRef.current = false;
+        setLoading(false);
+      }
     }
-  }, [clearDraft]);
+  }, [clearDraft, confirm, setEditorBuffer]);
 
   const saveFile = useCallback(async () => {
+    const filename = activeTabRef.current;
+    const bufferFile = contentFileRef.current;
+    const contentToSave = contentRef.current;
+    const savedContentSnapshot = savedContentRef.current;
+    if (
+      savingRef.current ||
+      loadingRef.current ||
+      bufferFile !== filename ||
+      contentToSave === savedContentSnapshot
+    ) {
+      return;
+    }
+
+    savingRef.current = true;
     setSaving(true);
     setMessage(null);
     try {
-      const res = await api.updateSoulFile(activeTab, content);
-      setSavedContent(content);
-      clearDraft(activeTab);
-      setMessage({ type: 'success', text: res.data.message });
-      toast.success(res.data.message ?? 'File saved successfully');
+      const res = await api.updateSoulFile(filename, contentToSave);
+      clearDraft(filename);
+      if (activeTabRef.current === filename && contentFileRef.current === filename) {
+        savedContentRef.current = contentToSave;
+        setSavedContent(contentToSave);
+        setMessage({ type: 'success', text: res.data.message });
+        toast.success(res.data.message ?? 'File saved successfully');
+      }
     } catch (err) {
-      setMessage({ type: 'error', text: err instanceof Error ? err.message : String(err) });
-      toast.error(`Save failed: ${err instanceof Error ? err.message : String(err)}`);
+      if (activeTabRef.current === filename && contentFileRef.current === filename) {
+        setMessage({ type: 'error', text: err instanceof Error ? err.message : String(err) });
+        toast.error(`Save failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
     } finally {
+      savingRef.current = false;
       setSaving(false);
     }
-  }, [activeTab, content, clearDraft]);
+  }, [clearDraft]);
 
   const handleSaveVersion = useCallback(async (comment: string) => {
+    const filename = activeTabRef.current;
+    const bufferFile = contentFileRef.current;
+    const contentToSave = contentRef.current;
+    if (loadingRef.current || bufferFile !== filename) {
+      setShowSaveVersionDialog(false);
+      return;
+    }
+
     setShowSaveVersionDialog(false);
     setSavingVersion(true);
     setMessage(null);
     try {
-      await api.saveSoulVersion(activeTab, content, comment || undefined);
-      setMessage({ type: 'success', text: 'Version saved' });
+      await api.saveSoulVersion(filename, contentToSave, comment || undefined);
+      if (activeTabRef.current === filename && contentFileRef.current === filename) {
+        setMessage({ type: 'success', text: 'Version saved' });
+      }
     } catch (err) {
-      setMessage({ type: 'error', text: err instanceof Error ? err.message : String(err) });
+      if (activeTabRef.current === filename && contentFileRef.current === filename) {
+        setMessage({ type: 'error', text: err instanceof Error ? err.message : String(err) });
+      }
     } finally {
       setSavingVersion(false);
     }
-  }, [activeTab, content]);
+  }, []);
 
   // Ctrl+S / Cmd+S to save
   useKeyboardShortcuts([
-    { key: 's', ctrl: true, handler: () => { if (dirty && !saving) void saveFile(); } },
+    { key: 's', ctrl: true, handler: () => { if (canSave) void saveFile(); } },
   ]);
 
   // Warn before leaving with unsaved changes
@@ -502,20 +573,32 @@ export function Soul() {
     if (autoSaveRef.current) clearInterval(autoSaveRef.current);
 
     autoSaveRef.current = setInterval(() => {
-      if (dirty) {
-        saveDraft(activeTab, content);
+      const filename = activeTabRef.current;
+      const draftContent = contentRef.current;
+      if (
+        !loadingRef.current &&
+        contentFileRef.current === filename &&
+        draftContent !== savedContentRef.current
+      ) {
+        saveDraft(filename, draftContent);
       }
     }, AUTO_SAVE_INTERVAL_MS);
 
     return () => {
       if (autoSaveRef.current) clearInterval(autoSaveRef.current);
     };
-  }, [dirty, activeTab, content, saveDraft]);
+  }, [saveDraft]);
 
   // Confirm before switching tabs with unsaved changes
   const handleTabSwitch = async (file: string) => {
     if (file === activeTab) return;
     if (dirty && !(await confirm({ title: "Discard changes?", description: "You have unsaved changes.", variant: "warning", confirmText: "Discard" }))) return;
+    loadRequestRef.current += 1;
+    activeTabRef.current = file;
+    loadingRef.current = true;
+    setLoading(true);
+    setMessage(null);
+    setEditorBuffer(null, '', '');
     setActiveTab(file);
     setShowVersionHistory(false);
   };
@@ -527,8 +610,8 @@ export function Soul() {
   const editor = (
     <MarkdownEditor
       value={content}
-      onChange={setContent}
-      onSave={() => { if (dirty && !saving) void saveFile(); }}
+      onChange={handleContentChange}
+      onSave={() => { if (canSave) void saveFile(); }}
       placeholder={`Edit ${activeTab}...`}
     />
   );
@@ -569,7 +652,7 @@ export function Soul() {
 
           <TemplateSelector
             activeFile={activeTab}
-            onLoad={setContent}
+            onLoad={handleContentChange}
             hasUnsavedChanges={dirty}
           />
 
@@ -598,13 +681,13 @@ export function Soul() {
             )}
 
             <div style={{ marginTop: '8px', display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
-              <button onClick={() => void saveFile()} disabled={saving || !dirty} title="Save (Ctrl+S)">
+              <button onClick={() => void saveFile()} disabled={!canSave} title="Save (Ctrl+S)">
                 {saving ? 'Saving...' : 'Save'}
               </button>
 
               <button
                 onClick={() => setShowSaveVersionDialog(true)}
-                disabled={savingVersion}
+                disabled={savingVersion || loading || contentFile !== activeTab}
                 title="Save a named snapshot to version history"
               >
                 {savingVersion ? 'Saving...' : 'Save Version'}
@@ -642,7 +725,7 @@ export function Soul() {
       {showVersionHistory && (
         <VersionHistory
           filename={activeTab}
-          onRestore={(restoredContent) => setContent(restoredContent)}
+          onRestore={handleContentChange}
           onDiff={(versionContent, label) => setDiffState({ versionContent, label })}
           onClose={() => setShowVersionHistory(false)}
         />

--- a/web/src/pages/Tasks.tsx
+++ b/web/src/pages/Tasks.tsx
@@ -574,7 +574,7 @@ export function Tasks() {
             )}
           </div>
         )}
-        <button style={{ padding: '4px 12px', fontSize: '12px', opacity: 0.7 }} onClick={loadTasks}>
+        <button style={{ padding: '4px 12px', fontSize: '12px' }} onClick={loadTasks}>
           Refresh
         </button>
       </div>

--- a/web/src/pages/Tools.tsx
+++ b/web/src/pages/Tools.tsx
@@ -417,7 +417,7 @@ export function Tools() {
             </span>
           )}
           <button
-            style={{ padding: '4px 12px', fontSize: '12px', opacity: 0.7 }}
+            style={{ padding: '4px 12px', fontSize: '12px' }}
             onClick={loadTools}
           >
             Refresh

--- a/web/src/pages/Workflows.tsx
+++ b/web/src/pages/Workflows.tsx
@@ -985,7 +985,7 @@ export function Workflows() {
         </span>
         <div style={{ display: "flex", gap: "8px" }}>
           <button
-            style={{ padding: "4px 12px", fontSize: "12px", opacity: 0.7 }}
+            style={{ padding: "4px 12px", fontSize: "12px" }}
             onClick={loadWorkflows}
           >
             Refresh
@@ -1065,7 +1065,7 @@ export function Workflows() {
         </div>
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: "12px" }}>
           <div>
-            <div style={{ fontWeight: 600, color: "#6ea8fe", marginBottom: "4px" }}>Triggers</div>
+            <div style={{ fontWeight: 600, color: "var(--accent-text)", marginBottom: "4px" }}>Triggers</div>
             <div>
               <strong>Time-based</strong> — cron schedule (e.g. every Monday at 9am)
             </div>
@@ -1077,7 +1077,7 @@ export function Workflows() {
             </div>
           </div>
           <div>
-            <div style={{ fontWeight: 600, color: "#5cb85c", marginBottom: "4px" }}>Actions</div>
+            <div style={{ fontWeight: 600, color: "var(--green)", marginBottom: "4px" }}>Actions</div>
             <div>
               <strong>Send message</strong> — send text to a Telegram chat
             </div>
@@ -1089,7 +1089,7 @@ export function Workflows() {
             </div>
           </div>
           <div>
-            <div style={{ fontWeight: 600, color: "#f0ad4e", marginBottom: "4px" }}>Limits</div>
+            <div style={{ fontWeight: 600, color: "var(--orange)", marginBottom: "4px" }}>Limits</div>
             <div>Max 100 workflows</div>
             <div>Max 10 actions per workflow</div>
             <div>Cron format: minute hour day month weekday</div>


### PR DESCRIPTION
## Что исправлено

Fixes xlabtg/teleton-agent#609.

Soul editor теперь хранит владельца текущего буфера (`contentFile`) отдельно от активной вкладки. При переключении вкладки буфер сразу сбрасывается в безопасное состояние, а текущая in-flight загрузка инвалидируется до старта новой.

Сохранение теперь защищено на всех путях:

- ручной Save / Ctrl+S не выполняет PUT, если идёт загрузка или буфер не принадлежит активной вкладке;
- autosave draft пишет только draft для файла, чей буфер сейчас реально отображается;
- Save Version использует тот же guard, чтобы не сохранить snapshot не того файла;
- устаревшие ответы `loadFile` игнорируются и не могут вернуть старый буфер после переключения.

Дополнительно исправлены CI-падения, найденные после пуша:

- `protobufjs` закреплён на `7.6.4`, чтобы закрыть high advisory `GHSA-wcpc-wj8m-hjx6` в `audit-ci`;
- a11y mock backend теперь отдаёт корректную форму `/api/agents`, `/api/agents/archetypes` и EventSource-эндпоинты, чтобы страницы рендерились без error boundary;
- устранены критичные/serious WCAG 2.1 AA нарушения: добавлены доступные имена для select/switch/CodeMirror, исправлен контраст light theme и отдельных action/status элементов.

## Как воспроизводилось

Новый e2e-тест `e2e/soul.spec.ts` на старой реализации падал: после dirty-редактирования `SOUL.md`, discard-перехода на `STRATEGY.md` и Ctrl+S во время задержанной загрузки mock backend получал `PUT /api/soul/STRATEGY.md` с содержимым старого `SOUL.md`.

После исправления тот же сценарий оставляет `STRATEGY.md` с исходным содержимым и не отправляет cross-file update.

## Проверка

- `git diff --check`
- `npm run audit:ci`
- `npm run build:sdk`
- `npm run lint`
- `npm test`
- `npm run build:web`
- `cd web && npm run test:a11y`
- `npx playwright test e2e/soul.spec.ts`
