### PR TITLE
fix(webui): убрать записи из GET temporal context

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T22:37:48.838Z for PR creation at branch issue-619-21ea0d76474f for issue https://github.com/xlabtg/teleton-agent/issues/619

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T22:37:48.838Z for PR creation at branch issue-619-21ea0d76474f for issue https://github.com/xlabtg/teleton-agent/issues/619

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -3834,6 +3834,48 @@
         ]
       }
     },
+    "/v1/context/patterns/analyze": {
+      "post": {
+        "tags": [
+          "Temporal Context"
+        ],
+        "summary": "Create / invoke /v1/context/patterns/analyze",
+        "operationId": "post_v1_context_patterns_analyze",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ]
+      }
+    },
     "/v1/context/temporal": {
       "get": {
         "tags": [
@@ -3841,6 +3883,48 @@
         ],
         "summary": "Get /v1/context/temporal",
         "operationId": "get_v1_context_temporal",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ]
+      }
+    },
+    "/v1/context/temporal/sync": {
+      "post": {
+        "tags": [
+          "Temporal Context"
+        ],
+        "summary": "Create / invoke /v1/context/temporal/sync",
+        "operationId": "post_v1_context_temporal_sync",
         "responses": {
           "200": {
             "description": "Successful response",

--- a/docs/api-reference/openapi.yaml
+++ b/docs/api-reference/openapi.yaml
@@ -2379,12 +2379,64 @@ paths:
           $ref: "#/components/responses/ServiceUnavailable"
       security:
         - BearerAuth: []
+  /v1/context/patterns/analyze:
+    post:
+      tags:
+        - Temporal Context
+      summary: Create / invoke /v1/context/patterns/analyze
+      operationId: post_v1_context_patterns_analyze
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      security:
+        - BearerAuth: []
   /v1/context/temporal:
     get:
       tags:
         - Temporal Context
       summary: Get /v1/context/temporal
       operationId: get_v1_context_temporal
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"
+        "500":
+          $ref: "#/components/responses/InternalError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+      security:
+        - BearerAuth: []
+  /v1/context/temporal/sync:
+    post:
+      tags:
+        - Temporal Context
+      summary: Create / invoke /v1/context/temporal/sync
+      operationId: post_v1_context_temporal_sync
       responses:
         "200":
           description: Successful response

--- a/src/agent/runtime.ts
+++ b/src/agent/runtime.ts
@@ -2124,6 +2124,7 @@ export class AgentRuntime {
         getDatabase().getDb(),
         this.config.temporal_context
       );
+      service.analyzeAndStorePatterns();
       const snapshot = service.getCurrentTemporalContext({
         time: opts.timestamp,
         sessionIndex: opts.sessionIndex,

--- a/src/services/temporal-context.ts
+++ b/src/services/temporal-context.ts
@@ -841,7 +841,6 @@ export class TemporalContextService {
       limit?: number;
     } = {}
   ): TemporalContextSnapshot {
-    this.analyzeAndStorePatterns();
     const metadata = deriveTemporalMetadata({
       timestamp: input.time,
       timezone: this.timezone,

--- a/src/webui/__tests__/temporal-routes.test.ts
+++ b/src/webui/__tests__/temporal-routes.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "hono";
 import Database from "better-sqlite3";
 import { ensureSchema } from "../../memory/schema.js";
 import { BehaviorTracker } from "../../services/behavior-tracker.js";
+import { TemporalContextService } from "../../services/temporal-context.js";
 import { createTemporalRoutes } from "../routes/temporal.js";
 import type { WebUIServerDeps } from "../types.js";
 
@@ -52,6 +53,7 @@ describe("Temporal WebUI routes", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     db.close();
   });
 
@@ -63,6 +65,17 @@ describe("Temporal WebUI routes", () => {
     expect(json.success).toBe(true);
     expect(json.data.metadata.dayName).toBe("Friday");
     expect(json.data.metadata.hourOfDay).toBe(9);
+  });
+
+  it("GET /context/temporal does not run temporal write operations", async () => {
+    const syncSpy = vi.spyOn(TemporalContextService.prototype, "syncTemporalMetadata");
+    const analyzeSpy = vi.spyOn(TemporalContextService.prototype, "analyzeAndStorePatterns");
+
+    const res = await app.request("/context/temporal?time=2026-04-24T09:00:00Z");
+
+    expect(res.status).toBe(200);
+    expect(syncSpy).not.toHaveBeenCalled();
+    expect(analyzeSpy).not.toHaveBeenCalled();
   });
 
   it("GET /context/patterns returns detected temporal patterns", async () => {
@@ -79,6 +92,9 @@ describe("Temporal WebUI routes", () => {
       timestamp: Date.parse("2026-05-01T09:00:00Z") / 1000,
     });
 
+    const analyzeRes = await app.request("/context/patterns/analyze", { method: "POST" });
+    expect(analyzeRes.status).toBe(200);
+
     const res = await app.request("/context/patterns?includeDisabled=true");
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -86,6 +102,39 @@ describe("Temporal WebUI routes", () => {
     expect(json.success).toBe(true);
     expect(json.data.length).toBeGreaterThan(0);
     expect(json.data[0].description).toContain("weekly review");
+  });
+
+  it("GET /context/patterns does not run temporal pattern analysis", async () => {
+    const analyzeSpy = vi.spyOn(TemporalContextService.prototype, "analyzeAndStorePatterns");
+
+    const res = await app.request("/context/patterns?includeDisabled=true");
+
+    expect(res.status).toBe(200);
+    expect(analyzeSpy).not.toHaveBeenCalled();
+  });
+
+  it("POST /context/temporal/sync runs metadata synchronization", async () => {
+    const syncSpy = vi.spyOn(TemporalContextService.prototype, "syncTemporalMetadata");
+
+    const res = await app.request("/context/temporal/sync", { method: "POST" });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.synced).toBeGreaterThanOrEqual(0);
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("POST /context/patterns/analyze runs temporal pattern analysis", async () => {
+    const analyzeSpy = vi.spyOn(TemporalContextService.prototype, "analyzeAndStorePatterns");
+
+    const res = await app.request("/context/patterns/analyze", { method: "POST" });
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.upserted).toBeGreaterThanOrEqual(0);
+    expect(analyzeSpy).toHaveBeenCalledTimes(1);
   });
 
   it("PUT /context/patterns/:id updates a stored pattern", async () => {
@@ -101,6 +150,9 @@ describe("Temporal WebUI routes", () => {
       text: "deploy check",
       timestamp: Date.parse("2026-05-01T09:00:00Z") / 1000,
     });
+
+    const analyzeRes = await app.request("/context/patterns/analyze", { method: "POST" });
+    expect(analyzeRes.status).toBe(200);
 
     const patternsRes = await app.request("/context/patterns?includeDisabled=true");
     const patternsJson = await patternsRes.json();

--- a/src/webui/routes/temporal.ts
+++ b/src/webui/routes/temporal.ts
@@ -38,7 +38,6 @@ export function createTemporalRoutes(deps: WebUIServerDeps) {
   app.get("/temporal", (c) => {
     try {
       const service = getService(deps);
-      service.syncTemporalMetadata();
       const data = service.getCurrentTemporalContext({
         time: c.req.query("time") ?? undefined,
         limit: parseLimit(c.req.query("limit"), 5),
@@ -50,14 +49,35 @@ export function createTemporalRoutes(deps: WebUIServerDeps) {
     }
   });
 
+  app.post("/temporal/sync", (c) => {
+    try {
+      const service = getService(deps);
+      const data = service.syncTemporalMetadata();
+      const response: APIResponse<typeof data> = { success: true, data };
+      return c.json(response);
+    } catch (error) {
+      return c.json<APIResponse>({ success: false, error: getErrorMessage(error) }, 500);
+    }
+  });
+
   app.get("/patterns", (c) => {
     try {
       const service = getService(deps);
-      service.analyzeAndStorePatterns();
       const data = service.listPatterns({
         includeDisabled: c.req.query("includeDisabled") === "true",
         limit: parseLimit(c.req.query("limit"), 100),
       });
+      const response: APIResponse<typeof data> = { success: true, data };
+      return c.json(response);
+    } catch (error) {
+      return c.json<APIResponse>({ success: false, error: getErrorMessage(error) }, 500);
+    }
+  });
+
+  app.post("/patterns/analyze", (c) => {
+    try {
+      const service = getService(deps);
+      const data = service.analyzeAndStorePatterns();
       const response: APIResponse<typeof data> = { success: true, data };
       return c.json(response);
     } catch (error) {


### PR DESCRIPTION
## Что исправлено

Fixes xlabtg/teleton-agent#619.

- `GET /api/context/temporal` больше не вызывает `syncTemporalMetadata()`.
- `GET /api/context/patterns` больше не вызывает `analyzeAndStorePatterns()`.
- `TemporalContextService.getCurrentTemporalContext()` стал read-only, чтобы route-level GET не получал скрытую запись через сервисный метод.
- Записи перенесены в явные POST-эндпоинты: `POST /api/context/temporal/sync` и `POST /api/context/patterns/analyze`; в WebUI они покрываются существующей CSRF middleware для `/api/*` mutation methods.
- Runtime агента явно вызывает `analyzeAndStorePatterns()` перед построением temporal prompt context, чтобы сохранить прежнее поведение вне GET-запросов.
- Обновлены OpenAPI artifacts для новых `/v1/context/...` POST routes.

## Как воспроизвести исходную проблему

Новый regression test шпионит за `TemporalContextService.prototype.syncTemporalMetadata` и `TemporalContextService.prototype.analyzeAndStorePatterns`.

До исправления:

- `GET /context/temporal` вызывал `syncTemporalMetadata()`.
- `GET /context/patterns` вызывал `analyzeAndStorePatterns()`.

После исправления оба GET route возвращают данные без вызова write-методов, а соответствующие операции запускаются только POST routes.

## Тесты

- `npm run build:sdk`
- `npm test -- src/webui/__tests__/temporal-routes.test.ts` (до фикса: 2 failed; после фикса: 8 passed)
- `npm test -- src/services/__tests__/temporal-context.test.ts`
- `npm test -- src/api/__tests__/openapi-spec.test.ts src/webui/__tests__/temporal-routes.test.ts src/services/__tests__/temporal-context.test.ts`
- `npm run generate:openapi`
- `npm run lint:openapi` (passed; остались существующие Redocly warnings про ambiguous paths)
- `npm run lint`
- `npm run format:check`
- `npm run knip`
- `npm run circular`
- `npm run typecheck`
- `npm run test:coverage`
- `cd web && npm run check:i18n`
- `npm run build`
- `npm run audit:ci`

UI не менялся, скриншоты не требуются.
