### PR TITLE
fix(registry): логировать предупреждение при коллизии имён в registerPluginTools (#623)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-17T10:38:25.821Z for PR creation at branch issue-623-d5a82ce1dee5 for issue https://github.com/xlabtg/teleton-agent/issues/623

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-17T10:38:25.821Z for PR creation at branch issue-623-d5a82ce1dee5 for issue https://github.com/xlabtg/teleton-agent/issues/623

--- a/src/agent/tools/__tests__/registry.test.ts
+++ b/src/agent/tools/__tests__/registry.test.ts
@@ -7,7 +7,20 @@ import type { Tool, ToolExecutor, ToolContext, ToolScope } from "../types.js";
 import type { ToolCall } from "@mariozechner/pi-ai";
 import { PolicyEngine } from "../../../services/policy-engine.js";
 
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
 // Mock modules
+vi.mock("../../../utils/logger.js", () => ({
+  createLogger: () => mockLogger,
+}));
+
 vi.mock("@mariozechner/pi-ai", () => ({
   validateToolCall: vi.fn((tools, toolCall) => toolCall.arguments),
 }));
@@ -748,6 +761,24 @@ describe("ToolRegistry", () => {
 
       const count = registry.registerPluginTools("test-plugin", pluginTools);
       expect(count).toBe(0);
+    });
+
+    it("should warn when a plugin tool name collides with an existing tool", () => {
+      const tool = createMockTool("collision_tool");
+      registry.register(tool, createMockExecutor());
+
+      const pluginTools = [
+        {
+          tool,
+          executor: createMockExecutor(),
+          scope: "always" as ToolScope,
+        },
+      ];
+
+      registry.registerPluginTools("test-plugin", pluginTools);
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("collision_tool"));
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("test-plugin"));
     });
 
     it("should set module name to plugin name", () => {

--- a/src/agent/tools/registry.ts
+++ b/src/agent/tools/registry.ts
@@ -437,7 +437,12 @@ export class ToolRegistry {
   ): number {
     const names: string[] = [];
     for (const { tool, executor, scope, mode } of tools) {
-      if (this.tools.has(tool.name)) continue;
+      if (this.tools.has(tool.name)) {
+        log.warn(
+          `Plugin "${pluginName}" tool "${tool.name}" collides with an existing tool — skipped`
+        );
+        continue;
+      }
       this.insertTool(tool.name, {
         tool,
         executor,


### PR DESCRIPTION
## Проблема

`ToolRegistry.registerPluginTools` молча пропускал инструмент при коллизии имён (`continue` без лога), тогда как `replacePluginTools` при той же ситуации логировал предупреждение. Авторы плагинов не получали никакой диагностики о потере своих инструментов при регистрации.

Closes #623

## Решение

Добавлен `log.warn` в `registerPluginTools` при пропуске коллизирующего инструмента — поведение приведено в соответствие с `replacePluginTools`.

**До:**
```ts
if (this.tools.has(tool.name)) continue;  // молча пропускает
```

**После:**
```ts
if (this.tools.has(tool.name)) {
  log.warn(
    `Plugin "${pluginName}" tool "${tool.name}" collides with an existing tool — skipped`
  );
  continue;
}
```

## Тест

Добавлен тест в `src/agent/tools/__tests__/registry.test.ts`, проверяющий что `log.warn` вызывается с именем плагина и именем коллизирующего инструмента.

## Как воспроизвести проблему

1. Зарегистрировать инструмент с именем `foo_tool`
2. Вызвать `registerPluginTools("my-plugin", [{ tool: fooTool, executor }])`
3. До исправления: инструмент молча пропускается, в логах ничего нет
4. После исправления: `warn: Plugin "my-plugin" tool "foo_tool" collides with an existing tool — skipped`