### PR TITLE
fix(tools): сохранить rowid при переиндексации инструментов

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-13T23:43:55.254Z for PR creation at branch issue-691-16c7ac451187 for issue https://github.com/xlabtg/teleton-agent/issues/691
-# Updated: 2026-07-14T00:08:56.885Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-07-13T23:43:55.254Z for PR creation at branch issue-691-16c7ac451187 for issue https://github.com/xlabtg/teleton-agent/issues/691
+# Updated: 2026-07-14T00:08:56.885Z

--- a/src/agent/tools/__tests__/tool-index.test.ts
+++ b/src/agent/tools/__tests__/tool-index.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+import type { Tool as PiAiTool } from "@mariozechner/pi-ai";
+import { NoopEmbeddingProvider } from "../../../memory/embeddings/provider.js";
+import { ensureSchema, runMigrations } from "../../../memory/schema.js";
+import { ToolIndex } from "../tool-index.js";
+
+describe("ToolIndex", () => {
+  let db: InstanceType<typeof Database>;
+  let toolIndex: ToolIndex;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    ensureSchema(db);
+    runMigrations(db);
+    toolIndex = new ToolIndex(db, new NoopEmbeddingProvider(), false, {
+      topK: 10,
+      alwaysInclude: [],
+      skipUnlimitedProviders: false,
+    });
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("keeps the FTS index in sync when re-registering a tool", async () => {
+    const tool = (description: string): PiAiTool => ({ name: "foo", description }) as PiAiTool;
+
+    await toolIndex.reindexTools([], [tool("alpha")]);
+    const rowidBefore = db.prepare(`SELECT rowid FROM tool_index WHERE name = 'foo'`).pluck().get();
+
+    await toolIndex.reindexTools([], [tool("beta")]);
+    const rowidAfter = db.prepare(`SELECT rowid FROM tool_index WHERE name = 'foo'`).pluck().get();
+
+    expect(rowidAfter).toBe(rowidBefore);
+    expect(await toolIndex.search("alpha", [])).toEqual([]);
+    expect((await toolIndex.search("beta", [])).map((result) => result.name)).toEqual(["foo"]);
+    expect(() =>
+      db.prepare(`INSERT INTO tool_index_fts(tool_index_fts) VALUES ('integrity-check')`).run()
+    ).not.toThrow();
+  });
+});

--- a/src/agent/tools/tool-index.ts
+++ b/src/agent/tools/tool-index.ts
@@ -169,8 +169,12 @@ export class ToolIndex {
         }
 
         const insertTool = this.db.prepare(`
-          INSERT OR REPLACE INTO tool_index (name, description, search_text, updated_at)
+          INSERT INTO tool_index (name, description, search_text, updated_at)
           VALUES (?, ?, ?, unixepoch())
+          ON CONFLICT(name) DO UPDATE SET
+            description = excluded.description,
+            search_text = excluded.search_text,
+            updated_at = excluded.updated_at
         `);
         // vec0 virtual tables don't support OR REPLACE — delete first, then insert
         const deleteVec = this.vectorEnabled


### PR DESCRIPTION
## Что исправлено

- заменён `INSERT OR REPLACE` в delta-переиндексации `tool_index` на `INSERT ... ON CONFLICT(name) DO UPDATE`;
- повторная регистрация инструмента теперь сохраняет исходный `rowid`, поэтому update-триггер корректно удаляет старую FTS-запись и добавляет актуальную;
- добавлен регрессионный тест для синхронности `tool_index_fts` и проверки целостности индекса.

## Воспроизведение

До исправления последовательная регистрация `foo` с описаниями `alpha`, затем `beta` меняла `rowid` с `1` на `2`. Из-за неявного удаления в `INSERT OR REPLACE` старый FTS posting оставался в индексе.

Регрессионный тест выполняет ту же последовательность и проверяет:

1. `rowid` не меняется;
2. поиск `alpha` больше ничего не возвращает;
3. поиск `beta` возвращает `foo`;
4. FTS5 `integrity-check` проходит.

Ранее повреждённые индексы уже восстанавливает миграция схемы `1.41.0`, добавленная в #713, поэтому отдельный bump схемы здесь не требуется.

## Проверки

- `npm test -- --run src/agent/tools/__tests__/tool-index.test.ts`
- `npm run lint`
- `npm run format:check`
- `npm run build:sdk`
- `npm run typecheck`
- полный `npm test`: 3763 теста прошли; 3 несвязанных нестабильных теста дочерних процессов/таймаута не прошли локально, при точечном повторе 18/19 прошли, один managed-agent тест не дождался stdout дочернего процесса

Fixes #692
