### PR TITLE
fix(webui): очищать SSE listeners при ошибках стрима

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T21:26:29.426Z for PR creation at branch issue-614-18c338d6215f for issue https://github.com/xlabtg/teleton-agent/issues/614

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T21:26:29.426Z for PR creation at branch issue-614-18c338d6215f for issue https://github.com/xlabtg/teleton-agent/issues/614

--- a/src/webui/__tests__/sse-listener-cleanup.test.ts
+++ b/src/webui/__tests__/sse-listener-cleanup.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import Database from "better-sqlite3";
+import type { WebUIServerDeps } from "../types.js";
+
+const streamHarness = vi.hoisted(() => ({
+  error: undefined as unknown,
+  stream: undefined as unknown,
+}));
+
+vi.mock("hono/streaming", () => ({
+  streamSSE: vi.fn(
+    async (_context: unknown, callback: (stream: unknown) => Promise<void>): Promise<Response> => {
+      streamHarness.error = undefined;
+      try {
+        await callback(streamHarness.stream);
+      } catch (error) {
+        streamHarness.error = error;
+      }
+
+      return new Response("", {
+        headers: { "Content-Type": "text/event-stream" },
+        status: 200,
+      });
+    }
+  ),
+}));
+
+import { auditTrailBus } from "../../services/audit-trail.js";
+import { notificationBus } from "../../services/notifications.js";
+import { createAuditRoutes } from "../routes/audit.js";
+import { createNotificationsRoutes } from "../routes/notifications.js";
+
+function createFailingHeartbeatStream() {
+  return {
+    onAbort: vi.fn(),
+    sleep: vi.fn(async () => {}),
+    writeSSE: vi.fn(async (payload: { event?: string }) => {
+      if (payload.event === "ping") {
+        throw new Error("simulated stream write failure");
+      }
+    }),
+  };
+}
+
+function buildNotificationsApp(db: Database.Database) {
+  const deps = { memory: { db } } as unknown as WebUIServerDeps;
+  const app = new Hono();
+  app.route("/notifications", createNotificationsRoutes(deps));
+  return app;
+}
+
+function buildAuditApp(db: Database.Database) {
+  const deps = { memory: { db } } as unknown as WebUIServerDeps;
+  const app = new Hono();
+  app.route("/audit", createAuditRoutes(deps));
+  return app;
+}
+
+describe("SSE listener cleanup", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    notificationBus.removeAllListeners("update");
+    auditTrailBus.removeAllListeners("event");
+  });
+
+  afterEach(() => {
+    notificationBus.removeAllListeners("update");
+    auditTrailBus.removeAllListeners("event");
+    db.close();
+  });
+
+  it("removes notification listeners when a heartbeat write fails", async () => {
+    const app = buildNotificationsApp(db);
+    const before = notificationBus.listenerCount("update");
+    streamHarness.stream = createFailingHeartbeatStream();
+
+    const res = await app.request("/notifications/stream");
+
+    expect(res.status).toBe(200);
+    expect(streamHarness.error).toBeInstanceOf(Error);
+    expect(notificationBus.listenerCount("update")).toBe(before);
+  });
+
+  it("removes audit listeners when a heartbeat write fails", async () => {
+    const app = buildAuditApp(db);
+    const before = auditTrailBus.listenerCount("event");
+    streamHarness.stream = createFailingHeartbeatStream();
+
+    const res = await app.request("/audit/stream");
+
+    expect(res.status).toBe(200);
+    expect(streamHarness.error).toBeInstanceOf(Error);
+    expect(auditTrailBus.listenerCount("event")).toBe(before);
+  });
+});

--- a/src/webui/routes/audit.ts
+++ b/src/webui/routes/audit.ts
@@ -134,26 +134,45 @@ export function createAuditRoutes(deps: WebUIServerDeps) {
   app.get("/stream", (c) => {
     return streamSSE(c, async (stream) => {
       let aborted = false;
-      stream.onAbort(() => {
-        aborted = true;
-      });
+      let listening = false;
 
       const onEvent = (event: unknown) => {
         if (aborted) return;
-        void stream.writeSSE({
-          event: "audit-event",
-          data: JSON.stringify(event),
-        });
+        void stream
+          .writeSSE({
+            event: "audit-event",
+            data: JSON.stringify(event),
+          })
+          .catch(() => {
+            aborted = true;
+            cleanup();
+          });
       };
 
-      auditTrailBus.on("event", onEvent);
-
-      while (!aborted) {
-        await stream.sleep(30_000);
-        if (!aborted) await stream.writeSSE({ event: "ping", data: "" });
+      function cleanup() {
+        if (!listening) return;
+        listening = false;
+        auditTrailBus.off("event", onEvent);
       }
 
-      auditTrailBus.off("event", onEvent);
+      stream.onAbort(() => {
+        aborted = true;
+        cleanup();
+      });
+
+      try {
+        if (aborted) return;
+
+        auditTrailBus.on("event", onEvent);
+        listening = true;
+
+        while (!aborted) {
+          await stream.sleep(30_000);
+          if (!aborted) await stream.writeSSE({ event: "ping", data: "" });
+        }
+      } finally {
+        cleanup();
+      }
     });
   });
 

--- a/src/webui/routes/notifications.ts
+++ b/src/webui/routes/notifications.ts
@@ -38,40 +38,62 @@ export function createNotificationsRoutes(deps: WebUIServerDeps) {
   app.get("/stream", (c) => {
     return streamSSE(c, async (stream) => {
       let aborted = false;
-
-      stream.onAbort(() => {
-        aborted = true;
-      });
-
-      // Send current unread count immediately on connect
-      try {
-        const count = svc().unreadCount();
-        await stream.writeSSE({
-          event: "unread-count",
-          data: JSON.stringify({ count }),
-        });
-      } catch {
-        // db may not be ready yet — ignore
-      }
+      let listening = false;
 
       const onUpdate = (count: number) => {
         if (aborted) return;
-        void stream.writeSSE({
-          event: "unread-count",
-          data: JSON.stringify({ count }),
-        });
+        void stream
+          .writeSSE({
+            event: "unread-count",
+            data: JSON.stringify({ count }),
+          })
+          .catch(() => {
+            aborted = true;
+            cleanup();
+          });
       };
 
-      notificationBus.on("update", onUpdate);
-
-      // Heartbeat to keep connection alive
-      while (!aborted) {
-        await stream.sleep(30_000);
-        if (aborted) break;
-        await stream.writeSSE({ event: "ping", data: "" });
+      function cleanup() {
+        if (!listening) return;
+        listening = false;
+        notificationBus.off("update", onUpdate);
       }
 
-      notificationBus.off("update", onUpdate);
+      stream.onAbort(() => {
+        aborted = true;
+        cleanup();
+      });
+
+      try {
+        // Send current unread count immediately on connect. DB readiness errors
+        // are ignored; stream write errors must still reach finally cleanup.
+        let count: number | null = null;
+        try {
+          count = svc().unreadCount();
+        } catch {
+          count = null;
+        }
+        if (count !== null && !aborted) {
+          await stream.writeSSE({
+            event: "unread-count",
+            data: JSON.stringify({ count }),
+          });
+        }
+
+        if (aborted) return;
+
+        notificationBus.on("update", onUpdate);
+        listening = true;
+
+        // Heartbeat to keep connection alive
+        while (!aborted) {
+          await stream.sleep(30_000);
+          if (aborted) break;
+          await stream.writeSSE({ event: "ping", data: "" });
+        }
+      } finally {
+        cleanup();
+      }
     });
   });
 


### PR DESCRIPTION
## Что исправлено

Fixes xlabtg/teleton-agent#614.

- `GET /api/notifications/stream` и `GET /api/audit/stream` теперь снимают bus listener через идемпотентный `cleanup()` в `stream.onAbort` и `finally`.
- Если heartbeat `writeSSE`/`sleep` падает после регистрации listener, обработчик больше не остаётся висеть на module-level bus.
- Ошибки записи из bus-event callback также приводят к cleanup, чтобы dead stream не продолжал получать события.
- В notifications initial unread-count теперь разделяет ошибку чтения БД и ошибку записи SSE: DB readiness по-прежнему игнорируется, а write error проходит в `finally`.
- Удалён временный `.gitkeep` из стартового WIP-коммита.

## Как воспроизвести исходную проблему

Новый regression test мокает `streamSSE`, даёт heartbeat `writeSSE({ event: "ping" })` упасть после регистрации listener и проверяет `listenerCount`.

До исправления оба теста падали:

```text
expected 1 to be +0
```

После исправления `notificationBus.listenerCount("update")` и `auditTrailBus.listenerCount("event")` возвращаются к исходному значению.

## Тесты

- `npm test -- src/webui/__tests__/sse-listener-cleanup.test.ts` (до фикса: failed; после фикса: passed)
- `npm test -- src/webui/__tests__/notifications-routes.test.ts src/webui/__tests__/audit-routes.test.ts`
- `npx prettier --check src/webui/routes/notifications.ts src/webui/routes/audit.ts src/webui/__tests__/sse-listener-cleanup.test.ts`
- `npm run build -w packages/sdk`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run test:coverage`
- `npm run knip`
- `npm run circular`

UI не менялся, скриншоты не требуются.
