### PR TITLE
fix(memory): ограничить amount в boostImpact/recordAccess значением MAX_BOOST_AMOUNT

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-17T09:53:27.699Z for PR creation at branch issue-620-331196f4beec for issue https://github.com/xlabtg/teleton-agent/issues/620

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-17T09:53:27.699Z for PR creation at branch issue-620-331196f4beec for issue https://github.com/xlabtg/teleton-agent/issues/620

--- a/src/constants/limits.ts
+++ b/src/constants/limits.ts
@@ -92,6 +92,10 @@ export const TOOL_RAG_KEYWORD_WEIGHT = 0.4;
 /** Age (in days) after which old transcripts and sessions are pruned at startup */
 export const SESSION_PRUNE_DAYS = 30;
 
+// ─── Memory Scoring ─────────────────────────────────────────────
+/** Maximum allowed value for boostImpact / recordAccess amount parameter */
+export const MAX_BOOST_AMOUNT = 100;
+
 // ─── Telegram Bridge ────────────────────────────────────────────
 /** Default number of messages to fetch when no limit is specified */
 export const DEFAULT_GET_MESSAGES_LIMIT = 50;

--- a/src/memory/__tests__/scoring-boost-clamp.test.ts
+++ b/src/memory/__tests__/scoring-boost-clamp.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { ensureSchema } from "../schema.js";
+import { MemoryScorer } from "../scoring.js";
+import { MAX_BOOST_AMOUNT } from "../../constants/limits.js";
+
+function createDb(): InstanceType<typeof Database> {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  ensureSchema(db);
+  return db;
+}
+
+function insertKnowledge(db: InstanceType<typeof Database>, id: string): void {
+  const now = Math.floor(Date.now() / 1000);
+  db.prepare(
+    `INSERT INTO knowledge (id, source, text, hash, created_at, updated_at)
+     VALUES (?, 'memory', ?, ?, ?, ?)`
+  ).run(id, `text-${id}`, `hash-${id}`, now, now);
+}
+
+describe("MemoryScorer — boost amount clamping (WORK6-015)", () => {
+  let db: InstanceType<typeof Database>;
+  let scorer: MemoryScorer;
+
+  beforeEach(() => {
+    db = createDb();
+    insertKnowledge(db, "m1");
+    scorer = new MemoryScorer(db);
+  });
+
+  it("clamps an out-of-range boostImpact amount to MAX_BOOST_AMOUNT", () => {
+    scorer.boostImpact(["m1"], 1e9);
+    const row = db
+      .prepare("SELECT impact_count FROM memory_scores WHERE memory_id = ?")
+      .get("m1") as { impact_count: number } | undefined;
+    expect(row).toBeDefined();
+    expect(row!.impact_count).toBeLessThanOrEqual(MAX_BOOST_AMOUNT);
+  });
+
+  it("clamps an out-of-range recordAccess amount to MAX_BOOST_AMOUNT", () => {
+    scorer.recordAccess(["m1"], 1e9);
+    const row = db
+      .prepare("SELECT access_count FROM memory_scores WHERE memory_id = ?")
+      .get("m1") as { access_count: number } | undefined;
+    expect(row).toBeDefined();
+    expect(row!.access_count).toBeLessThanOrEqual(MAX_BOOST_AMOUNT);
+  });
+
+  it("applies the full amount when within bounds", () => {
+    scorer.boostImpact(["m1"], 50);
+    const row = db
+      .prepare("SELECT impact_count FROM memory_scores WHERE memory_id = ?")
+      .get("m1") as { impact_count: number } | undefined;
+    expect(row!.impact_count).toBe(50);
+  });
+
+  it("treats non-finite boostImpact amount as minimum 1", () => {
+    scorer.boostImpact(["m1"], NaN);
+    const row = db
+      .prepare("SELECT impact_count FROM memory_scores WHERE memory_id = ?")
+      .get("m1") as { impact_count: number } | undefined;
+    expect(row!.impact_count).toBe(1);
+  });
+
+  it("treats negative boostImpact amount as minimum 1", () => {
+    scorer.boostImpact(["m1"], -5);
+    const row = db
+      .prepare("SELECT impact_count FROM memory_scores WHERE memory_id = ?")
+      .get("m1") as { impact_count: number } | undefined;
+    expect(row!.impact_count).toBe(1);
+  });
+});

--- a/src/memory/scoring.ts
+++ b/src/memory/scoring.ts
@@ -1,5 +1,5 @@
 import type Database from "better-sqlite3";
-import { SECONDS_PER_DAY } from "../constants/limits.js";
+import { MAX_BOOST_AMOUNT, SECONDS_PER_DAY } from "../constants/limits.js";
 
 export interface MemoryScoringWeights {
   recency: number;
@@ -148,6 +148,11 @@ function uniqueIds(memoryIds: string[]): string[] {
   return [...new Set(memoryIds.map((id) => id.trim()).filter(Boolean))];
 }
 
+function clampBoostAmount(amount: number): number {
+  if (!Number.isFinite(amount)) return 1;
+  return Math.min(MAX_BOOST_AMOUNT, Math.max(1, Math.floor(amount)));
+}
+
 export class MemoryScorer {
   private weights: MemoryScoringWeights;
   private halfLifeDays: number;
@@ -165,7 +170,7 @@ export class MemoryScorer {
     if (ids.length === 0) return;
 
     this.ensureScoreRows(ids);
-    const increment = Math.max(1, Math.floor(amount));
+    const increment = clampBoostAmount(amount);
     const update = this.db.prepare(
       `
       UPDATE memory_scores
@@ -190,7 +195,7 @@ export class MemoryScorer {
     if (ids.length === 0) return;
 
     this.ensureScoreRows(ids);
-    const increment = Math.max(1, Math.floor(amount));
+    const increment = clampBoostAmount(amount);
     const update = this.db.prepare(
       `
       UPDATE memory_scores

--- a/src/webui/routes/memory.ts
+++ b/src/webui/routes/memory.ts
@@ -8,6 +8,7 @@ import type {
   APIResponse,
 } from "../types.js";
 import { getErrorMessage } from "../../utils/errors.js";
+import { MAX_BOOST_AMOUNT } from "../../constants/limits.js";
 import { MemoryGraphStore } from "../../memory/graph-store.js";
 import { MemoryGraphQuery } from "../../memory/graph-query.js";
 import { HybridSearch } from "../../memory/search/hybrid.js";
@@ -249,8 +250,17 @@ export function createMemoryRoutes(deps: WebUIServerDeps) {
         return c.json(response, 400);
       }
 
+      const rawAmount = body.amount ?? 1;
+      if (!Number.isFinite(rawAmount) || rawAmount < 1) {
+        const response: APIResponse = {
+          success: false,
+          error: `amount must be a finite number >= 1 (max ${MAX_BOOST_AMOUNT})`,
+        };
+        return c.json(response, 400);
+      }
+
       const memoryScorer = scorer();
-      memoryScorer.boostImpact(ids, body.amount ?? 1);
+      memoryScorer.boostImpact(ids, rawAmount);
       const data = ids.map((id) => memoryScorer.getScore(id)).filter(Boolean);
       const response: APIResponse<typeof data> = {
         success: true,


### PR DESCRIPTION
## Проблема

`MemoryScorer.boostImpact()` и `recordAccess()` клампировали `amount` только снизу (минимум 1), не ограничивая верхнее значение. Любой клиент мог передать `amount: 1e9` через `POST /api/memory/boost` и произвольно поднять рейтинг памяти, доминируя в выдаче. Закрывает #620.

## Как воспроизвести (до фикса)

```bash
POST /api/memory/boost
{ "memoryIds": ["m1"], "amount": 1000000000 }
# m1 мгновенно занимает первое место в recall
```

## Решение

- Добавлена константа `MAX_BOOST_AMOUNT = 100` в `src/constants/limits.ts`
- Добавлена функция `clampBoostAmount(amount)` в `src/memory/scoring.ts`, которая:
  - отклоняет не-конечные значения (`NaN`, `Infinity`) → возвращает 1
  - клампирует отрицательные → 1
  - клампирует значения выше 100 → 100
- В маршруте `POST /scores/impact` добавлена валидация с ответом HTTP 400 для не-конечных/отрицательных значений

## Тест

Новый файл `src/memory/__tests__/scoring-boost-clamp.test.ts` содержит 5 тестов:
1. `boostImpact` с `1e9` клампируется до `MAX_BOOST_AMOUNT`
2. `recordAccess` с `1e9` клампируется до `MAX_BOOST_AMOUNT`
3. Значение в допустимом диапазоне (50) применяется как есть
4. `NaN` трактуется как 1
5. Отрицательное значение трактуется как 1

```
✓ clamps an out-of-range boostImpact amount to MAX_BOOST_AMOUNT
✓ clamps an out-of-range recordAccess amount to MAX_BOOST_AMOUNT
✓ applies the full amount when within bounds
✓ treats non-finite boostImpact amount as minimum 1
✓ treats negative boostImpact amount as minimum 1
```

## Критерии приёмки

- [x] `amount` клампируется к задокументированному максимуму на уровне API и в scorer
- [x] Не-конечные/отрицательные значения отклоняются


Fixes xlabtg/teleton-agent#620