### PR TITLE
fix(agent): учитывать abort signal в LLM-запросе

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T22:18:30.696Z for PR creation at branch issue-617-d5039456a734 for issue https://github.com/xlabtg/teleton-agent/issues/617

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T22:18:30.696Z for PR creation at branch issue-617-d5039456a734 for issue https://github.com/xlabtg/teleton-agent/issues/617

--- a/src/agent/__tests__/client-abort.test.ts
+++ b/src/agent/__tests__/client-abort.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentConfig } from "../../config/schema.js";
+
+const mockComplete = vi.fn();
+
+vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mariozechner/pi-ai")>();
+  return {
+    ...actual,
+    complete: (...args: unknown[]) => mockComplete(...args),
+  };
+});
+
+function agentConfig(): AgentConfig {
+  return {
+    provider: "nvidia",
+    api_key: "nvapi-test-key",
+    model: "meta/llama-3.1-8b-instruct",
+    max_tokens: 1024,
+    temperature: 0.7,
+    system_prompt: null,
+    max_agentic_iterations: 5,
+    session_reset_policy: {
+      daily_reset_enabled: false,
+      daily_reset_hour: 4,
+      idle_expiry_enabled: false,
+      idle_expiry_minutes: 1440,
+    },
+    compaction: {
+      enabled: false,
+      log_compaction: true,
+      auto_preserve: true,
+    },
+  };
+}
+
+function makeAssistantMessage(text: string) {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    api: "openai-completions",
+    provider: "nvidia",
+    model: "meta/llama-3.1-8b-instruct",
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 2,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
+
+type CapturedCompleteOptions = {
+  signal?: AbortSignal;
+};
+
+function getCapturedCompleteOptions(): CapturedCompleteOptions {
+  const [, , options] = mockComplete.mock.calls[0] as [unknown, unknown, CapturedCompleteOptions];
+  return options;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockComplete.mockResolvedValue(makeAssistantMessage("ok"));
+});
+
+describe("chatWithContext abort signal handling", () => {
+  it("aborts the in-flight LLM request signal when the caller signal fires", async () => {
+    const { chatWithContext } = await import("../client.js");
+    const controller = new AbortController();
+
+    await chatWithContext(agentConfig(), {
+      context: { messages: [], systemPrompt: "test" },
+      signal: controller.signal,
+    });
+
+    const completeSignal = getCapturedCompleteOptions().signal;
+    expect(completeSignal).toBeInstanceOf(AbortSignal);
+    expect(completeSignal?.aborted).toBe(false);
+
+    const reason = new Error("caller cancelled");
+    controller.abort(reason);
+
+    expect(completeSignal?.aborted).toBe(true);
+    expect(completeSignal?.reason).toBe(reason);
+  });
+});

--- a/src/agent/__tests__/runtime-retry.test.ts
+++ b/src/agent/__tests__/runtime-retry.test.ts
@@ -157,6 +157,29 @@ async function createRuntime(config = makeConfig()) {
 }
 
 describe("AgentRuntime retry backoff", () => {
+  it("passes the caller abort signal to chatWithContext", async () => {
+    const runtime = await createRuntime();
+    const controller = new AbortController();
+    chatWithContextMock.mockResolvedValueOnce(assistantResponse("ok"));
+
+    await expect(
+      runtime.processMessage({
+        chatId: "1001",
+        userMessage: "hello",
+        userName: "Owner",
+        signal: controller.signal,
+      })
+    ).resolves.toMatchObject({
+      content: "ok",
+      toolCalls: [],
+    });
+
+    expect(chatWithContextMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ signal: controller.signal })
+    );
+  });
+
   it("does not count a rate-limit retry against max_agentic_iterations", async () => {
     vi.useFakeTimers();
     const runtime = await createRuntime();

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -264,6 +264,7 @@ export interface ChatOptions {
   temperature?: number;
   persistTranscript?: boolean;
   tools?: Tool[];
+  signal?: AbortSignal;
 }
 
 export interface ChatResponse {
@@ -307,13 +308,16 @@ export async function chatWithContext(
     options.temperature ?? config.temperature
   );
 
+  const requestTimeoutSignal = AbortSignal.timeout(LLM_REQUEST_TIMEOUT_MS);
   const completeOptions: Record<string, unknown> = {
     apiKey: getEffectiveApiKey(provider, config.api_key),
     maxTokens: options.maxTokens ?? config.max_tokens,
     temperature,
     sessionId: options.sessionId,
     cacheRetention: provider === "nvidia" ? NVIDIA_CACHE_RETENTION : DEFAULT_CACHE_RETENTION,
-    signal: AbortSignal.timeout(LLM_REQUEST_TIMEOUT_MS),
+    signal: options.signal
+      ? AbortSignal.any([options.signal, requestTimeoutSignal])
+      : requestTimeoutSignal,
   };
   if (isCocoon) {
     const { stripCocoonPayload } = await import("../cocoon/tool-adapter.js");

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -891,6 +891,7 @@ export class AgentRuntime {
             sessionId: session.sessionId,
             persistTranscript: true,
             tools,
+            signal,
           });
           recordLlmRequest(
             provider,


### PR DESCRIPTION
## Description

Исправляет xlabtg/teleton-agent#617: `AgentRuntime.processMessage()` теперь передает caller `AbortSignal` в `chatWithContext`, а LLM-клиент объединяет его с собственным `LLM_REQUEST_TIMEOUT_MS` через `AbortSignal.any(...)`.

До исправления уже запущенный LLM-запрос продолжал выполняться до ответа провайдера или внутреннего timeout, даже если pipeline step timeout, отмена run или shutdown уже abort-нули caller signal. Теперь caller abort отменяет in-flight LLM request, а внутренний timeout сохраняется.

Добавлены регрессионные тесты:

- `src/agent/__tests__/client-abort.test.ts` проверяет, что signal, переданный в `complete(...)`, abort-ится при abort caller signal.
- `src/agent/__tests__/runtime-retry.test.ts` проверяет, что runtime прокидывает caller signal в `chatWithContext`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Build/CI/tooling change
- [ ] Breaking change (fix or feature that changes an existing public contract)

## Testing Done

- [x] `npm run build:sdk`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test -- src/agent/__tests__/client-abort.test.ts src/agent/__tests__/runtime-retry.test.ts`
- [x] `npm test`

Дополнительно запускал `npx tsc -p tsconfig.test.json --noEmit`: команда остается красной на уже существующих строгих типовых ошибках в тестовых fixtures (`runtime-retry`, `mcp-loader`, `exec`, `providers` и др.). Новые `client-abort.test.ts`, `src/agent/client.ts` и `src/agent/runtime.ts` среди этих ошибок отсутствуют.

## Screenshots or Logs

UI не менялся. Ключевой результат после сборки SDK:

```text
Test Files  241 passed (241)
Tests       3731 passed (3731)
```

До исправления новый регрессионный тест падал на том, что signal внутри `complete(...)` не abort-ился после abort caller signal.

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My PR targets the `main` branch
- [x] Tests were added or updated for behavior changes, or I explained why tests are not needed
- [x] Documentation was updated for user-facing or contributor-facing changes
- [x] CHANGELOG entry or release note is included when appropriate
- [x] Security, privacy, and migration implications were considered

## Related Issues

Closes xlabtg/teleton-agent#617