### PR TITLE
fix(security): chmod реальных SQLite-файлов при hardening

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T19:39:58.900Z for PR creation at branch issue-611-19360c77b270 for issue https://github.com/xlabtg/teleton-agent/issues/611

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T19:39:58.900Z for PR creation at branch issue-611-19360c77b270 for issue https://github.com/xlabtg/teleton-agent/issues/611

--- a/src/backup/targets.ts
+++ b/src/backup/targets.ts
@@ -24,20 +24,20 @@ export interface BackupTarget {
 }
 
 /** Top-level SQLite databases stored directly under TELETON_ROOT. */
-const SQLITE_FILES = ["memory.db", "deals.db"];
+export const SQLITE_FILES = ["memory.db", "deals.db"] as const;
 
 /**
  * Plain files (non-SQLite) under TELETON_ROOT that hold critical state.
  * wallet.json holds the (encrypted) TON mnemonic; the session/offset files
  * keep the Telegram login alive.
  */
-const PLAIN_FILES = [
+export const PLAIN_FILES = [
   "config.yaml",
   "wallet.json",
   "telegram_session.txt",
   "gramjs_bot_session.txt",
   "telegram-offset.json",
-];
+] as const;
 
 /** Directories copied recursively. */
 const DIRECTORIES = ["workspace"];

--- a/src/workspace/__tests__/harden-permissions.test.ts
+++ b/src/workspace/__tests__/harden-permissions.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import { chmodSync, existsSync, mkdirSync, rmSync, statSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+
+const { tempRoot, tempWorkspace } = vi.hoisted(() => {
+  const { mkdtempSync } = require("fs") as typeof import("fs");
+  const { join } = require("path") as typeof import("path");
+  const { tmpdir } = require("os") as typeof import("os");
+  const root = mkdtempSync(join(tmpdir(), "teleton-harden-test-"));
+  const workspace = join(root, "workspace");
+  return { tempRoot: root, tempWorkspace: workspace };
+});
+
+vi.mock("../paths.js", () => ({
+  TELETON_ROOT: tempRoot,
+  WORKSPACE_ROOT: tempWorkspace,
+  WORKSPACE_PATHS: {
+    SOUL: join(tempWorkspace, "SOUL.md"),
+    MEMORY: join(tempWorkspace, "MEMORY.md"),
+    IDENTITY: join(tempWorkspace, "IDENTITY.md"),
+    USER: join(tempWorkspace, "USER.md"),
+    STRATEGY: join(tempWorkspace, "STRATEGY.md"),
+    SECURITY: join(tempWorkspace, "SECURITY.md"),
+    HEARTBEAT: join(tempWorkspace, "HEARTBEAT.md"),
+    MEMORY_DIR: join(tempWorkspace, "memory"),
+    DOWNLOADS_DIR: join(tempWorkspace, "downloads"),
+    UPLOADS_DIR: join(tempWorkspace, "uploads"),
+    TEMP_DIR: join(tempWorkspace, "temp"),
+    MEMES_DIR: join(tempWorkspace, "memes"),
+    PLUGINS_DIR: join(tempRoot, "plugins"),
+  },
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const { hardenExistingPermissions } = await import("../harden-permissions.js");
+
+function cleanRoot() {
+  if (!existsSync(tempRoot)) {
+    mkdirSync(tempRoot, { recursive: true });
+    return;
+  }
+
+  for (const entry of require("fs").readdirSync(tempRoot) as string[]) {
+    rmSync(join(tempRoot, entry), { recursive: true, force: true });
+  }
+}
+
+function writePermissiveRootFile(name: string): string {
+  const absPath = join(tempRoot, name);
+  mkdirSync(dirname(absPath), { recursive: true });
+  writeFileSync(absPath, "sensitive", { mode: 0o644 });
+  chmodSync(absPath, 0o644);
+  return absPath;
+}
+
+function fileMode(absPath: string): number {
+  return statSync(absPath).mode & 0o777;
+}
+
+describe("hardenExistingPermissions", () => {
+  beforeEach(() => {
+    cleanRoot();
+    mkdirSync(tempWorkspace, { recursive: true });
+  });
+
+  afterAll(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("hardens real root database files, sqlite sidecars, and session artifacts", () => {
+    const sensitiveFiles = [
+      "config.yaml",
+      "wallet.json",
+      "telegram_session.txt",
+      "gramjs_bot_session.txt",
+      "telegram-offset.json",
+      "memory.db",
+      "memory.db-wal",
+      "memory.db-shm",
+      "memory.db-journal",
+      "deals.db",
+      "deals.db-wal",
+      "deals.db-shm",
+      "deals.db-journal",
+    ];
+
+    const paths = sensitiveFiles.map(writePermissiveRootFile);
+    for (const path of paths) {
+      expect(fileMode(path)).toBe(0o644);
+    }
+
+    hardenExistingPermissions();
+
+    for (const path of paths) {
+      expect(fileMode(path)).toBe(0o600);
+    }
+  });
+});

--- a/src/workspace/harden-permissions.ts
+++ b/src/workspace/harden-permissions.ts
@@ -9,22 +9,24 @@ import { chmodSync, existsSync, readdirSync, statSync } from "fs";
 import { join } from "path";
 import { TELETON_ROOT, WORKSPACE_PATHS } from "./paths.js";
 import { createLogger } from "../utils/logger.js";
+import { PLAIN_FILES, SQLITE_FILES } from "../backup/targets.js";
 
 const log = createLogger("Permissions");
 
 const TARGET_MODE = 0o600;
 const TARGET_DIR_MODE = 0o700;
 
+const SQLITE_SIDECAR_SUFFIXES = ["-wal", "-shm", "-journal"] as const;
+
+function sqliteFilesWithSidecars(): string[] {
+  return SQLITE_FILES.flatMap((file) => [
+    file,
+    ...SQLITE_SIDECAR_SUFFIXES.map((suffix) => `${file}${suffix}`),
+  ]);
+}
+
 /** Files in TELETON_ROOT that should be 0o600 */
-const ROOT_FILES = [
-  "config.yaml",
-  "wallet.json",
-  "telegram_session.txt",
-  "telegram-offset.json",
-  "teleton.db",
-  "teleton.db-wal",
-  "teleton.db-shm",
-];
+const ROOT_FILES = [...PLAIN_FILES, ...sqliteFilesWithSidecars()];
 
 /** Directories that should be 0o700 */
 const SECURE_DIRS = ["secrets", "plugins", "tls"];


### PR DESCRIPTION
## Что исправлено

Fixes xlabtg/teleton-agent#611.

- `SQLITE_FILES` и `PLAIN_FILES` в `src/backup/targets.ts` теперь экспортируются как общий источник чувствительных root-файлов.
- `hardenExistingPermissions()` больше не использует несуществующие `teleton.db*`; список строится из `memory.db`, `deals.db` и их SQLite sidecar-файлов `-wal`, `-shm`, `-journal`.
- В hardening включен `gramjs_bot_session.txt`, который уже входит в backup targets.
- Удален временный `.gitkeep` из стартового WIP-коммита.

## Как воспроизводилось

Новый регрессионный тест `src/workspace/__tests__/harden-permissions.test.ts` создает root-файлы с режимом `0644`: `memory.db`, `deals.db`, их `-wal`/`-shm`/`-journal` sidecar-и и session/config артефакты.

До исправления тест падал: после `hardenExistingPermissions()` часть реальных DB/session-файлов оставалась `0644` вместо `0600`, потому что код chmod-ил только `teleton.db*`. После исправления все проверяемые файлы получают `0600`.

## Проверка

- `npm ci`
- `npm test -- src/workspace/__tests__/harden-permissions.test.ts` (до фикса: failed; после фикса: passed)
- `npm test -- src/workspace/__tests__/harden-permissions.test.ts src/backup/__tests__/backup.test.ts`
- `npx prettier --check src/backup/targets.ts src/workspace/harden-permissions.ts src/workspace/__tests__/harden-permissions.test.ts`
- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm test` (238 files, 3716 tests)
