### PR TITLE
fix(memory): не кэшировать пустые embeddings в embedQuery

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T21:05:14.077Z for PR creation at branch issue-615-036f68c3e09d for issue https://github.com/xlabtg/teleton-agent/issues/615

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T21:05:14.077Z for PR creation at branch issue-615-036f68c3e09d for issue https://github.com/xlabtg/teleton-agent/issues/615

--- a/src/memory/embeddings/__tests__/cached.test.ts
+++ b/src/memory/embeddings/__tests__/cached.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Database from "better-sqlite3";
+import { getCache, initCache, resetCacheForTests } from "../../../services/cache.js";
+import { ensureSchema } from "../../schema.js";
+import { CachedEmbeddingProvider } from "../cached.js";
+import type { EmbeddingProvider } from "../provider.js";
+import { deserializeEmbedding, hashText, serializeEmbedding } from "../utils.js";
+
+vi.mock("../../../utils/logger.js", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+describe("CachedEmbeddingProvider", () => {
+  let db: InstanceType<typeof Database>;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    ensureSchema(db);
+    initCache({
+      enabled: true,
+      max_entries: 10,
+      ttl: {
+        tools_ms: 300_000,
+        prompts_ms: 60_000,
+        embeddings_ms: 1_800_000,
+        api_responses_ms: 300_000,
+      },
+    });
+  });
+
+  afterEach(() => {
+    db.close();
+    resetCacheForTests();
+  });
+
+  it("does not cache empty embedQuery results from a transient provider failure", async () => {
+    const text = "transient provider failure";
+    const recoveredEmbedding = [0.25, 0.5, 0.75];
+    const embedQuery = vi
+      .fn<(value: string) => Promise<number[]>>()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(recoveredEmbedding);
+    const inner: EmbeddingProvider = {
+      id: "test-provider",
+      model: "test-model",
+      dimensions: recoveredEmbedding.length,
+      embedQuery,
+      embedBatch: vi.fn(async (texts: string[]) => texts.map(() => recoveredEmbedding)),
+    };
+    const provider = new CachedEmbeddingProvider(inner, db);
+
+    await expect(provider.embedQuery(text)).resolves.toEqual([]);
+
+    const count = db.prepare("SELECT COUNT(*) as count FROM embedding_cache").get() as {
+      count: number;
+    };
+    expect(count.count).toBe(0);
+
+    const resourceCache = getCache();
+    expect(resourceCache).not.toBeNull();
+    const key = resourceCache!.makeKey("embeddings", hashText(text), {
+      provider: inner.id,
+      model: inner.model,
+    });
+    expect(resourceCache!.peekByKey(key)).toBeUndefined();
+
+    await expect(provider.embedQuery(text)).resolves.toEqual(recoveredEmbedding);
+    expect(embedQuery).toHaveBeenCalledTimes(2);
+
+    const persisted = db.prepare("SELECT COUNT(*) as count FROM embedding_cache").get() as {
+      count: number;
+    };
+    expect(persisted.count).toBe(1);
+  });
+
+  it("treats existing empty embedQuery cache entries as misses", async () => {
+    const text = "previously poisoned embedding";
+    const recoveredEmbedding = [0.1, 0.2, 0.3];
+    const inner: EmbeddingProvider = {
+      id: "test-provider",
+      model: "test-model",
+      dimensions: recoveredEmbedding.length,
+      embedQuery: vi.fn().mockResolvedValue(recoveredEmbedding),
+      embedBatch: vi.fn(async (texts: string[]) => texts.map(() => recoveredEmbedding)),
+    };
+    const hash = hashText(text);
+    const cacheConfig = { provider: inner.id, model: inner.model };
+
+    db.prepare(
+      `INSERT INTO embedding_cache (hash, model, provider, embedding, dims)
+       VALUES (?, ?, ?, ?, ?)`
+    ).run(hash, inner.model, inner.id, serializeEmbedding([]), inner.dimensions);
+
+    const resourceCache = getCache();
+    expect(resourceCache).not.toBeNull();
+    const key = resourceCache!.set("embeddings", hash, cacheConfig, []);
+
+    const provider = new CachedEmbeddingProvider(inner, db);
+
+    await expect(provider.embedQuery(text)).resolves.toEqual(recoveredEmbedding);
+    expect(inner.embedQuery).toHaveBeenCalledTimes(1);
+    expect(resourceCache!.peekByKey(key)).toEqual(recoveredEmbedding);
+
+    const row = db.prepare("SELECT embedding FROM embedding_cache WHERE hash = ?").get(hash) as {
+      embedding: Buffer;
+    };
+    const storedEmbedding = deserializeEmbedding(row.embedding);
+    expect(storedEmbedding).toHaveLength(recoveredEmbedding.length);
+    storedEmbedding.forEach((value, index) => {
+      expect(value).toBeCloseTo(recoveredEmbedding[index]);
+    });
+  });
+});

--- a/src/memory/embeddings/cached.ts
+++ b/src/memory/embeddings/cached.ts
@@ -26,6 +26,7 @@ export class CachedEmbeddingProvider implements EmbeddingProvider {
   private readonly stmtCacheGet: Database.Statement;
   private readonly stmtCachePut: Database.Statement;
   private readonly stmtCacheTouch: Database.Statement;
+  private readonly stmtCacheDelete: Database.Statement;
 
   constructor(
     private inner: EmbeddingProvider,
@@ -44,6 +45,9 @@ export class CachedEmbeddingProvider implements EmbeddingProvider {
     this.stmtCacheTouch = db.prepare(
       `UPDATE embedding_cache SET accessed_at = unixepoch() WHERE hash = ? AND model = ? AND provider = ?`
     );
+    this.stmtCacheDelete = db.prepare(
+      `DELETE FROM embedding_cache WHERE hash = ? AND model = ? AND provider = ?`
+    );
   }
 
   private cacheGet(hash: string): { embedding: Buffer | string } | undefined {
@@ -60,6 +64,10 @@ export class CachedEmbeddingProvider implements EmbeddingProvider {
     this.stmtCacheTouch.run(hash, this.model, this.id);
   }
 
+  private cacheDelete(hash: string): void {
+    this.stmtCacheDelete.run(hash, this.model, this.id);
+  }
+
   async warmup(): Promise<boolean> {
     return this.inner.warmup?.() ?? true;
   }
@@ -67,25 +75,32 @@ export class CachedEmbeddingProvider implements EmbeddingProvider {
   async embedQuery(text: string): Promise<number[]> {
     const hash = hashText(text);
     const resourceCache = getCache();
-    const cached = resourceCache?.getCachedByKey<number[]>(
-      resourceCache.makeKey("embeddings", hash, this.cacheConfig())
-    );
-    if (cached) return cached;
+    const cacheKey = resourceCache?.makeKey("embeddings", hash, this.cacheConfig());
+    const cached = cacheKey ? resourceCache?.getCachedByKey<number[]>(cacheKey) : undefined;
+    if (cached !== undefined) {
+      if (cached.length > 0) return cached;
+      resourceCache?.invalidate({ key: cacheKey });
+    }
 
     const row = this.cacheGet(hash);
     if (row) {
-      this.hits++;
-      this.cacheTouch(hash);
-      this.tick();
       const embedding = deserializeEmbedding(row.embedding);
-      resourceCache?.set("embeddings", hash, this.cacheConfig(), embedding);
-      return embedding;
+      if (embedding.length > 0) {
+        this.hits++;
+        this.cacheTouch(hash);
+        this.tick();
+        resourceCache?.set("embeddings", hash, this.cacheConfig(), embedding);
+        return embedding;
+      }
+      this.cacheDelete(hash);
     }
 
     this.misses++;
     const embedding = await this.inner.embedQuery(text);
-    this.cachePut(hash, serializeEmbedding(embedding));
-    resourceCache?.set("embeddings", hash, this.cacheConfig(), embedding);
+    if (embedding.length > 0) {
+      this.cachePut(hash, serializeEmbedding(embedding));
+      resourceCache?.set("embeddings", hash, this.cacheConfig(), embedding);
+    }
     this.tick();
     return embedding;
   }
@@ -101,22 +116,31 @@ export class CachedEmbeddingProvider implements EmbeddingProvider {
     // Check cache for each text
     for (let i = 0; i < texts.length; i++) {
       const resourceCache = getCache();
-      const cached = resourceCache?.getCachedByKey<number[]>(
-        resourceCache.makeKey("embeddings", hashes[i], this.cacheConfig())
-      );
-      if (cached) {
-        results[i] = cached;
-        continue;
+      const cacheKey = resourceCache?.makeKey("embeddings", hashes[i], this.cacheConfig());
+      const cached = cacheKey ? resourceCache?.getCachedByKey<number[]>(cacheKey) : undefined;
+      if (cached !== undefined) {
+        if (cached.length > 0) {
+          results[i] = cached;
+          continue;
+        }
+        resourceCache?.invalidate({ key: cacheKey });
       }
 
       const row = this.cacheGet(hashes[i]);
 
       if (row) {
-        this.hits++;
-        this.cacheTouch(hashes[i]);
         const embedding = deserializeEmbedding(row.embedding);
-        results[i] = embedding;
-        resourceCache?.set("embeddings", hashes[i], this.cacheConfig(), embedding);
+        if (embedding.length > 0) {
+          this.hits++;
+          this.cacheTouch(hashes[i]);
+          results[i] = embedding;
+          resourceCache?.set("embeddings", hashes[i], this.cacheConfig(), embedding);
+        } else {
+          this.cacheDelete(hashes[i]);
+          this.misses++;
+          missIndices.push(i);
+          missTexts.push(texts[i]);
+        }
       } else {
         this.misses++;
         missIndices.push(i);


### PR DESCRIPTION
## Что исправлено

Fixes xlabtg/teleton-agent#615.

`CachedEmbeddingProvider.embedQuery` больше не записывает пустой embedding `[]` в SQLite `embedding_cache` и in-memory `ResourceCacheService`. Пустые значения, если они уже попали в кэш ранее, теперь считаются cache miss: запись удаляется, провайдер вызывается заново, а успешный непустой embedding заново заполняет кэш.

Та же защита применена к чтению `embedBatch`, чтобы старые отравленные записи из одиночного `embedQuery` не возвращались через batch-путь.

## Как воспроизвести проблему

1. Inner-провайдер временно возвращает `[]` из `embedQuery("foo")`.
2. Старое поведение записывало `[]` в `embedding_cache` и resource cache.
3. После восстановления провайдера повторный `embedQuery("foo")` возвращал пустой вектор из кэша и не вызывал провайдер.

## Проверка

- `npm test -- src/memory/embeddings/__tests__/cached.test.ts`
- `npx eslint src/memory/embeddings/cached.ts src/memory/embeddings/__tests__/cached.test.ts --max-warnings 0`
- `npx prettier --check src/memory/embeddings/cached.ts src/memory/embeddings/__tests__/cached.test.ts`
- `npm run typecheck`
- `npm test` — 239 files passed, 3727 tests passed

Скриншоты не требуются: изменение не затрагивает UI.
