### PR TITLE
fix(integrations): защитить OAuth token exchange от SSRF

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T19:57:06.390Z for PR creation at branch issue-610-ddb0ef2c40de for issue https://github.com/xlabtg/teleton-agent/issues/610

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T19:57:06.390Z for PR creation at branch issue-610-ddb0ef2c40de for issue https://github.com/xlabtg/teleton-agent/issues/610

--- a/src/services/integrations/__tests__/auth.test.ts
+++ b/src/services/integrations/__tests__/auth.test.ts
@@ -35,6 +35,7 @@ describe("IntegrationAuthManager — WORK4-003 regression", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     db.close();
     if (originalEnv !== undefined) {
       process.env.TELETON_INTEGRATIONS_KEY = originalEnv;

--- a/src/services/integrations/__tests__/auth.test.ts
+++ b/src/services/integrations/__tests__/auth.test.ts
@@ -3,6 +3,12 @@ import Database from "better-sqlite3";
 import { IntegrationAuthManager } from "../auth.js";
 import { ensureIntegrationTables } from "../storage.js";
 
+const dnsMocks = vi.hoisted(() => ({
+  lookup: vi.fn(),
+}));
+
+vi.mock("node:dns/promises", () => dnsMocks);
+
 vi.mock("../../../utils/logger.js", () => ({
   createLogger: vi.fn(() => ({
     info: vi.fn(),
@@ -23,6 +29,8 @@ describe("IntegrationAuthManager — WORK4-003 regression", () => {
     db.prepare(
       `INSERT INTO integrations (id, name, type, provider) VALUES ('svc', 'Test', 'api', 'custom-http')`
     ).run();
+    dnsMocks.lookup.mockReset();
+    dnsMocks.lookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
     delete process.env.TELETON_INTEGRATIONS_KEY;
   });
 
@@ -113,5 +121,101 @@ describe("IntegrationAuthManager — WORK4-003 regression", () => {
     const retrieved = manager.getCredential(cred.id);
     expect(retrieved).not.toBeNull();
     expect(retrieved!.credentials.apiKey).toBe("env-secret");
+  });
+
+  it("exchanges OAuth codes through a pinned fetch dispatcher", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "read",
+        }),
+        { headers: { "Content-Type": "application/json" } }
+      )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const manager = new IntegrationAuthManager(db, "a".repeat(64));
+
+    const credential = await manager.exchangeOAuthCode({
+      integrationId: "svc",
+      tokenUrl: "https://oauth.example.com/token",
+      clientId: "client-id",
+      code: "oauth-code",
+      redirectUri: "https://teleton.example.com/oauth/callback",
+    });
+
+    expect(dnsMocks.lookup).toHaveBeenCalledWith("oauth.example.com", {
+      all: true,
+      verbatim: true,
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit & { dispatcher?: unknown }];
+    expect(String(url)).toBe("https://oauth.example.com/token");
+    expect(init.dispatcher).toBeDefined();
+    expect(init.redirect).toBe("manual");
+    expect(init.method).toBe("POST");
+    expect(String(init.body)).toContain("grant_type=authorization_code");
+    expect(credential.credentials).toMatchObject({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+      tokenUrl: "https://oauth.example.com/token",
+    });
+  });
+
+  it("rejects OAuth tokenUrl values targeting metadata IPs before fetch", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ access_token: "access-token" }), {
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const manager = new IntegrationAuthManager(db, "a".repeat(64));
+
+    await expect(
+      manager.exchangeOAuthCode({
+        integrationId: "svc",
+        tokenUrl: "https://169.254.169.254/latest/meta-data/",
+        clientId: "client-id",
+        code: "oauth-code",
+        redirectUri: "https://teleton.example.com/oauth/callback",
+      })
+    ).rejects.toThrow(/private|loopback|metadata|not allowed/i);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    const row = db.prepare("SELECT id FROM integration_credentials").get();
+    expect(row).toBeUndefined();
+  });
+
+  it("rejects OAuth tokenUrl values whose hostname resolves to metadata IPs", async () => {
+    dnsMocks.lookup.mockResolvedValueOnce([{ address: "169.254.169.254", family: 4 }]);
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ access_token: "access-token" }), {
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const manager = new IntegrationAuthManager(db, "a".repeat(64));
+
+    await expect(
+      manager.exchangeOAuthCode({
+        integrationId: "svc",
+        tokenUrl: "https://rebind.example.com/oauth/token",
+        clientId: "client-id",
+        code: "oauth-code",
+        redirectUri: "https://teleton.example.com/oauth/callback",
+      })
+    ).rejects.toThrow(/private|loopback|metadata|not allowed/i);
+
+    expect(dnsMocks.lookup).toHaveBeenCalledWith("rebind.example.com", {
+      all: true,
+      verbatim: true,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    const row = db.prepare("SELECT id FROM integration_credentials").get();
+    expect(row).toBeUndefined();
   });
 });

--- a/src/services/integrations/auth.ts
+++ b/src/services/integrations/auth.ts
@@ -7,9 +7,11 @@ import {
   isIntegrationAuthType,
 } from "./base.js";
 import { ensureIntegrationTables } from "./storage.js";
+import { createPinnedOutboundFetch, validateResolvedOutboundUrl } from "../outbound-url-guard.js";
 import { createLogger } from "../../utils/logger.js";
 
 const log = createLogger("IntegrationAuth");
+const OAUTH_TOKEN_URL_GUARD = { allowedProtocols: ["https:"] as const, label: "OAuth token URL" };
 
 interface CredentialRow {
   id: string;
@@ -61,6 +63,10 @@ const SECRET_KEYS = new Set([
 const MISSING_CREDENTIAL_KEY_ERROR =
   "Integration credential encryption key is required. Set TELETON_INTEGRATIONS_KEY " +
   "or integrations.credential_key before storing or reading integration credentials.";
+
+export async function validateOAuthTokenUrl(raw: string): Promise<void> {
+  await validateResolvedOutboundUrl(raw, OAUTH_TOKEN_URL_GUARD);
+}
 
 function nowSeconds(): number {
   return Math.floor(Date.now() / 1000);
@@ -351,25 +357,30 @@ async function requestOAuthToken(
   expiresIn?: number;
   scope?: string;
 }> {
-  const response = await fetch(tokenUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams(params),
-  });
-  if (!response.ok) {
-    throw new Error(`OAuth token request failed with HTTP ${response.status}`);
+  const target = await createPinnedOutboundFetch(tokenUrl, OAUTH_TOKEN_URL_GUARD);
+  try {
+    const response = await target.fetch(target.url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(params),
+    });
+    if (!response.ok) {
+      throw new Error(`OAuth token request failed with HTTP ${response.status}`);
+    }
+    const json = (await response.json()) as OAuthTokenResponse;
+    if (typeof json.access_token !== "string" || json.access_token.length === 0) {
+      throw new Error("OAuth token response did not include access_token");
+    }
+    return {
+      accessToken: json.access_token,
+      refreshToken: typeof json.refresh_token === "string" ? json.refresh_token : undefined,
+      tokenType: typeof json.token_type === "string" ? json.token_type : "Bearer",
+      expiresIn: typeof json.expires_in === "number" ? json.expires_in : undefined,
+      scope: typeof json.scope === "string" ? json.scope : undefined,
+    };
+  } finally {
+    await target.close();
   }
-  const json = (await response.json()) as OAuthTokenResponse;
-  if (typeof json.access_token !== "string" || json.access_token.length === 0) {
-    throw new Error("OAuth token response did not include access_token");
-  }
-  return {
-    accessToken: json.access_token,
-    refreshToken: typeof json.refresh_token === "string" ? json.refresh_token : undefined,
-    tokenType: typeof json.token_type === "string" ? json.token_type : "Bearer",
-    expiresIn: typeof json.expires_in === "number" ? json.expires_in : undefined,
-    scope: typeof json.scope === "string" ? json.scope : undefined,
-  };
 }
 
 function readString(credentials: Record<string, unknown>, key: string): string {

--- a/src/webui/__tests__/integrations-routes.test.ts
+++ b/src/webui/__tests__/integrations-routes.test.ts
@@ -4,6 +4,12 @@ import { Hono } from "hono";
 import { createIntegrationsRoutes } from "../routes/integrations.js";
 import type { WebUIServerDeps } from "../types.js";
 
+const dnsMocks = vi.hoisted(() => ({
+  lookup: vi.fn(),
+}));
+
+vi.mock("node:dns/promises", () => dnsMocks);
+
 vi.mock("../../utils/logger.js", () => ({
   createLogger: vi.fn(() => ({
     info: vi.fn(),
@@ -42,9 +48,12 @@ describe("Integrations routes", () => {
   beforeEach(() => {
     db = new Database(":memory:");
     app = createApp(db);
+    dnsMocks.lookup.mockReset();
+    dnsMocks.lookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     db.close();
   });
 
@@ -192,5 +201,82 @@ describe("Integrations routes", () => {
     expect(url.searchParams.get("response_type")).toBe("code");
     expect(url.searchParams.get("client_id")).toBe("client-123");
     expect(url.searchParams.get("scope")).toBe("read");
+  });
+
+  it("rejects OAuth token exchange requests targeting metadata IPs before fetch", async () => {
+    app = createApp(db, "route-test-master-key");
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ access_token: "access-token" }), {
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await app.request("/api/integrations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "notion-main",
+        name: "Notion Main",
+        type: "oauth",
+        provider: "notion",
+        config: { baseUrl: "https://api.notion.com/v1" },
+      }),
+    });
+
+    const res = await app.request("/api/integrations/notion-main/oauth/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tokenUrl: "https://169.254.169.254/latest/meta-data/",
+        clientId: "client-123",
+        code: "oauth-code",
+        redirectUri: "https://teleton.example.com/oauth/callback",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/private|loopback|metadata|not allowed/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects OAuth token exchange requests when tokenUrl resolves to metadata IPs", async () => {
+    app = createApp(db, "route-test-master-key");
+    dnsMocks.lookup.mockResolvedValueOnce([{ address: "169.254.169.254", family: 4 }]);
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ access_token: "access-token" }), {
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await app.request("/api/integrations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: "notion-main",
+        name: "Notion Main",
+        type: "oauth",
+        provider: "notion",
+        config: { baseUrl: "https://api.notion.com/v1" },
+      }),
+    });
+
+    const res = await app.request("/api/integrations/notion-main/oauth/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tokenUrl: "https://rebind.example.com/oauth/token",
+        clientId: "client-123",
+        code: "oauth-code",
+        redirectUri: "https://teleton.example.com/oauth/callback",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/private|loopback|metadata|not allowed/i);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/webui/routes/integrations.ts
+++ b/src/webui/routes/integrations.ts
@@ -8,6 +8,7 @@ import {
   type IntegrationConfig,
   isIntegrationAuthType,
   isIntegrationType,
+  validateOAuthTokenUrl,
 } from "../../services/integrations/index.js";
 import { getErrorMessage } from "../../utils/errors.js";
 
@@ -242,6 +243,14 @@ export function createIntegrationsRoutes(deps: WebUIServerDeps): Hono {
       if (!code) return c.json<APIResponse>({ success: false, error: "code is required" }, 400);
       if (!redirectUri) {
         return c.json<APIResponse>({ success: false, error: "redirectUri is required" }, 400);
+      }
+      try {
+        await validateOAuthTokenUrl(tokenUrl);
+      } catch (error) {
+        return c.json<APIResponse>(
+          { success: false, error: `tokenUrl is not allowed: ${getErrorMessage(error)}` },
+          400
+        );
       }
       const credential = await registry.auth.exchangeOAuthCode({
         integrationId: c.req.param("id"),


### PR DESCRIPTION
## Что изменено

Fixes xlabtg/teleton-agent#610

- OAuth `tokenUrl` теперь проходит общий `outbound-url-guard`: разрешён только `https:`, блокируются loopback/private/link-local/metadata IP literals и hostnames из denylist.
- `requestOAuthToken` использует `createPinnedOutboundFetch`, поэтому hostname резолвится перед запросом, все resolved адреса проверяются, а сам `fetch` идёт через pinned `undici.Agent` с `redirect: manual`.
- WebUI/Management route `POST /api/integrations/:id/oauth/token` выполняет DNS-aware validation до exchange и возвращает `400` для небезопасного пользовательского `tokenUrl`.

## Как воспроизвести исходную проблему

1. Вызвать `POST /api/integrations/<id>/oauth/token` с `tokenUrl` вроде `https://169.254.169.254/latest/meta-data/` или hostname, который резолвится в `169.254.169.254`.
2. До исправления route возвращал `201`, `IntegrationAuthManager.exchangeOAuthCode` вызывал `fetch(tokenUrl, ...)`, и credential сохранялся с небезопасным `tokenUrl`.
3. Новые regression tests фиксируют, что такие URL отклоняются до outbound `fetch` и credentials не создаются.

## Тесты

- `npx vitest run src/services/integrations/__tests__/auth.test.ts src/webui/__tests__/integrations-routes.test.ts`
- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run format:check`
- `npm run build:backend`
