### PR TITLE
fix(setup): запускать агента после веб-настройки

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-18T19:32:20.864Z for PR creation at branch issue-665-989a308f0d2d for issue https://github.com/xlabtg/teleton-agent/issues/665

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-18T19:32:20.864Z for PR creation at branch issue-665-989a308f0d2d for issue https://github.com/xlabtg/teleton-agent/issues/665

--- a/e2e/fixtures/mock-backend.ts
+++ b/e2e/fixtures/mock-backend.ts
@@ -165,6 +165,9 @@ export async function setupMockBackend(
     }
 
     // ── Auth (not under /api) ──────────────────────────────────────────
+    if (path === "/auth/exchange") {
+      return route.continue();
+    }
     if (path === "/auth/check") {
       return json(route, ok({ authenticated }));
     }
@@ -255,6 +258,9 @@ export async function setupMockBackend(
     }
     if (path === "/api/setup/config/save") {
       return json(route, ok({ path: "/tmp/teleton-workspace/config.yaml" }));
+    }
+    if (path === "/api/setup/launch") {
+      return json(route, ok({ token: "agent-token" }));
     }
 
     // ── Agent status / control ─────────────────────────────────────────

--- a/e2e/setup.spec.ts
+++ b/e2e/setup.spec.ts
@@ -9,7 +9,7 @@ import { setupMockBackend } from "./fixtures/mock-backend";
 test("setup wizard completes end to end", async ({ page }) => {
   await setupMockBackend(page);
 
-  await page.goto("/setup");
+  await page.goto("/setup#nonce=test-nonce");
 
   const next = page.getByRole("button", { name: /^Next:/ });
 
@@ -44,15 +44,22 @@ test("setup wizard completes end to end", async ({ page }) => {
   // exact match: the API Hash placeholder substring-contains "12345678".
   await page.getByPlaceholder("12345678", { exact: true }).fill("12345678");
   await page.getByPlaceholder("abcdef0123456789abcdef0123456789").fill("abcdef0123456789");
+  await page.getByPlaceholder("+33612345678").fill("+33612345678");
+  await expect(next).toBeEnabled();
   await next.click();
 
   // ── Step 6: Connect — start the QR flow; the mock authenticates on poll. ──
   await expect(page.getByRole("heading", { name: "Connect your Agent to Telegram" })).toBeVisible();
+  const launchRequest = page.waitForRequest(
+    (request) => request.method() === "POST" && request.url().endsWith("/api/setup/launch")
+  );
   await page.getByRole("button", { name: "Show QR Code" }).click();
   await expect(page.getByText("Waiting for scan...")).toBeVisible();
 
-  // The QR poll (every 5s) authenticates, auto-saves, and shows completion.
+  // The QR poll (every 5s) authenticates, auto-saves, shows completion, and
+  // starts the agent without requiring a manual click or console command.
   await expect(page.getByRole("heading", { name: "Your Agent is ready" })).toBeVisible({
     timeout: 20_000,
   });
+  await launchRequest;
 });

--- a/web/src/components/setup/SetupComplete.tsx
+++ b/web/src/components/setup/SetupComplete.tsx
@@ -16,8 +16,16 @@ function LottiePlayer() {
   );
 }
 
+let autoLaunchStarted = false;
+
 export function SetupComplete() {
   const { launching, launchError, handleLaunch } = useSetup();
+
+  useEffect(() => {
+    if (autoLaunchStarted) return;
+    autoLaunchStarted = true;
+    void handleLaunch();
+  }, [handleLaunch]);
 
   return (
     <div className="step-content text-center" style={{ paddingTop: '40px' }}>
@@ -27,7 +35,7 @@ export function SetupComplete() {
         Your Agent is ready
       </h2>
       <p style={{ color: 'var(--text-secondary)', fontSize: '14px', marginBottom: '32px' }}>
-        Configuration saved. Start your agent to begin.
+        Configuration saved. Starting your agent...
       </p>
 
       <button
@@ -36,7 +44,15 @@ export function SetupComplete() {
         className="btn-lg"
         style={{ minWidth: '200px' }}
       >
-        {launching ? <><span className="spinner sm" /> Starting...</> : 'Start Agent'}
+        {launching ? (
+          <>
+            <span className="spinner sm" /> Starting...
+          </>
+        ) : launchError ? (
+          'Retry Start Agent'
+        ) : (
+          'Start Agent'
+        )}
       </button>
 
       {launching && (

--- a/web/src/components/setup/SetupContext.tsx
+++ b/web/src/components/setup/SetupContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useCallback, useEffect, useRef, type ReactNode } from 'react';
-import { setup, SetupConfig } from '../../lib/api';
+import { setup, SetupConfig, SETUP_AGENT_LAUNCH_TIMEOUT_MS } from '../../lib/api';
 
 // ── Step metadata ───────────────────────────────────────────────────
 
@@ -292,7 +292,7 @@ export function SetupProvider({ children }: { children: ReactNode }) {
       }
       const { token } = await setup.launch(nonce);
       // Poll until the agent WebUI is up
-      await setup.pollHealth(30000);
+      await setup.pollHealth(SETUP_AGENT_LAUNCH_TIMEOUT_MS);
       // Redirect to the dashboard with token-based auth
       window.location.href = `/auth/exchange?token=${encodeURIComponent(token)}`;
     } catch (err) {

--- a/web/src/lib/__tests__/api.test.ts
+++ b/web/src/lib/__tests__/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { api, setup } from "../api";
+import { api, setup, SETUP_AGENT_LAUNCH_TIMEOUT_MS } from "../api";
 
 describe("web API client CSRF handling", () => {
   afterEach(() => {
@@ -43,6 +43,7 @@ describe("web API client CSRF handling", () => {
 
 describe("setup API client", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -88,6 +89,38 @@ describe("setup API client", () => {
         }),
       })
     );
+  });
+
+  it("keeps polling long enough for a slow first WebUI handoff", async () => {
+    vi.useFakeTimers();
+
+    let healthChecks = 0;
+    const fetchMock = vi.fn(async () => {
+      healthChecks += 1;
+      const ready = healthChecks >= 31;
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: ready ? { authenticated: false } : { setup: true },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const poll = setup.pollHealth();
+    await vi.advanceTimersByTimeAsync(35_000);
+
+    await expect(poll).resolves.toBeUndefined();
+    expect(SETUP_AGENT_LAUNCH_TIMEOUT_MS).toBeGreaterThan(30_000);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/auth/check",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    expect(healthChecks).toBeGreaterThanOrEqual(31);
   });
 });
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,8 @@
 const API_BASE = "/api";
+export const SETUP_AGENT_LAUNCH_TIMEOUT_MS = 120_000;
+const SETUP_AGENT_INITIAL_POLL_DELAY_MS = 1_500;
+const SETUP_AGENT_POLL_INTERVAL_MS = 1_000;
+const SETUP_AGENT_POLL_REQUEST_TIMEOUT_MS = 2_000;
 
 // ── Dynamic Dashboard types ──────────────────────────────────────────────────
 
@@ -4609,15 +4613,16 @@ export const setup = {
       headers: { "X-Setup-Nonce": nonce },
     }),
 
-  pollHealth: async (timeoutMs = 30000): Promise<void> => {
+  pollHealth: async (timeoutMs = SETUP_AGENT_LAUNCH_TIMEOUT_MS): Promise<void> => {
     const start = Date.now();
-    const interval = 1000;
     // Wait a beat for the server to restart
-    await new Promise((r) => setTimeout(r, 1500));
+    await new Promise((r) => setTimeout(r, SETUP_AGENT_INITIAL_POLL_DELAY_MS));
 
     while (Date.now() - start < timeoutMs) {
       try {
-        const authRes = await fetch("/auth/check", { signal: AbortSignal.timeout(2000) });
+        const authRes = await fetch("/auth/check", {
+          signal: AbortSignal.timeout(SETUP_AGENT_POLL_REQUEST_TIMEOUT_MS),
+        });
         if (authRes.ok) {
           const json = await authRes.json();
           // The setup server returns { data: { setup: true } } — reject it.
@@ -4627,7 +4632,7 @@ export const setup = {
       } catch {
         // Server not up yet (connection refused, timeout, etc.)
       }
-      await new Promise((r) => setTimeout(r, interval));
+      await new Promise((r) => setTimeout(r, SETUP_AGENT_POLL_INTERVAL_MS));
     }
     throw new Error("Agent did not start within the expected time");
   },


### PR DESCRIPTION
## Что исправлено

Fixes xlabtg/teleton-agent#665.

После завершения `teleton setup --ui` финальный экран больше не требует ручного запуска агента из консоли. Экран завершения сам вызывает nonce-gated `/api/setup/launch`, дожидается поднятия основного WebUI и переводит пользователя через `/auth/exchange`.

Дополнительно увеличено окно ожидания первого handoff с 30 до 120 секунд, чтобы медленный старт агента не завершался преждевременной ошибкой `Agent did not start within the expected time`.

## Как воспроизвести

1. Запустить настройку через `teleton setup --ui` и открыть URL с `#nonce=...`.
2. Пройти web-мастер настройки до успешного Telegram-подключения.
3. Раньше финальный экран показывал кнопку запуска, мог упасть по 30-секундному timeout и предлагал `teleton start` вручную.
4. Теперь агент стартует автоматически после сохранения конфигурации; ручной запуск остаётся только fallback при реальной ошибке.

## Проверки

- `npm test -- --run web/src/lib/__tests__/api.test.ts`
- `npm run typecheck`
- `(cd web && npm run typecheck)`
- `npm run lint`
- `npm run test:e2e -- e2e/setup.spec.ts`

Примечание: e2e-сборка сохраняет существующие предупреждения Vite про `lottie-web`/размер чанков; тест проходит.
