### PR TITLE
fix(marketplace): показывать плагины marketplace

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-20T16:47:00.847Z for PR creation at branch issue-673-8e522c357e55 for issue https://github.com/xlabtg/teleton-agent/issues/673

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-20T16:47:00.847Z for PR creation at branch issue-673-8e522c357e55 for issue https://github.com/xlabtg/teleton-agent/issues/673

--- a/package-lock.json
+++ b/package-lock.json
@@ -4298,16 +4298,6 @@
         "npm": ">=9.5.0"
       }
     },
-    "node_modules/@redocly/respect-core/node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",

--- a/package.json
+++ b/package.json
@@ -154,6 +154,9 @@
     "@mariozechner/pi-ai": {
       "undici": "7.28.0"
     },
+    "@redocly/respect-core": {
+      "undici": "6.27.0"
+    },
     "@mistralai/mistralai": {
       "ws": "8.21.0"
     },

--- a/src/webui/__tests__/marketplace-routes.test.ts
+++ b/src/webui/__tests__/marketplace-routes.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { Hono } from "hono";
+import { createMarketplaceRoutes } from "../routes/marketplace.js";
+import type { WebUIServerDeps } from "../types.js";
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+vi.mock("../../agent/tools/plugin-loader.js", () => ({
+  adaptPlugin: vi.fn(),
+  ensurePluginDeps: vi.fn(),
+}));
+
+vi.mock("../../sdk/secrets.js", () => ({
+  deletePluginSecret: vi.fn(),
+  listPluginSecretKeys: vi.fn(() => []),
+  writePluginSecret: vi.fn(),
+}));
+
+vi.mock("../../config/configurable-keys.js", () => ({
+  readRawConfig: vi.fn(),
+  writeRawConfig: vi.fn(),
+}));
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function createApp(fetchMock: ReturnType<typeof vi.fn>, marketplaceOverrides = {}) {
+  vi.stubGlobal("fetch", fetchMock);
+
+  const deps = {
+    plugins: [],
+    configPath: "config.test.yaml",
+    toolRegistry: {
+      getModuleTools: vi.fn(() => []),
+      getAll: vi.fn(() => []),
+      isPluginModule: vi.fn(() => false),
+    },
+    marketplace: {
+      modules: [],
+      config: {
+        marketplace: {
+          extra_sources: [],
+        },
+      },
+      sdkDeps: {},
+      pluginContext: {},
+      loadedModuleNames: [],
+      rewireHooks: vi.fn(),
+      ...marketplaceOverrides,
+    },
+  } as unknown as WebUIServerDeps;
+
+  const app = new Hono();
+  app.route("/marketplace", createMarketplaceRoutes(deps));
+  return app;
+}
+
+describe("Marketplace routes", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads custom sources whose enabled flag is omitted and normalizes optional entry fields", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (
+        url === "https://raw.githubusercontent.com/TONresistor/teleton-plugins/main/registry.json"
+      ) {
+        return jsonResponse({ version: "1.0.0", plugins: [] });
+      }
+      if (url === "https://raw.githubusercontent.com/acme/plugins/main/registry.json") {
+        return jsonResponse({
+          version: "1.0.0",
+          plugins: [{ id: "alpha", name: "Alpha Plugin", path: "plugins/alpha" }],
+        });
+      }
+      if (
+        url === "https://raw.githubusercontent.com/acme/plugins/main/plugins/alpha/manifest.json"
+      ) {
+        return jsonResponse({
+          name: "Alpha Plugin",
+          version: "1.2.3",
+          description: "Alpha from manifest",
+          author: { name: "acme" },
+          tags: ["custom"],
+          tools: [{ name: "alpha_run", description: "Run alpha" }],
+        });
+      }
+      return jsonResponse({ error: "not found" }, 404);
+    });
+
+    const app = createApp(fetchMock, {
+      config: {
+        marketplace: {
+          extra_sources: [
+            {
+              url: "https://raw.githubusercontent.com/acme/plugins/main/registry.json",
+              label: "Acme",
+            },
+          ],
+        },
+      },
+    });
+
+    const res = await app.request("/marketplace");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual([
+      expect.objectContaining({
+        id: "alpha",
+        name: "Alpha Plugin",
+        description: "Alpha from manifest",
+        author: "acme",
+        tags: ["custom"],
+        remoteVersion: "1.2.3",
+        source: "custom",
+        sourceLabel: "Acme",
+        tools: [{ name: "alpha_run", description: "Run alpha" }],
+      }),
+    ]);
+  });
+
+  it("reports registry load failures instead of returning a successful empty marketplace", async () => {
+    const app = createApp(
+      vi.fn(async () => {
+        throw new Error("network down");
+      })
+    );
+
+    const res = await app.request("/marketplace");
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("No marketplace registry sources could be loaded");
+  });
+});

--- a/src/webui/services/marketplace.ts
+++ b/src/webui/services/marketplace.ts
@@ -19,6 +19,7 @@ import type {
   MarketplaceSource,
 } from "../types.js";
 import { createLogger } from "../../utils/logger.js";
+import { getErrorMessage } from "../../utils/errors.js";
 
 const log = createLogger("WebUI");
 
@@ -42,6 +43,7 @@ interface ManifestData {
   version: string;
   description?: string;
   author?: string;
+  tags?: string[];
   tools?: Array<{ name: string; description: string }>;
   secrets?: Record<string, { required: boolean; description: string; env?: string }>;
 }
@@ -103,6 +105,11 @@ function isTrustedGitHubDownloadUrl(rawUrl: string): boolean {
   }
 }
 
+function normalizeTags(tags: unknown): string[] {
+  if (!Array.isArray(tags)) return [];
+  return tags.filter((tag): tag is string => typeof tag === "string" && tag.length > 0);
+}
+
 export class MarketplaceService {
   private deps: ServiceDeps;
   // Per-source cache keyed by registryUrl
@@ -130,7 +137,7 @@ export class MarketplaceService {
 
     const extra = this.deps.config.marketplace?.extra_sources ?? [];
     for (const s of extra) {
-      if (!s.enabled) continue;
+      if (s.enabled === false) continue;
       const { pluginBaseUrl, githubApiBase } = deriveSourceUrls(s.url);
       sources.push({
         registryUrl: s.url,
@@ -178,11 +185,13 @@ export class MarketplaceService {
 
     const merged: RegistryEntry[] = [];
     const seen = new Set<string>();
+    const failures: string[] = [];
 
     for (let i = 0; i < sources.length; i++) {
       const result = allEntries[i];
       const src = sources[i];
       if (result.status === "rejected") {
+        failures.push(`${src.label}: ${getErrorMessage(result.reason)}`);
         log.warn({ err: result.reason }, `Registry fetch failed for ${src.registryUrl}`);
         continue;
       }
@@ -195,6 +204,10 @@ export class MarketplaceService {
           });
         }
       }
+    }
+
+    if (merged.length === 0 && failures.length === sources.length) {
+      throw new Error(`No marketplace registry sources could be loaded: ${failures.join("; ")}`);
     }
 
     return merged;
@@ -239,18 +252,34 @@ export class MarketplaceService {
     const plugins = Array.isArray(data) ? data : data?.plugins;
     if (!Array.isArray(plugins)) throw new Error("Registry has no plugins array");
 
-    // Validate each entry — defense-in-depth against poisoned registries
+    // Validate and normalize each entry — defense-in-depth against poisoned registries
     const VALID_PATH = /^[a-zA-Z0-9][a-zA-Z0-9._\/-]*$/;
-    for (const entry of plugins) {
-      if (!entry.id || !entry.name || !entry.path) {
-        throw new Error(`Invalid registry entry: missing required fields (id=${entry.id ?? "?"})`);
+    return plugins.map((rawEntry: unknown) => {
+      if (!rawEntry || typeof rawEntry !== "object") {
+        throw new Error("Invalid registry entry: expected object");
       }
-      if (!VALID_PATH.test(entry.path) || entry.path.includes("..")) {
-        throw new Error(`Invalid registry path for "${entry.id}": "${entry.path}"`);
-      }
-    }
 
-    return plugins as RegistryEntry[];
+      const entry = rawEntry as Record<string, unknown>;
+      const id = typeof entry.id === "string" ? entry.id : "";
+      const name = typeof entry.name === "string" ? entry.name : "";
+      const path = typeof entry.path === "string" ? entry.path : "";
+
+      if (!id || !name || !path) {
+        throw new Error(`Invalid registry entry: missing required fields (id=${id || "?"})`);
+      }
+      if (!VALID_PATH.test(path) || path.includes("..")) {
+        throw new Error(`Invalid registry path for "${id}": "${path}"`);
+      }
+
+      return {
+        id,
+        name,
+        description: typeof entry.description === "string" ? entry.description : "",
+        author: entry.author === undefined ? "unknown" : normalizeAuthor(entry.author),
+        tags: normalizeTags(entry.tags),
+        path,
+      };
+    });
   }
 
   // ── Remote manifest ─────────────────────────────────────────────────
@@ -274,13 +303,22 @@ export class MarketplaceService {
         version: "0.0.0",
         description: entry.description,
         author: entry.author,
+        tags: entry.tags,
       };
     }
-    const raw = await res.json();
+    const raw = (await res.json()) as Record<string, unknown>;
     // Normalize author: manifest may have { name, url } object or a plain string
     const data: ManifestData = {
-      ...raw,
-      author: normalizeAuthor(raw.author),
+      name: typeof raw.name === "string" ? raw.name : entry.name,
+      version: typeof raw.version === "string" ? raw.version : "0.0.0",
+      description: typeof raw.description === "string" ? raw.description : entry.description,
+      author: raw.author === undefined ? entry.author : normalizeAuthor(raw.author),
+      tags: normalizeTags(raw.tags),
+      tools: Array.isArray(raw.tools) ? (raw.tools as ManifestData["tools"]) : undefined,
+      secrets:
+        raw.secrets && typeof raw.secrets === "object"
+          ? (raw.secrets as ManifestData["secrets"])
+          : undefined,
     };
     this.manifestCache.set(cacheKey, { data, fetchedAt: Date.now() });
     return data;
@@ -298,11 +336,16 @@ export class MarketplaceService {
 
     const results: MarketplacePlugin[] = [];
     const seenIds = new Set<string>();
+    const registryFailures: string[] = [];
 
     for (let si = 0; si < sources.length; si++) {
       const src = sources[si];
       const regResult = registryResults[si];
-      if (regResult.status === "rejected") continue;
+      if (regResult.status === "rejected") {
+        registryFailures.push(`${src.label}: ${getErrorMessage(regResult.reason)}`);
+        log.warn({ err: regResult.reason }, `Registry fetch failed for ${src.registryUrl}`);
+        continue;
+      }
 
       const registry = regResult.value;
 
@@ -327,7 +370,9 @@ export class MarketplaceService {
                 version: "0.0.0",
                 description: entry.description,
                 author: entry.author,
+                tags: entry.tags,
               };
+        const manifestTags = normalizeTags(manifest.tags);
 
         // Cross-reference with loaded modules
         const installed = this.deps.modules.find(
@@ -369,7 +414,7 @@ export class MarketplaceService {
           name: entry.name,
           description: manifest.description || entry.description,
           author: manifest.author || entry.author,
-          tags: entry.tags,
+          tags: manifestTags.length > 0 ? manifestTags : entry.tags,
           remoteVersion,
           installedVersion,
           status,
@@ -380,6 +425,12 @@ export class MarketplaceService {
           sourceLabel: src.label,
         });
       }
+    }
+
+    if (results.length === 0 && registryFailures.length === sources.length) {
+      throw new Error(
+        `No marketplace registry sources could be loaded: ${registryFailures.join("; ")}`
+      );
     }
 
     return results;


### PR DESCRIPTION
## Что изменено
- Исправлена загрузка источников marketplace: дополнительные источники без поля `enabled` теперь считаются включенными, как это уже отображалось в UI.
- Реестр marketplace нормализует необязательные поля `description`, `author` и `tags`, чтобы минимальные записи реестра не ломали список плагинов.
- Если все источники реестра недоступны, API теперь возвращает ошибку вместо успешного пустого marketplace.
- Обновлен npm override/lockfile для `@redocly/respect-core > undici`, чтобы `audit:ci` больше не падал на high advisory `GHSA-vxpw-j846-p89q`.

## Как воспроизвести
1. Добавить marketplace source без `enabled` и с минимальной записью плагина в `registry.json`.
2. Открыть `/marketplace`.
3. До исправления источник пропускался, и список плагинов оставался пустым.

## Проверка
- `npm run build -w packages/sdk`
- `npm run test -- src/webui/__tests__/marketplace-routes.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build:backend`
- `npm run audit:ci`

Fixes xlabtg/teleton-agent#673
