### PR TITLE
Ограничить суточный расход TON в автономном режиме

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-14T00:39:51.197Z for PR creation at branch issue-693-7d0179f4e36a for issue https://github.com/xlabtg/teleton-agent/issues/693

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-14T00:39:51.197Z for PR creation at branch issue-693-7d0179f4e36a for issue https://github.com/xlabtg/teleton-agent/issues/693

--- a/src/autonomous/__tests__/policy-engine.test.ts
+++ b/src/autonomous/__tests__/policy-engine.test.ts
@@ -311,6 +311,52 @@ describe("PolicyEngine", () => {
     expect(result.violations.filter((v) => v.type === "budget_exceeded")).toHaveLength(0);
   });
 
+  it("blocks when cumulative daily TON spend would exceed the daily cap", () => {
+    const dailyEngine = new PolicyEngine({
+      ...DEFAULT_POLICY_CONFIG,
+      tonSpending: { perTask: 1, daily: 0.25, requireConfirmationAbove: 1 },
+      restrictedTools: [],
+    });
+    const task = makeTask({ constraints: { budgetTON: 1 } });
+
+    dailyEngine.setDailySpend(0.2);
+    const result = dailyEngine.checkAction(task, {
+      toolName: "ton_send",
+      params: { amount: 0.1 },
+    });
+
+    expect(result.allowed).toBe(false);
+    const violation = result.violations.find((v) => v.type === "budget_exceeded");
+    expect(violation?.message).toContain("daily");
+    expect(violation?.message).toContain("0.25");
+  });
+
+  it("distinguishes per-task and daily budget rejections", () => {
+    const dailyEngine = new PolicyEngine({
+      ...DEFAULT_POLICY_CONFIG,
+      tonSpending: { perTask: 0.1, daily: 0.5, requireConfirmationAbove: 1 },
+      restrictedTools: [],
+    });
+    const task = makeTask();
+
+    const perTaskResult = dailyEngine.checkAction(task, {
+      toolName: "ton_send",
+      params: { amount: 0.2 },
+    });
+    dailyEngine.setDailySpend(0.45);
+    const dailyResult = dailyEngine.checkAction(task, {
+      toolName: "ton_send",
+      params: { amount: 0.1 },
+    });
+
+    expect(perTaskResult.violations.find((v) => v.type === "budget_exceeded")?.message).toContain(
+      "per-task"
+    );
+    expect(dailyResult.violations.find((v) => v.type === "budget_exceeded")?.message).toContain(
+      "daily"
+    );
+  });
+
   // ─── Loop detection ────────────────────────────────────────────────────────
 
   it("detects loops when same action is repeated maxIdenticalActions times", () => {

--- a/src/autonomous/__tests__/policy-persistence.test.ts
+++ b/src/autonomous/__tests__/policy-persistence.test.ts
@@ -288,6 +288,81 @@ describe("PolicyEngine state persistence across pause/resume (issue #256)", () =
     expect(store.getPolicyState(task.id)).toBeUndefined();
   });
 
+  it("records successful TON spend and blocks a later task at the shared daily cap", async () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY_CONFIG,
+      tonSpending: { perTask: 1, daily: 0.25, requireConfirmationAbove: 1 },
+      restrictedTools: [],
+      rateLimit: { apiCallsPerMinute: 100000, toolCallsPerHour: 100000 },
+      loopDetection: { enabled: false, maxIdenticalActions: 999 },
+    };
+    const tonAction = {
+      toolName: "ton_send",
+      params: { amount: 0.2 },
+      reasoning: "Send TON",
+      confidence: 0.9,
+    } satisfies PlannedAction;
+    const firstDeps = makeDeps({
+      planNextAction: vi.fn().mockResolvedValue(tonAction),
+      executeTool: vi.fn().mockResolvedValue({
+        success: true,
+        data: { amount: 0.2, from: "EQ-wallet", txHash: "tx-1" },
+      }),
+      evaluateSuccess: vi.fn().mockResolvedValue(true),
+    });
+
+    const first = await new AutonomousLoop(store, firstDeps, policy).run(task);
+    expect(first.status).toBe("completed");
+    expect(store.getDailyTonSpend("EQ-wallet")).toBe(0.2);
+
+    const secondTask = store.createTask({
+      goal: "Second spend",
+      constraints: { maxIterations: 10 },
+    });
+    const executeSecondTool = vi.fn().mockResolvedValue({ success: true });
+    const secondDeps = makeDeps({
+      planNextAction: vi.fn().mockResolvedValue({
+        ...tonAction,
+        params: { amount: 0.1 },
+      }),
+      executeTool: executeSecondTool,
+    });
+    const second = await new AutonomousLoop(store, secondDeps, policy).run(secondTask);
+
+    expect(second.status).toBe("failed");
+    expect(second.error).toMatch(/daily/i);
+    expect(executeSecondTool).not.toHaveBeenCalled();
+  });
+
+  it("does not record failed TON executions in daily spend", async () => {
+    const policy: PolicyConfig = {
+      ...DEFAULT_POLICY_CONFIG,
+      tonSpending: { perTask: 1, daily: 1, requireConfirmationAbove: 1 },
+      restrictedTools: [],
+      rateLimit: { apiCallsPerMinute: 100000, toolCallsPerHour: 100000 },
+      loopDetection: { enabled: false, maxIdenticalActions: 999 },
+    };
+    const deps = makeDeps({
+      planNextAction: vi.fn().mockResolvedValue({
+        toolName: "ton_send",
+        params: { amount: 0.2 },
+      }),
+      executeTool: vi.fn().mockResolvedValue({ success: false, error: "not settled" }),
+      evaluateSuccess: vi.fn().mockResolvedValue(true),
+    });
+
+    await new AutonomousLoop(store, deps, policy).run(task);
+
+    expect(store.getDailyTonSpend("default")).toBe(0);
+  });
+
+  it("resets the accumulated budget on the next UTC day", () => {
+    store.recordDailyTonSpend("EQ-wallet", 0.2, new Date("2026-07-14T23:59:59Z"));
+
+    expect(store.getTotalDailyTonSpend(new Date("2026-07-14T23:59:59Z"))).toBe(0.2);
+    expect(store.getTotalDailyTonSpend(new Date("2026-07-15T00:00:00Z"))).toBe(0);
+  });
+
   it("pause preserves policy_state for the next resume", async () => {
     // Race-free pause: transition the task to 'paused' from inside the
     // evaluateSuccess hook. On the next iteration the loop sees the

--- a/src/autonomous/loop.ts
+++ b/src/autonomous/loop.ts
@@ -4,7 +4,7 @@ import type {
   TaskCheckpoint,
 } from "../memory/agent/autonomous-tasks.js";
 import type { AutonomousTaskStore } from "../memory/agent/autonomous-tasks.js";
-import { PolicyEngine, DEFAULT_POLICY_CONFIG } from "./policy-engine.js";
+import { PolicyEngine, DEFAULT_POLICY_CONFIG, extractTonSpend } from "./policy-engine.js";
 import type { PolicyConfig, PolicyEngineState } from "./policy-engine.js";
 import { createLogger } from "../utils/logger.js";
 import { recordTask } from "../services/prometheus.js";
@@ -127,6 +127,10 @@ export class AutonomousLoop {
    */
   getPolicyEngine(): PolicyEngine {
     return this.policyEngine;
+  }
+
+  private syncDailySpend(): void {
+    this.policyEngine.setDailySpend(this.store.getTotalDailyTonSpend());
   }
 
   /** Request graceful stop of the loop */
@@ -315,6 +319,7 @@ export class AutonomousLoop {
         });
 
         // 2. Check policies / guardrails
+        this.syncDailySpend();
         const policyCheck = this.policyEngine.satisfiesPolicies(current, {
           toolName: action.toolName,
           params: action.params,
@@ -391,6 +396,23 @@ export class AutonomousLoop {
           message: result.success ? "Tool succeeded" : `Tool failed: ${result.error}`,
           data: { success: result.success, data: result.data, error: result.error },
         });
+
+        if (result.success) {
+          const tonSpend = extractTonSpend({
+            toolName: action.toolName,
+            params: action.params,
+            tonAmount: action.tonAmount,
+          });
+          if (tonSpend.kind === "amount") {
+            const from =
+              result.data && typeof result.data === "object" && "from" in result.data
+                ? (result.data as { from?: unknown }).from
+                : undefined;
+            const walletKey = typeof from === "string" && from.length > 0 ? from : "default";
+            this.store.recordDailyTonSpend(walletKey, tonSpend.amount);
+            this.syncDailySpend();
+          }
+        }
 
         history.push({ action, result });
         this.policyEngine.recordAction(action.toolName);

--- a/src/autonomous/policy-engine.ts
+++ b/src/autonomous/policy-engine.ts
@@ -132,7 +132,11 @@ function isNativeTonAsset(value: unknown): boolean {
   return typeof value === "string" && (value.toLowerCase() === "ton" || value === NATIVE_TON_ASSET);
 }
 
-function extractTonSpend(action: PolicyAction): TonSpend {
+function formatTon(amount: number): string {
+  return Number(amount.toFixed(9)).toString();
+}
+
+export function extractTonSpend(action: PolicyAction): TonSpend {
   const toolName = action.toolName;
   if (!toolName) return { kind: "none" };
 
@@ -177,6 +181,7 @@ export class PolicyEngine {
   private apiCallTimestamps: number[] = [];
   private consecutiveUncertainCount = 0;
   private recentActions: string[] = [];
+  private dailySpend = 0;
   private onStateChange?: (state: PolicyEngineState) => void;
 
   constructor(private config: PolicyConfig = DEFAULT_POLICY_CONFIG) {}
@@ -219,6 +224,11 @@ export class PolicyEngine {
 
   private notifyChange(): void {
     if (this.onStateChange) this.onStateChange(this.serialize());
+  }
+
+  /** Set the persisted amount already spent during the current UTC day. */
+  setDailySpend(amount: number): void {
+    this.dailySpend = isFiniteNonNegativeAmount(amount) ? amount : 0;
   }
 
   checkAction(task: AutonomousTask, action: PolicyAction): PolicyCheckResult {
@@ -304,7 +314,16 @@ export class PolicyEngine {
       if (tonSpend.amount > budgetTON) {
         violations.push({
           type: "budget_exceeded",
-          message: `TON amount ${tonSpend.amount} exceeds budget ${budgetTON}`,
+          message: `TON amount ${tonSpend.amount} exceeds budget ${budgetTON} (per-task)`,
+          requiresConfirmation: true,
+        });
+        blockingViolationCount++;
+      }
+      const projectedDailySpend = this.dailySpend + tonSpend.amount;
+      if (projectedDailySpend > this.config.tonSpending.daily) {
+        violations.push({
+          type: "budget_exceeded",
+          message: `TON daily budget exceeded: ${formatTon(this.dailySpend)} already spent + ${formatTon(tonSpend.amount)} requested = ${formatTon(projectedDailySpend)} (daily limit: ${formatTon(this.config.tonSpending.daily)})`,
           requiresConfirmation: true,
         });
         blockingViolationCount++;

--- a/src/memory/__tests__/schema.test.ts
+++ b/src/memory/__tests__/schema.test.ts
@@ -1495,7 +1495,17 @@ describe("Memory Schema", () => {
     });
 
     it("CURRENT_SCHEMA_VERSION is set to expected value", () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe("1.41.0");
+      expect(CURRENT_SCHEMA_VERSION).toBe("1.42.0");
+    });
+
+    it("creates persistent autonomous daily TON spend storage", () => {
+      ensureSchema(db);
+      const table = db
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'autonomous_daily_ton_spend'`
+        )
+        .get();
+      expect(table).toBeDefined();
     });
   });
 

--- a/src/memory/agent/autonomous-tasks.ts
+++ b/src/memory/agent/autonomous-tasks.ts
@@ -553,6 +553,43 @@ export class AutonomousTaskStore {
   clearPolicyState(taskId: string): void {
     this.db.prepare(`DELETE FROM policy_state WHERE task_id = ?`).run(taskId);
   }
+
+  getDailyTonSpend(walletKey: string, now = new Date()): number {
+    const utcDate = now.toISOString().slice(0, 10);
+    const row = this.db
+      .prepare(
+        `SELECT amount FROM autonomous_daily_ton_spend WHERE wallet_key = ? AND utc_date = ?`
+      )
+      .get(walletKey, utcDate) as { amount: number } | undefined;
+    return row?.amount ?? 0;
+  }
+
+  getTotalDailyTonSpend(now = new Date()): number {
+    const utcDate = now.toISOString().slice(0, 10);
+    const row = this.db
+      .prepare(
+        `SELECT COALESCE(SUM(amount), 0) AS amount FROM autonomous_daily_ton_spend WHERE utc_date = ?`
+      )
+      .get(utcDate) as { amount: number };
+    return row.amount;
+  }
+
+  recordDailyTonSpend(walletKey: string, amount: number, now = new Date()): number {
+    if (!Number.isFinite(amount) || amount <= 0) {
+      throw new Error(`Daily TON spend must be a positive finite number, got ${String(amount)}`);
+    }
+    const utcDate = now.toISOString().slice(0, 10);
+    this.db
+      .prepare(
+        `INSERT INTO autonomous_daily_ton_spend (wallet_key, utc_date, amount, updated_at)
+         VALUES (?, ?, ?, unixepoch())
+         ON CONFLICT(wallet_key, utc_date) DO UPDATE SET
+           amount = autonomous_daily_ton_spend.amount + excluded.amount,
+           updated_at = excluded.updated_at`
+      )
+      .run(walletKey, utcDate, amount);
+    return this.getDailyTonSpend(walletKey, now);
+  }
 }
 
 const instances = new WeakMap<Database.Database, AutonomousTaskStore>();

--- a/src/memory/migrations/1.42.0.sql
+++ b/src/memory/migrations/1.42.0.sql
@@ -1,0 +1,10 @@
+-- Migration 1.42.0: persistent per-wallet daily TON spend for autonomous tasks.
+CREATE TABLE IF NOT EXISTS autonomous_daily_ton_spend (
+  wallet_key TEXT NOT NULL,
+  utc_date TEXT NOT NULL,
+  amount REAL NOT NULL DEFAULT 0 CHECK(amount >= 0),
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  PRIMARY KEY (wallet_key, utc_date)
+);
+
+UPDATE meta SET value = '1.42.0', updated_at = unixepoch() WHERE key = 'schema_version';

--- a/src/memory/schema.ts
+++ b/src/memory/schema.ts
@@ -901,6 +901,16 @@ export function ensureSchema(db: Database.Database): void {
       FOREIGN KEY (task_id) REFERENCES autonomous_tasks(id) ON DELETE CASCADE
     );
 
+    -- Settled TON spend shared by all autonomous tasks. The UTC date is part
+    -- of the key so a new day starts with an empty budget without a reset job.
+    CREATE TABLE IF NOT EXISTS autonomous_daily_ton_spend (
+      wallet_key TEXT NOT NULL,
+      utc_date TEXT NOT NULL,
+      amount REAL NOT NULL DEFAULT 0 CHECK(amount >= 0),
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      PRIMARY KEY (wallet_key, utc_date)
+    );
+
     -- =====================================================
     -- JOURNAL (Trading & Business Operations)
     -- =====================================================
@@ -1108,7 +1118,7 @@ function repairAutonomousTaskChildForeignKeys(db: Database.Database): number {
   return tablesToRepair.length;
 }
 
-export const CURRENT_SCHEMA_VERSION = "1.41.0";
+export const CURRENT_SCHEMA_VERSION = "1.42.0";
 
 export function runMigrations(db: Database.Database): void {
   const currentVersion = getSchemaVersion(db);
@@ -2486,6 +2496,25 @@ export function runMigrations(db: Database.Database): void {
       log.info("Migration 1.41.0 complete: External-content FTS indexes repaired and rebuilt");
     } catch (error) {
       log.error({ err: error }, "Migration 1.41.0 failed");
+      throw error;
+    }
+  }
+
+  if (!currentVersion || versionLessThan(currentVersion, "1.42.0")) {
+    log.info("Running migration 1.42.0: Add autonomous daily TON spend tracking");
+    try {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS autonomous_daily_ton_spend (
+          wallet_key TEXT NOT NULL,
+          utc_date TEXT NOT NULL,
+          amount REAL NOT NULL DEFAULT 0 CHECK(amount >= 0),
+          updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+          PRIMARY KEY (wallet_key, utc_date)
+        );
+      `);
+      log.info("Migration 1.42.0 complete: autonomous daily TON spend tracking created");
+    } catch (error) {
+      log.error({ err: error }, "Migration 1.42.0 failed");
       throw error;
     }
   }


### PR DESCRIPTION
## Что изменено

Исправляет #693.

- `PolicyEngine` теперь проверяет прогнозируемый суточный расход (`уже потрачено + текущая сумма`) против `tonSpending.daily`.
- Пер-task и суточное превышение бюджета различимы в сообщениях `budget_exceeded`.
- Успешные TON-действия записываются в постоянную SQLite-агрегацию по кошельку и UTC-дню; неуспешные действия расход не увеличивают.
- Сумма сохраняется между автономными задачами и автоматически начинается с нуля при смене UTC-даты.
- Добавлена миграция схемы `1.42.0`. Версия npm-пакета не менялась вручную: релизом управляет release-please.

## Как воспроизвести исходную проблему

При `perTask: 0.1` и `daily: 0.5` последовательно выполнить десять успешных автономных действий по `0.1 TON`. До исправления каждое действие проходило индивидуальную проверку, и общий расход `1 TON` не блокировался.

## Автоматическая проверка

Добавлены регрессионные тесты, которые подтверждают:

- блокировку следующей задачи, если она превысит общий суточный лимит;
- сохранение settled-расхода между задачами;
- отсутствие списания при неуспешном выполнении;
- сброс агрегата при смене UTC-дня;
- различимые причины per-task и daily budget rejection.

Локально выполнено:

- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- 212 целевых и смежных тестов — пройдены
- полный `npm test`: 3771/3772; единственный несвязанный тест `start-config-missing.test.ts` превысил общий 10-секундный timeout под параллельной нагрузкой и прошёл изолированно (2/2)

UI не изменялся, скриншоты не требуются.

Fixes #693
