### PR TITLE
fix(security): закрыть права на workspace-директории

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T20:21:42.995Z for PR creation at branch issue-612-4f4d1355f4c3 for issue https://github.com/xlabtg/teleton-agent/issues/612

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T20:21:42.995Z for PR creation at branch issue-612-4f4d1355f4c3 for issue https://github.com/xlabtg/teleton-agent/issues/612

--- a/src/workspace/__tests__/harden-permissions.test.ts
+++ b/src/workspace/__tests__/harden-permissions.test.ts
@@ -61,6 +61,12 @@ function writePermissiveRootFile(name: string): string {
   return absPath;
 }
 
+function createPermissiveDirectory(absPath: string): string {
+  mkdirSync(absPath, { recursive: true });
+  chmodSync(absPath, 0o755);
+  return absPath;
+}
+
 function fileMode(absPath: string): number {
   return statSync(absPath).mode & 0o777;
 }
@@ -101,6 +107,32 @@ describe("hardenExistingPermissions", () => {
 
     for (const path of paths) {
       expect(fileMode(path)).toBe(0o600);
+    }
+  });
+
+  it("hardens the teleton root, workspace root, and workspace directory tree", () => {
+    const dirs = [
+      tempRoot,
+      tempWorkspace,
+      join(tempWorkspace, "memory"),
+      join(tempWorkspace, "memory", "daily"),
+      join(tempWorkspace, "downloads"),
+      join(tempWorkspace, "downloads", "nested"),
+      join(tempWorkspace, "uploads"),
+      join(tempWorkspace, "temp"),
+      join(tempWorkspace, "memes"),
+      join(tempRoot, "plugins"),
+      join(tempRoot, "plugins", "example-plugin"),
+    ].map(createPermissiveDirectory);
+
+    for (const dir of dirs) {
+      expect(fileMode(dir)).toBe(0o755);
+    }
+
+    hardenExistingPermissions();
+
+    for (const dir of dirs) {
+      expect(fileMode(dir)).toBe(0o700);
     }
   });
 });

--- a/src/workspace/__tests__/manager.test.ts
+++ b/src/workspace/__tests__/manager.test.ts
@@ -71,6 +71,10 @@ function cleanWorkspace() {
   }
 }
 
+function dirMode(absPath: string): number {
+  return statSync(absPath).mode & 0o777;
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("ensureWorkspace", () => {
@@ -103,6 +107,29 @@ describe("ensureWorkspace", () => {
     expect(existsSync(ws.uploadsDir)).toBe(true);
     expect(existsSync(ws.tempDir)).toBe(true);
     expect(existsSync(ws.memesDir)).toBe(true);
+  });
+
+  it("creates the teleton root, workspace, and workspace subdirectories with 0o700", async () => {
+    rmSync(tempRoot, { recursive: true, force: true });
+    const previousUmask = process.umask(0o022);
+
+    try {
+      const ws = await ensureWorkspace({ silent: true });
+
+      for (const dir of [
+        tempRoot,
+        tempWorkspace,
+        ws.memoryDir,
+        ws.downloadsDir,
+        ws.uploadsDir,
+        ws.tempDir,
+        ws.memesDir,
+      ]) {
+        expect(dirMode(dir)).toBe(0o700);
+      }
+    } finally {
+      process.umask(previousUmask);
+    }
   });
 
   it("returns a Workspace object with the expected root fields", async () => {

--- a/src/workspace/harden-permissions.ts
+++ b/src/workspace/harden-permissions.ts
@@ -7,7 +7,7 @@
 
 import { chmodSync, existsSync, readdirSync, statSync } from "fs";
 import { join } from "path";
-import { TELETON_ROOT, WORKSPACE_PATHS } from "./paths.js";
+import { TELETON_ROOT, WORKSPACE_ROOT, WORKSPACE_PATHS } from "./paths.js";
 import { createLogger } from "../utils/logger.js";
 import { PLAIN_FILES, SQLITE_FILES } from "../backup/targets.js";
 
@@ -39,12 +39,16 @@ const SECURE_DIRS = ["secrets", "plugins", "tls"];
 export function hardenExistingPermissions(): void {
   let hardened = 0;
 
-  // 1. Root-level sensitive files
+  // 1. Root and workspace directory modes
+  hardened += hardenDirectoryMode(TELETON_ROOT);
+  hardened += hardenDirectoryTreeModes(WORKSPACE_ROOT);
+
+  // 2. Root-level sensitive files
   for (const file of ROOT_FILES) {
     hardened += hardenFile(join(TELETON_ROOT, file));
   }
 
-  // 2. Workspace files (MEMORY.md, IDENTITY.md, etc.)
+  // 3. Workspace files (MEMORY.md, IDENTITY.md, etc.)
   for (const path of [
     WORKSPACE_PATHS.MEMORY,
     WORKSPACE_PATHS.IDENTITY,
@@ -57,34 +61,56 @@ export function hardenExistingPermissions(): void {
     hardened += hardenFile(path);
   }
 
-  // 3. Memory directory (session files, daily logs)
+  // 4. Memory directory (session files, daily logs)
   hardened += hardenDirectory(WORKSPACE_PATHS.MEMORY_DIR, TARGET_MODE);
 
-  // 4. Downloads directory
+  // 5. Downloads directory
   hardened += hardenDirectory(WORKSPACE_PATHS.DOWNLOADS_DIR, TARGET_MODE);
 
-  // 5. Secure directories themselves
+  // 6. Secure directory trees
   for (const dir of SECURE_DIRS) {
-    const dirPath = join(TELETON_ROOT, dir);
-    if (existsSync(dirPath)) {
-      try {
-        const stat = statSync(dirPath);
-        if ((stat.mode & 0o777) !== TARGET_DIR_MODE) {
-          chmodSync(dirPath, TARGET_DIR_MODE);
-          hardened++;
-        }
-      } catch {
-        // Skip if inaccessible
-      }
-    }
+    hardened += hardenDirectoryTreeModes(join(TELETON_ROOT, dir));
   }
 
-  // 6. Plugin files
+  // 7. Plugin files
   hardened += hardenDirectory(WORKSPACE_PATHS.PLUGINS_DIR, TARGET_MODE);
 
   if (hardened > 0) {
-    log.info(`Hardened permissions on ${hardened} existing file(s)`);
+    log.info(`Hardened permissions on ${hardened} existing path(s)`);
   }
+}
+
+function hardenDirectoryMode(dirPath: string): number {
+  if (!existsSync(dirPath)) return 0;
+  try {
+    const stat = statSync(dirPath);
+    if (!stat.isDirectory()) return 0;
+    if ((stat.mode & 0o777) !== TARGET_DIR_MODE) {
+      chmodSync(dirPath, TARGET_DIR_MODE);
+      return 1;
+    }
+  } catch {
+    // Skip directories we can't stat/chmod (e.g., owned by another user)
+  }
+  return 0;
+}
+
+function hardenDirectoryTreeModes(dirPath: string): number {
+  if (!existsSync(dirPath)) return 0;
+  let count = hardenDirectoryMode(dirPath);
+
+  try {
+    const entries = readdirSync(dirPath, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        count += hardenDirectoryTreeModes(join(dirPath, entry.name));
+      }
+    }
+  } catch {
+    // Skip inaccessible directories
+  }
+
+  return count;
 }
 
 function hardenFile(filePath: string): number {

--- a/src/workspace/manager.ts
+++ b/src/workspace/manager.ts
@@ -1,12 +1,13 @@
 // src/workspace/manager.ts
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { TELETON_ROOT, WORKSPACE_ROOT, WORKSPACE_PATHS } from "./paths.js";
 import { createLogger } from "../utils/logger.js";
 
 const log = createLogger("Workspace");
+const PRIVATE_DIR_MODE = 0o700;
 
 // Resolve package root by walking up from current file until we find package.json
 function findPackageRoot(): string {
@@ -18,6 +19,13 @@ function findPackageRoot(): string {
   return process.cwd();
 }
 const TEMPLATES_DIR = join(findPackageRoot(), "src", "templates");
+
+function ensurePrivateDirectory(dirPath: string): boolean {
+  const created = !existsSync(dirPath);
+  mkdirSync(dirPath, { recursive: true, mode: PRIVATE_DIR_MODE });
+  chmodSync(dirPath, PRIVATE_DIR_MODE);
+  return created;
+}
 
 export interface WorkspaceConfig {
   workspaceDir?: string;
@@ -55,14 +63,12 @@ export async function ensureWorkspace(config?: WorkspaceConfig): Promise<Workspa
   const silent = config?.silent ?? false;
 
   // Create base teleton directory
-  if (!existsSync(TELETON_ROOT)) {
-    mkdirSync(TELETON_ROOT, { recursive: true });
+  if (ensurePrivateDirectory(TELETON_ROOT)) {
     if (!silent) log.info(`Created Teleton root at ${TELETON_ROOT}`);
   }
 
   // Create workspace directory
-  if (!existsSync(WORKSPACE_ROOT)) {
-    mkdirSync(WORKSPACE_ROOT, { recursive: true });
+  if (ensurePrivateDirectory(WORKSPACE_ROOT)) {
     if (!silent) log.info(`Created workspace at ${WORKSPACE_ROOT}`);
   }
 
@@ -76,9 +82,7 @@ export async function ensureWorkspace(config?: WorkspaceConfig): Promise<Workspa
   ];
 
   for (const dir of directories) {
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
-    }
+    ensurePrivateDirectory(dir);
   }
 
   // Define file paths


### PR DESCRIPTION
## Описание

Закрывает `TELETON_ROOT`, `WORKSPACE_ROOT` и стандартные workspace-директории от group/other доступа.

- `ensureWorkspace` теперь создаёт `TELETON_ROOT`, `WORKSPACE_ROOT`, `memory`, `downloads`, `uploads`, `temp` и `memes` с `mode: 0o700` и сразу делает `chmod(0o700)`, чтобы результат не зависел от `umask`.
- `hardenExistingPermissions` теперь ретроактивно приводит `TELETON_ROOT`, весь workspace directory tree и secure directory trees (`secrets`, `plugins`, `tls`) к `0o700`.
- Существующее ужесточение sensitive/root/workspace/plugin файлов до `0o600` сохранено.
- Временный `.gitkeep`, созданный только для открытия PR, удалён.

## Тип изменения

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling change
- [ ] Breaking change (fix or feature that changes an existing public contract)

## Воспроизведение и тесты

До фикса новые регрессионные тесты падали с `0755` (`493`) вместо `0700` (`448`) для workspace/root директорий при `umask 022`.

Добавлены тесты:

- `src/workspace/__tests__/manager.test.ts`: проверяет, что свежее создание root/workspace/subdirectories даёт `0o700`.
- `src/workspace/__tests__/harden-permissions.test.ts`: проверяет, что hardening исправляет уже существующие permissive директории и вложенные workspace/plugin директории до `0o700`.

## Проверки

- [x] `npm run build:sdk`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test:coverage`
- [x] `npm run knip`
- [x] `npm run circular`
- [x] `npm run generate:openapi` + проверка отсутствия diff в `docs/api-reference`
- [x] `npm run lint:openapi`
- [x] `npm run audit:ci`
- [x] `npm run build:backend`
- [x] `cd web && npm run check:i18n`
- [x] `cd web && npm run build`
- [x] `node dist/cli/index.js --help`

## Скриншоты или логи

UI не менялся. Итоговый локальный coverage run завершился успешно:

```text
Coverage summary:
Statements : 50.99%
Branches   : 43.37%
Functions  : 57.91%
Lines      : 51.95%
```

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] Tests were added or updated for behavior changes, or I explained why tests are not needed
- [x] Documentation was updated for user-facing or contributor-facing changes, or is not needed
- [x] CHANGELOG entry or release note is included when appropriate, or is not needed
- [x] Security, privacy, and migration implications were considered

## Related Issues

Fixes xlabtg/teleton-agent#612
