### PR TITLE
fix(memory): исправить повреждение внешних FTS-индексов

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-13T23:43:55.254Z for PR creation at branch issue-691-16c7ac451187 for issue https://github.com/xlabtg/teleton-agent/issues/691

--- a/src/memory/__tests__/schema.test.ts
+++ b/src/memory/__tests__/schema.test.ts
@@ -1495,7 +1495,7 @@ describe("Memory Schema", () => {
     });
 
     it("CURRENT_SCHEMA_VERSION is set to expected value", () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe("1.40.0");
+      expect(CURRENT_SCHEMA_VERSION).toBe("1.41.0");
     });
   });
 
@@ -1743,6 +1743,134 @@ describe("Memory Schema", () => {
 
       expect(replacedAfterMigration).toHaveLength(0);
       expect(updatedAfterMigration).toEqual([{ id: "msg1", text: "finaltoken message" }]);
+      expect(getSchemaVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
+    });
+
+    it("runMigrations from version 1.40.0 repairs and rebuilds external-content FTS indexes", () => {
+      ensureSchema(db);
+      db.exec(`
+        CREATE TABLE tool_index (
+          name TEXT PRIMARY KEY,
+          description TEXT NOT NULL,
+          search_text TEXT NOT NULL,
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+        );
+        CREATE VIRTUAL TABLE tool_index_fts USING fts5(
+          search_text,
+          name UNINDEXED,
+          content='tool_index',
+          content_rowid='rowid'
+        );
+        CREATE TRIGGER tool_index_fts_insert AFTER INSERT ON tool_index BEGIN
+          INSERT INTO tool_index_fts(rowid, search_text, name)
+          VALUES (new.rowid, new.search_text, new.name);
+        END;
+        CREATE TRIGGER tool_index_fts_delete AFTER DELETE ON tool_index BEGIN
+          DELETE FROM tool_index_fts WHERE rowid = old.rowid;
+        END;
+        CREATE TRIGGER tool_index_fts_update AFTER UPDATE ON tool_index BEGIN
+          DELETE FROM tool_index_fts WHERE rowid = old.rowid;
+          INSERT INTO tool_index_fts(rowid, search_text, name)
+          VALUES (new.rowid, new.search_text, new.name);
+        END;
+      `);
+      db.prepare(
+        `INSERT INTO knowledge (id, source, text, hash)
+         VALUES ('k1', 'memory', 'knowledgeoldtoken', 'hash1')`
+      ).run();
+      db.prepare(
+        `INSERT INTO tool_index (name, description, search_text)
+         VALUES ('tool1', 'Tool one', 'toololdtoken')`
+      ).run();
+
+      db.exec(`
+        DROP TRIGGER knowledge_fts_delete;
+        DROP TRIGGER knowledge_fts_update;
+        CREATE TRIGGER knowledge_fts_delete AFTER DELETE ON knowledge BEGIN
+          DELETE FROM knowledge_fts WHERE rowid = old.rowid;
+        END;
+        CREATE TRIGGER knowledge_fts_update AFTER UPDATE ON knowledge BEGIN
+          DELETE FROM knowledge_fts WHERE rowid = old.rowid;
+          INSERT INTO knowledge_fts(rowid, text, id, path, source)
+          VALUES (new.rowid, new.text, new.id, new.path, new.source);
+        END;
+      `);
+
+      db.prepare(`UPDATE knowledge SET text = 'knowledgecurrenttoken' WHERE id = 'k1'`).run();
+      db.prepare(
+        `UPDATE tool_index SET search_text = 'toolcurrenttoken' WHERE name = 'tool1'`
+      ).run();
+
+      expect(
+        db
+          .prepare(`SELECT rowid FROM knowledge_fts WHERE knowledge_fts MATCH 'knowledgeoldtoken'`)
+          .all()
+      ).toHaveLength(1);
+      expect(
+        db
+          .prepare(`SELECT rowid FROM tool_index_fts WHERE tool_index_fts MATCH 'toololdtoken'`)
+          .all()
+      ).toHaveLength(1);
+
+      setSchemaVersion(db, "1.40.0");
+      runMigrations(db);
+
+      expect(
+        db
+          .prepare(`SELECT rowid FROM knowledge_fts WHERE knowledge_fts MATCH 'knowledgeoldtoken'`)
+          .all()
+      ).toHaveLength(0);
+      expect(
+        db
+          .prepare(`SELECT rowid FROM tool_index_fts WHERE tool_index_fts MATCH 'toololdtoken'`)
+          .all()
+      ).toHaveLength(0);
+      expect(
+        db
+          .prepare(`SELECT id FROM knowledge_fts WHERE knowledge_fts MATCH 'knowledgecurrenttoken'`)
+          .all()
+      ).toEqual([{ id: "k1" }]);
+      expect(
+        db
+          .prepare(`SELECT name FROM tool_index_fts WHERE tool_index_fts MATCH 'toolcurrenttoken'`)
+          .all()
+      ).toEqual([{ name: "tool1" }]);
+
+      db.prepare(`UPDATE knowledge SET text = 'knowledgefinaltoken' WHERE id = 'k1'`).run();
+      db.prepare(`UPDATE tool_index SET search_text = 'toolfinaltoken' WHERE name = 'tool1'`).run();
+      expect(
+        db
+          .prepare(
+            `SELECT rowid FROM knowledge_fts WHERE knowledge_fts MATCH 'knowledgecurrenttoken'`
+          )
+          .all()
+      ).toHaveLength(0);
+      expect(
+        db
+          .prepare(`SELECT rowid FROM tool_index_fts WHERE tool_index_fts MATCH 'toolcurrenttoken'`)
+          .all()
+      ).toHaveLength(0);
+
+      db.prepare(`DELETE FROM knowledge WHERE id = 'k1'`).run();
+      db.prepare(`DELETE FROM tool_index WHERE name = 'tool1'`).run();
+      expect(
+        db
+          .prepare(
+            `SELECT rowid FROM knowledge_fts WHERE knowledge_fts MATCH 'knowledgefinaltoken'`
+          )
+          .all()
+      ).toHaveLength(0);
+      expect(
+        db
+          .prepare(`SELECT rowid FROM tool_index_fts WHERE tool_index_fts MATCH 'toolfinaltoken'`)
+          .all()
+      ).toHaveLength(0);
+      expect(() =>
+        db.prepare(`INSERT INTO knowledge_fts(knowledge_fts) VALUES ('integrity-check')`).run()
+      ).not.toThrow();
+      expect(() =>
+        db.prepare(`INSERT INTO tool_index_fts(tool_index_fts) VALUES ('integrity-check')`).run()
+      ).not.toThrow();
       expect(getSchemaVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
     });
   });

--- a/src/memory/schema.ts
+++ b/src/memory/schema.ts
@@ -272,11 +272,13 @@ export function ensureSchema(db: Database.Database): void {
     END;
 
     CREATE TRIGGER IF NOT EXISTS knowledge_fts_delete AFTER DELETE ON knowledge BEGIN
-      DELETE FROM knowledge_fts WHERE rowid = old.rowid;
+      INSERT INTO knowledge_fts(knowledge_fts, rowid, text, id, path, source)
+      VALUES ('delete', old.rowid, old.text, old.id, old.path, old.source);
     END;
 
     CREATE TRIGGER IF NOT EXISTS knowledge_fts_update AFTER UPDATE ON knowledge BEGIN
-      DELETE FROM knowledge_fts WHERE rowid = old.rowid;
+      INSERT INTO knowledge_fts(knowledge_fts, rowid, text, id, path, source)
+      VALUES ('delete', old.rowid, old.text, old.id, old.path, old.source);
       INSERT INTO knowledge_fts(rowid, text, id, path, source)
       VALUES (new.rowid, new.text, new.id, new.path, new.source);
     END;
@@ -1106,7 +1108,7 @@ function repairAutonomousTaskChildForeignKeys(db: Database.Database): number {
   return tablesToRepair.length;
 }
 
-export const CURRENT_SCHEMA_VERSION = "1.40.0";
+export const CURRENT_SCHEMA_VERSION = "1.41.0";
 
 export function runMigrations(db: Database.Database): void {
   const currentVersion = getSchemaVersion(db);
@@ -1298,11 +1300,13 @@ export function runMigrations(db: Database.Database): void {
         END;
 
         CREATE TRIGGER IF NOT EXISTS tool_index_fts_delete AFTER DELETE ON tool_index BEGIN
-          DELETE FROM tool_index_fts WHERE rowid = old.rowid;
+          INSERT INTO tool_index_fts(tool_index_fts, rowid, search_text, name)
+          VALUES ('delete', old.rowid, old.search_text, old.name);
         END;
 
         CREATE TRIGGER IF NOT EXISTS tool_index_fts_update AFTER UPDATE ON tool_index BEGIN
-          DELETE FROM tool_index_fts WHERE rowid = old.rowid;
+          INSERT INTO tool_index_fts(tool_index_fts, rowid, search_text, name)
+          VALUES ('delete', old.rowid, old.search_text, old.name);
           INSERT INTO tool_index_fts(rowid, search_text, name)
           VALUES (new.rowid, new.search_text, new.name);
         END;
@@ -2421,6 +2425,67 @@ export function runMigrations(db: Database.Database): void {
       log.info("Migration 1.40.0 complete: tg_messages_fts triggers repaired and index rebuilt");
     } catch (error) {
       log.error({ err: error }, "Migration 1.40.0 failed");
+      throw error;
+    }
+  }
+
+  if (!currentVersion || versionLessThan(currentVersion, "1.41.0")) {
+    log.info("Running migration 1.41.0: Repair and rebuild external-content FTS indexes");
+    try {
+      if (tableExists(db, "knowledge") && tableExists(db, "knowledge_fts")) {
+        db.exec(`
+          DROP TRIGGER IF EXISTS knowledge_fts_insert;
+          DROP TRIGGER IF EXISTS knowledge_fts_delete;
+          DROP TRIGGER IF EXISTS knowledge_fts_update;
+
+          CREATE TRIGGER knowledge_fts_insert AFTER INSERT ON knowledge BEGIN
+            INSERT INTO knowledge_fts(rowid, text, id, path, source)
+            VALUES (new.rowid, new.text, new.id, new.path, new.source);
+          END;
+
+          CREATE TRIGGER knowledge_fts_delete AFTER DELETE ON knowledge BEGIN
+            INSERT INTO knowledge_fts(knowledge_fts, rowid, text, id, path, source)
+            VALUES ('delete', old.rowid, old.text, old.id, old.path, old.source);
+          END;
+
+          CREATE TRIGGER knowledge_fts_update AFTER UPDATE ON knowledge BEGIN
+            INSERT INTO knowledge_fts(knowledge_fts, rowid, text, id, path, source)
+            VALUES ('delete', old.rowid, old.text, old.id, old.path, old.source);
+            INSERT INTO knowledge_fts(rowid, text, id, path, source)
+            VALUES (new.rowid, new.text, new.id, new.path, new.source);
+          END;
+        `);
+        db.prepare(`INSERT INTO knowledge_fts(knowledge_fts) VALUES ('rebuild')`).run();
+      }
+
+      if (tableExists(db, "tool_index") && tableExists(db, "tool_index_fts")) {
+        db.exec(`
+          DROP TRIGGER IF EXISTS tool_index_fts_insert;
+          DROP TRIGGER IF EXISTS tool_index_fts_delete;
+          DROP TRIGGER IF EXISTS tool_index_fts_update;
+
+          CREATE TRIGGER tool_index_fts_insert AFTER INSERT ON tool_index BEGIN
+            INSERT INTO tool_index_fts(rowid, search_text, name)
+            VALUES (new.rowid, new.search_text, new.name);
+          END;
+
+          CREATE TRIGGER tool_index_fts_delete AFTER DELETE ON tool_index BEGIN
+            INSERT INTO tool_index_fts(tool_index_fts, rowid, search_text, name)
+            VALUES ('delete', old.rowid, old.search_text, old.name);
+          END;
+
+          CREATE TRIGGER tool_index_fts_update AFTER UPDATE ON tool_index BEGIN
+            INSERT INTO tool_index_fts(tool_index_fts, rowid, search_text, name)
+            VALUES ('delete', old.rowid, old.search_text, old.name);
+            INSERT INTO tool_index_fts(rowid, search_text, name)
+            VALUES (new.rowid, new.search_text, new.name);
+          END;
+        `);
+        db.prepare(`INSERT INTO tool_index_fts(tool_index_fts) VALUES ('rebuild')`).run();
+      }
+      log.info("Migration 1.41.0 complete: External-content FTS indexes repaired and rebuilt");
+    } catch (error) {
+      log.error({ err: error }, "Migration 1.41.0 failed");
       throw error;
     }
   }


### PR DESCRIPTION
## Что исправлено

- триггеры `knowledge_fts` и `tool_index_fts` для `UPDATE`/`DELETE` теперь используют специальную команду FTS5 `delete` с прежними значениями `old.*`;
- добавлена миграция схемы `1.41.0`, которая пересоздаёт триггеры и выполняет `rebuild` обоих индексов, восстанавливая уже повреждённые БД;
- добавлен регрессионный тест для обоих external-content индексов.

## Как воспроизвести проблему

1. Создать запись с уникальным токеном в `knowledge` или `tool_index`.
2. Обновить либо удалить базовую запись при старых триггерах с обычным `DELETE FROM ..._fts`.
3. Выполнить `MATCH` по старому токену: в индексе остаётся orphaned posting.

Регрессионный тест сначала явно создаёт старые триггеры и подтверждает наличие устаревших postings, затем запускает миграцию и проверяет:

- старые токены больше не находятся;
- актуальные токены находятся;
- последующие `UPDATE` и `DELETE` не оставляют postings;
- `integrity-check` проходит для обоих индексов.

## Проверки

- `npx vitest run src/memory/__tests__/schema.test.ts` — 95 тестов пройдено;
- `npm run typecheck`;
- `npm run lint`;
- `npm run format:check`;
- `git diff --check`.

Полный локальный `npm test` запускался дополнительно, но процесс Vitest был прерван окружением без итоговой сводки; полная матрица выполняется в CI.

Fixes #691
