### PR TITLE
fix(webui): маскировать секреты MTProto proxy

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T20:46:40.241Z for PR creation at branch issue-613-59d62a0e64c1 for issue https://github.com/xlabtg/teleton-agent/issues/613

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T20:46:40.241Z for PR creation at branch issue-613-59d62a0e64c1 for issue https://github.com/xlabtg/teleton-agent/issues/613

--- a/src/webui/__tests__/mtproto-routes.test.ts
+++ b/src/webui/__tests__/mtproto-routes.test.ts
@@ -92,6 +92,89 @@ describe("MTProto routes", () => {
     ]);
   });
 
+  it("masks proxy secrets in config reads", async () => {
+    const app = buildApp({
+      mtproto: {
+        enabled: true,
+        proxies,
+        bot_api_proxy: "http://proxy-user:proxy-password@localhost:8080",
+      },
+    });
+
+    const res = await app.request("/mtproto");
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.enabled).toBe(true);
+    expect(json.data.bot_api_proxy).toContain("****:****@localhost:8080");
+    expect(json.data.bot_api_proxy).not.toContain("proxy-user");
+    expect(json.data.bot_api_proxy).not.toContain("proxy-password");
+    expect(json.data.proxies).toHaveLength(2);
+    expect(json.data.proxies[0]).toMatchObject({
+      server: "proxy1.example.com",
+      port: 443,
+    });
+    expect(json.data.proxies[0].secret).not.toBe(proxies[0].secret);
+    expect(json.data.proxies[0].secret).toMatch(/\*+aaaa$/);
+    expect(JSON.stringify(json)).not.toContain(proxies[0].secret);
+    expect(JSON.stringify(json)).not.toContain(proxies[1].secret);
+  });
+
+  it("preserves stored proxy secrets when saving an unchanged masked config response", async () => {
+    const config = {
+      telegram: { api_id: 12345, api_hash: "hash" },
+      mtproto: { enabled: true, proxies },
+    };
+    const app = buildApp(config);
+
+    const configRes = await app.request("/mtproto");
+    const configJson = await configRes.json();
+    const maskedProxies = configJson.data.proxies;
+
+    expect(maskedProxies[0].secret).not.toBe(proxies[0].secret);
+
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(
+      "agent:\n" +
+        "  provider: openai\n" +
+        "  model: gpt-4o-mini\n" +
+        "  api_key: sk-testkey123456\n" +
+        "telegram:\n" +
+        "  api_id: 12345\n" +
+        "  api_hash: hash\n" +
+        "  phone: '+1234567890'\n" +
+        "mtproto:\n" +
+        "  enabled: true\n" +
+        "  proxies:\n" +
+        "    - server: proxy1.example.com\n" +
+        "      port: 443\n" +
+        `      secret: ${proxies[0].secret}\n` +
+        "    - server: proxy2.example.com\n" +
+        "      port: 8443\n" +
+        `      secret: ${proxies[1].secret}\n`
+    );
+
+    const saveRes = await app.request("/mtproto/proxies", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ proxies: maskedProxies }),
+    });
+    const saveJson = await saveRes.json();
+
+    expect(saveRes.status).toBe(200);
+    expect(saveJson.success).toBe(true);
+    expect(JSON.stringify(saveJson)).not.toContain(proxies[0].secret);
+    expect(JSON.stringify(saveJson)).not.toContain(proxies[1].secret);
+    expect(config.mtproto.proxies).toEqual(proxies);
+
+    const writtenYaml = mockWriteFileSync.mock.calls.at(-1)?.[1] as string;
+    expect(writtenYaml).toContain(`secret: ${proxies[0].secret}`);
+    expect(writtenYaml).toContain(`secret: ${proxies[1].secret}`);
+    expect(writtenYaml).not.toContain(maskedProxies[0].secret);
+    expect(writtenYaml).not.toContain(maskedProxies[1].secret);
+  });
+
   it("returns per-proxy availability and latency without exposing proxy secrets", async () => {
     const app = buildApp({
       telegram: { api_id: 12345, api_hash: "hash" },
@@ -210,7 +293,14 @@ describe("MTProto routes", () => {
     expect(res.status).toBe(200);
     expect(json.success).toBe(true);
     expect(json.data.proxies).toEqual([
+      { server: "proxy.example.com", port: 443, secret: expect.stringMatching(/\*+6f6d$/) },
+    ]);
+    expect(JSON.stringify(json)).not.toContain(tlsSecret);
+    expect(config.mtproto.proxies).toEqual([
       { server: "proxy.example.com", port: 443, secret: tlsSecret },
     ]);
+
+    const writtenYaml = mockWriteFileSync.mock.calls.at(-1)?.[1] as string;
+    expect(writtenYaml).toContain(`secret: ${tlsSecret}`);
   });
 });

--- a/src/webui/routes/mtproto.ts
+++ b/src/webui/routes/mtproto.ts
@@ -11,8 +11,98 @@ import {
 import { getMtprotoProxySecretValidationError } from "../../telegram/mtproto-proxy.js";
 import { TELETON_ROOT } from "../../workspace/paths.js";
 
+type MtprotoConfigLike = Record<string, unknown> & {
+  proxies?: unknown;
+  bot_api_proxy?: unknown;
+};
+
 function unique(values: Array<string | undefined>): string[] {
   return [...new Set(values.filter((value): value is string => !!value))];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function maskSecretValue(secret: string): string {
+  if (secret.length <= 4) return "****";
+  const visible = secret.slice(-4);
+  const maskedLength = Math.max(secret.length - visible.length, 4);
+  return `${"*".repeat(maskedLength)}${visible}`;
+}
+
+function maskProxyUrlCredentials(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+
+  try {
+    const url = new URL(value);
+    if (!url.username && !url.password) return value;
+    if (url.username) url.username = "****";
+    if (url.password) url.password = "****";
+    return url.toString();
+  } catch {
+    return value;
+  }
+}
+
+function maskMtprotoProxy(proxy: unknown): unknown {
+  if (!isRecord(proxy)) return proxy;
+
+  return {
+    ...proxy,
+    ...(typeof proxy.secret === "string" && proxy.secret.length > 0
+      ? { secret: maskSecretValue(proxy.secret) }
+      : {}),
+  };
+}
+
+function maskMtprotoConfig(mtproto: unknown): MtprotoConfigLike {
+  const config = isRecord(mtproto) ? mtproto : { enabled: false, proxies: [] };
+  const proxies = Array.isArray(config.proxies) ? config.proxies.map(maskMtprotoProxy) : [];
+
+  return {
+    ...config,
+    proxies,
+    ...(typeof config.bot_api_proxy === "string"
+      ? { bot_api_proxy: maskProxyUrlCredentials(config.bot_api_proxy) }
+      : {}),
+  };
+}
+
+function getMtprotoProxies(config: Record<string, unknown>): MtprotoProxyEntry[] {
+  const mtproto = config.mtproto;
+  if (!isRecord(mtproto) || !Array.isArray(mtproto.proxies)) {
+    return [];
+  }
+  return mtproto.proxies as MtprotoProxyEntry[];
+}
+
+function findOriginalProxy(
+  proxy: MtprotoProxyEntry,
+  index: number,
+  existingProxies: MtprotoProxyEntry[]
+): MtprotoProxyEntry | undefined {
+  const indexed = existingProxies[index];
+  if (indexed && proxy.secret === maskSecretValue(indexed.secret)) {
+    return indexed;
+  }
+
+  return existingProxies.find(
+    (existing) =>
+      existing.server === proxy.server &&
+      existing.port === proxy.port &&
+      proxy.secret === maskSecretValue(existing.secret)
+  );
+}
+
+function restoreMaskedProxySecrets(
+  proxies: MtprotoProxyEntry[],
+  existingProxies: MtprotoProxyEntry[]
+): MtprotoProxyEntry[] {
+  return proxies.map((proxy, index) => {
+    const original = findOriginalProxy(proxy, index, existingProxies);
+    return original ? { ...proxy, secret: original.secret } : proxy;
+  });
 }
 
 function readSessionCandidate(path: string): string | undefined {
@@ -79,7 +169,7 @@ export function createMtprotoRoutes(deps: WebUIServerDeps) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- runtime config is dynamic
     const config = deps.agent.getConfig() as Record<string, any>;
     const mtproto = config.mtproto ?? { enabled: false, proxies: [] };
-    return c.json({ success: true, data: mtproto } as APIResponse);
+    return c.json({ success: true, data: maskMtprotoConfig(mtproto) } as APIResponse);
   });
 
   // GET /api/mtproto/status — runtime connection status
@@ -155,7 +245,12 @@ export function createMtprotoRoutes(deps: WebUIServerDeps) {
   app.put("/proxies", async (c) => {
     try {
       const body = await c.req.json<{ proxies: MtprotoProxyEntry[] }>();
-      const proxies = body.proxies ?? [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- runtime config is dynamic
+      const runtimeConfig = deps.agent.getConfig() as Record<string, any>;
+      const proxies = restoreMaskedProxySecrets(
+        body.proxies ?? [],
+        getMtprotoProxies(runtimeConfig)
+      );
 
       // Validate entries
       for (let i = 0; i < proxies.length; i++) {
@@ -194,11 +289,9 @@ export function createMtprotoRoutes(deps: WebUIServerDeps) {
       setNestedValue(raw, "mtproto.proxies", proxies);
       writeRawConfig(raw, deps.configPath);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- runtime config is dynamic
-      const runtimeConfig = deps.agent.getConfig() as Record<string, any>;
       setNestedValue(runtimeConfig, "mtproto.proxies", proxies);
 
-      return c.json({ success: true, data: { proxies } } as APIResponse);
+      return c.json({ success: true, data: maskMtprotoConfig({ proxies }) } as APIResponse);
     } catch (err) {
       return c.json(
         { success: false, error: err instanceof Error ? err.message : String(err) } as APIResponse,


### PR DESCRIPTION
## Что сделано

- Добавлено маскирование MTProto config перед возвратом из `GET /api/mtproto`.
- Маскируются `proxies[].secret` и credentials в `bot_api_proxy` URL.
- `PUT /api/mtproto/proxies` распознает неизмененные masked secrets и сохраняет реальные значения из текущей runtime config, поэтому round-trip `GET -> PUT` не записывает маску в config.
- Ответ `PUT /api/mtproto/proxies` тоже не возвращает raw secrets.
- Удален служебный root `.gitkeep` из initial PR commit.

## Как воспроизвести

1. Настроить MTProto proxy с `secret`.
2. Выполнить `GET /api/mtproto`.
3. До исправления `data.proxies[].secret` возвращался в plaintext; после исправления возвращается masked placeholder с сохранением последних 4 символов.

## Тесты

- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm test -- src/webui/__tests__/mtproto-routes.test.ts`
- `npm test` (238 files, 3725 tests passed)

Fixes xlabtg/teleton-agent#613