### PR TITLE
fix(sessions): защита от краша при malformed 2xx ответе (issue #621)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-17T10:16:34.823Z for PR creation at branch issue-621-f05a7ecc0a1e for issue https://github.com/xlabtg/teleton-agent/issues/621

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-17T10:16:34.823Z for PR creation at branch issue-621-f05a7ecc0a1e for issue https://github.com/xlabtg/teleton-agent/issues/621

--- a/web/src/lib/__tests__/sessionsDataGuards.test.ts
+++ b/web/src/lib/__tests__/sessionsDataGuards.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+// Simulate the data-extraction logic from SessionDetail.loadMessages so we can
+// verify that a malformed 2xx response (res.data === undefined) yields safe
+// defaults instead of throwing.
+function extractSessionData(
+  resData: { messages?: unknown[]; total?: number } | undefined,
+  correctionResData: { corrections?: unknown[] } | undefined
+) {
+  const messages = resData?.messages ?? [];
+  const total = resData?.total ?? 0;
+  const corrections = correctionResData?.corrections ?? [];
+  return { messages, total, corrections };
+}
+
+describe("Sessions page – malformed 2xx response guards (issue #621)", () => {
+  it("returns empty defaults when res.data is undefined", () => {
+    const { messages, total, corrections } = extractSessionData(
+      undefined,
+      undefined
+    );
+    expect(messages).toEqual([]);
+    expect(total).toBe(0);
+    expect(corrections).toEqual([]);
+  });
+
+  it("returns empty defaults when res.data is an empty object", () => {
+    const { messages, total, corrections } = extractSessionData({}, {});
+    expect(messages).toEqual([]);
+    expect(total).toBe(0);
+    expect(corrections).toEqual([]);
+  });
+
+  it("returns populated data when res.data is well-formed", () => {
+    const msg = { id: "1", text: "hello" };
+    const correction = { id: "c1" };
+    const { messages, total, corrections } = extractSessionData(
+      { messages: [msg], total: 1 },
+      { corrections: [correction] }
+    );
+    expect(messages).toEqual([msg]);
+    expect(total).toBe(1);
+    expect(corrections).toEqual([correction]);
+  });
+
+  it("messages is always an array so .length and .map() never throw", () => {
+    const { messages } = extractSessionData(undefined, undefined);
+    expect(() => messages.length).not.toThrow();
+    expect(() => messages.map((m) => m)).not.toThrow();
+  });
+});

--- a/web/src/pages/Sessions.tsx
+++ b/web/src/pages/Sessions.tsx
@@ -402,9 +402,9 @@ function SessionDetail({
           api.getSessionCorrections(session.sessionId),
           api.getFeedback({ session: session.sessionId, limit: 500 }),
         ]);
-        setMessages(res.data.messages);
-        setTotal(res.data.total);
-        setCorrections(correctionRes.data.corrections);
+        setMessages(res.data?.messages ?? []);
+        setTotal(res.data?.total ?? 0);
+        setCorrections(correctionRes.data?.corrections ?? []);
         const nextFeedbackByMessage: Record<string, FeedbackRecord> = {};
         for (const record of feedbackRes.data?.feedback ?? []) {
           if (record.messageId && !nextFeedbackByMessage[record.messageId]) {


### PR DESCRIPTION
## Суть проблемы

Страница Sessions падала с «Cannot read properties of undefined» при получении 2xx ответа с пустым/дефектным телом от API. В `SessionDetail.loadMessages` (строки 405–407) поля читались без защиты:

```ts
setMessages(res.data.messages);   // throws if res.data === undefined
setTotal(res.data.total);
setCorrections(correctionRes.data.corrections);
```

## Исправление

Добавлены опциональная цепочка и значения по умолчанию:

```ts
setMessages(res.data?.messages ?? []);
setTotal(res.data?.total ?? 0);
setCorrections(correctionRes.data?.corrections ?? []);
```

Теперь при `res.data === undefined` компонент отображает пустое состояние вместо краша.

## Тест

Добавлен `web/src/lib/__tests__/sessionsDataGuards.test.ts` — 4 тест-кейса, воспроизводящих сценарий malformed ответа:
- `res.data === undefined` → пустые массивы, `total = 0`, без ошибок
- `res.data === {}` → аналогично
- Корректный ответ → данные передаются без изменений
- `messages.length` и `messages.map()` никогда не кидают исключение

## Файлы изменений

- `web/src/pages/Sessions.tsx` — 3 строки: добавлены `?.` и `?? []`/`?? 0`
- `web/src/lib/__tests__/sessionsDataGuards.test.ts` — новый тест

Fixes xlabtg/teleton-agent#621