### PR TITLE
Исправляет гонку ответов в загрузчиках Sessions и Analytics

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T22:57:26.028Z for PR creation at branch issue-618-d5cb66185c07 for issue https://github.com/xlabtg/teleton-agent/issues/618

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T22:57:26.028Z for PR creation at branch issue-618-d5cb66185c07 for issue https://github.com/xlabtg/teleton-agent/issues/618

--- a/web/src/lib/__tests__/latestRequest.test.ts
+++ b/web/src/lib/__tests__/latestRequest.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runLatestRequest } from "../latestRequest";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("runLatestRequest", () => {
+  it("ignores a stale response that resolves after a newer request", async () => {
+    const requestRef = { current: 0 };
+    const slow = deferred<string>();
+    const fast = deferred<string>();
+    const apply = vi.fn();
+    const fail = vi.fn();
+    const finish = vi.fn();
+
+    const slowRequest = runLatestRequest(requestRef, () => slow.promise, {
+      onSuccess: apply,
+      onError: fail,
+      onFinally: finish,
+    });
+    const fastRequest = runLatestRequest(requestRef, () => fast.promise, {
+      onSuccess: apply,
+      onError: fail,
+      onFinally: finish,
+    });
+
+    fast.resolve("newer");
+    await fastRequest;
+
+    expect(apply).toHaveBeenCalledWith("newer");
+    expect(finish).toHaveBeenCalledTimes(1);
+
+    slow.resolve("stale");
+    await slowRequest;
+
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(fail).not.toHaveBeenCalled();
+    expect(finish).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a stale error and finalizer after a newer request starts", async () => {
+    const requestRef = { current: 0 };
+    const stale = deferred<string>();
+    const current = deferred<string>();
+    const apply = vi.fn();
+    const fail = vi.fn();
+    const finish = vi.fn();
+
+    const staleRequest = runLatestRequest(requestRef, () => stale.promise, {
+      onSuccess: apply,
+      onError: fail,
+      onFinally: finish,
+    });
+    const currentRequest = runLatestRequest(requestRef, () => current.promise, {
+      onSuccess: apply,
+      onError: fail,
+      onFinally: finish,
+    });
+
+    stale.reject(new Error("old failure"));
+    await staleRequest;
+
+    expect(fail).not.toHaveBeenCalled();
+    expect(finish).not.toHaveBeenCalled();
+
+    current.resolve("current");
+    await currentRequest;
+
+    expect(apply).toHaveBeenCalledWith("current");
+    expect(fail).not.toHaveBeenCalled();
+    expect(finish).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/lib/latestRequest.ts
+++ b/web/src/lib/latestRequest.ts
@@ -1,0 +1,27 @@
+export type LatestRequestRef = { current: number };
+
+export async function runLatestRequest<T>(
+  requestRef: LatestRequestRef,
+  run: () => Promise<T>,
+  handlers: {
+    onSuccess: (result: T) => void;
+    onError: (error: unknown) => void;
+    onFinally?: () => void;
+  }
+): Promise<void> {
+  const requestId = requestRef.current + 1;
+  requestRef.current = requestId;
+
+  try {
+    const result = await run();
+    if (requestRef.current !== requestId) return;
+    handlers.onSuccess(result);
+  } catch (error) {
+    if (requestRef.current !== requestId) return;
+    handlers.onError(error);
+  } finally {
+    if (requestRef.current === requestId) {
+      handlers.onFinally?.();
+    }
+  }
+}

--- a/web/src/pages/Analytics.tsx
+++ b/web/src/pages/Analytics.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import {
   LineChart,
   Line,
@@ -30,6 +30,7 @@ import {
   type TemporalPattern,
   type TemporalTimelineEntry,
 } from "../lib/api";
+import { runLatestRequest } from "../lib/latestRequest";
 import { useTranslation } from "react-i18next";
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -190,22 +191,27 @@ function UsageSection() {
   const [toolData, setToolData] = useState<ToolUsageEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const requestRef = useRef(0);
 
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
-    try {
-      const [tokRes, toolRes] = await Promise.all([
-        api.getAnalyticsUsage(period),
-        api.getAnalyticsTools(period),
-      ]);
-      setTokenData(tokRes.data ?? []);
-      setToolData(toolRes.data ?? []);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load usage data");
-    } finally {
-      setLoading(false);
-    }
+    await runLatestRequest(
+      requestRef,
+      () => Promise.all([api.getAnalyticsUsage(period), api.getAnalyticsTools(period)]),
+      {
+        onSuccess: ([tokRes, toolRes]) => {
+          setTokenData(tokRes.data ?? []);
+          setToolData(toolRes.data ?? []);
+        },
+        onError: (e) => {
+          setError(e instanceof Error ? e.message : "Failed to load usage data");
+        },
+        onFinally: () => {
+          setLoading(false);
+        },
+      }
+    );
   }, [period]);
 
   useEffect(() => {
@@ -447,24 +453,33 @@ function AnomalySection() {
   const [stats, setStats] = useState<AnomalyStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const requestRef = useRef(0);
 
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
-    try {
-      const [eventRes, baselineRes, statsRes] = await Promise.all([
-        api.getAnomalies({ period }),
-        api.getAnomalyBaselines(),
-        api.getAnomalyStats(period),
-      ]);
-      setEvents(eventRes.data ?? []);
-      setBaselines(baselineRes.data ?? []);
-      setStats(statsRes.data ?? null);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load anomaly data");
-    } finally {
-      setLoading(false);
-    }
+    await runLatestRequest(
+      requestRef,
+      () =>
+        Promise.all([
+          api.getAnomalies({ period }),
+          api.getAnomalyBaselines(),
+          api.getAnomalyStats(period),
+        ]),
+      {
+        onSuccess: ([eventRes, baselineRes, statsRes]) => {
+          setEvents(eventRes.data ?? []);
+          setBaselines(baselineRes.data ?? []);
+          setStats(statsRes.data ?? null);
+        },
+        onError: (e) => {
+          setError(e instanceof Error ? e.message : "Failed to load anomaly data");
+        },
+        onFinally: () => {
+          setLoading(false);
+        },
+      }
+    );
   }, [period]);
 
   useEffect(() => {
@@ -732,18 +747,22 @@ function HeatmapSection() {
   const [data, setData] = useState<ActivityEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const requestRef = useRef(0);
 
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
-    try {
-      const res = await api.getAnalyticsHeatmap(period);
-      setData(res.data ?? []);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load heatmap");
-    } finally {
-      setLoading(false);
-    }
+    await runLatestRequest(requestRef, () => api.getAnalyticsHeatmap(period), {
+      onSuccess: (res) => {
+        setData(res.data ?? []);
+      },
+      onError: (e) => {
+        setError(e instanceof Error ? e.message : "Failed to load heatmap");
+      },
+      onFinally: () => {
+        setLoading(false);
+      },
+    });
   }, [period]);
 
   useEffect(() => {
@@ -1129,18 +1148,22 @@ function PerformanceSection() {
   const [data, setData] = useState<AnalyticsPerformanceData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const requestRef = useRef(0);
 
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
-    try {
-      const res = await api.getAnalyticsPerformance(period);
-      setData(res.data ?? null);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load performance data");
-    } finally {
-      setLoading(false);
-    }
+    await runLatestRequest(requestRef, () => api.getAnalyticsPerformance(period), {
+      onSuccess: (res) => {
+        setData(res.data ?? null);
+      },
+      onError: (e) => {
+        setError(e instanceof Error ? e.message : "Failed to load performance data");
+      },
+      onFinally: () => {
+        setLoading(false);
+      },
+    });
   }, [period]);
 
   useEffect(() => {
@@ -1297,25 +1320,30 @@ function CostSection() {
   const [saving, setSaving] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const requestRef = useRef(0);
 
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
-    try {
-      const [costRes, budgetRes] = await Promise.all([
-        api.getAnalyticsCost(period),
-        api.getAnalyticsBudget(),
-      ]);
-      setCostData(costRes.data ?? null);
-      setBudget(budgetRes.data ?? null);
-      if (budgetRes.data?.monthly_limit_usd != null) {
-        setLimitInput(String(budgetRes.data.monthly_limit_usd));
+    await runLatestRequest(
+      requestRef,
+      () => Promise.all([api.getAnalyticsCost(period), api.getAnalyticsBudget()]),
+      {
+        onSuccess: ([costRes, budgetRes]) => {
+          setCostData(costRes.data ?? null);
+          setBudget(budgetRes.data ?? null);
+          if (budgetRes.data?.monthly_limit_usd != null) {
+            setLimitInput(String(budgetRes.data.monthly_limit_usd));
+          }
+        },
+        onError: (e) => {
+          setError(e instanceof Error ? e.message : "Failed to load cost data");
+        },
+        onFinally: () => {
+          setLoading(false);
+        },
       }
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load cost data");
-    } finally {
-      setLoading(false);
-    }
+    );
   }, [period]);
 
   useEffect(() => {

--- a/web/src/pages/Sessions.tsx
+++ b/web/src/pages/Sessions.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import {
   api,
   type CorrectionLogEntry,
@@ -6,6 +6,7 @@ import {
   type SessionListItem,
   type SessionMessage,
 } from "../lib/api";
+import { runLatestRequest } from "../lib/latestRequest";
 import { useConfirm } from "../components/ConfirmDialog";
 import { useTranslation } from "react-i18next";
 
@@ -613,23 +614,32 @@ export function Sessions() {
   const [searchQuery, setSearchQuery] = useState("");
   const [chatTypeFilter, setChatTypeFilter] = useState("");
   const [selected, setSelected] = useState<SessionListItem | null>(null);
+  const sessionsRequestRef = useRef(0);
 
   const loadSessions = useCallback(async (p: number, q?: string, ct?: string) => {
     setLoading(true);
     setError(null);
-    try {
-      const res = await api.listSessions(p, limit, {
-        q: q || undefined,
-        chatType: ct || undefined,
-      });
-      setSessions(res.data.sessions);
-      setTotal(res.data.total);
-      setPage(p);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setLoading(false);
-    }
+    await runLatestRequest(
+      sessionsRequestRef,
+      () =>
+        api.listSessions(p, limit, {
+          q: q || undefined,
+          chatType: ct || undefined,
+        }),
+      {
+        onSuccess: (res) => {
+          setSessions(res.data.sessions);
+          setTotal(res.data.total);
+          setPage(p);
+        },
+        onError: (err) => {
+          setError(err instanceof Error ? err.message : String(err));
+        },
+        onFinally: () => {
+          setLoading(false);
+        },
+      }
+    );
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Что изменено

Fixes xlabtg/teleton-agent#618

- Добавлен общий helper `runLatestRequest`, который применяет `success`, `error` и `finally` только для последнего запущенного запроса.
- `Sessions` теперь защищает поиск, фильтр и пагинацию от устаревших ответов `api.listSessions`.
- `Analytics` защищает period-зависимые загрузчики usage/tools, anomalies, heatmap, performance и cost/budget.
- Добавлен регрессионный Vitest: медленный старый запрос завершается после быстрого нового и не перезаписывает состояние; stale error/finalizer тоже игнорируются.

## Как воспроизвести

1. Запустить загрузку списка или analytics периода, которая отвечает медленно.
2. До её завершения изменить фильтр/страницу/период так, чтобы ушёл новый быстрый запрос.
3. До исправления поздний старый ответ мог перезаписать состояние нового выбора.
4. После исправления состояние обновляет только последний request id.

## Проверка

- `npm run build:sdk`
- `cd web && npm run check:i18n`
- `npm test -- web/src/lib/__tests__/latestRequest.test.ts`
- `npm run typecheck`
- `npm run build:web`
- `npm run lint`
- `npm run test:coverage`
