### PR TITLE
fix(ton): не отпускать tx-lock до завершения операции

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-14T01:08:05.098Z for PR creation at branch issue-694-0f55ae1727d8 for issue https://github.com/xlabtg/teleton-agent/issues/694

--- a/src/ton/__tests__/tx-lock.test.ts
+++ b/src/ton/__tests__/tx-lock.test.ts
@@ -89,14 +89,66 @@ describe("TxLock", () => {
 
     it("should timeout after 60 seconds", async () => {
       // Use fake timers for timeout test
+      let finish: (() => void) | undefined;
       const neverResolves = withTxLock(
-        () => new Promise<void>(() => {}) // never resolves
+        () =>
+          new Promise<void>((resolve) => {
+            finish = resolve;
+          })
       );
+      const rejection = expect(neverResolves).rejects.toThrow("TON tx-lock timeout (60s)");
 
       // Advance past the 60s timeout — async version resolves microtasks
       await vi.advanceTimersByTimeAsync(61_000);
 
-      await expect(neverResolves).rejects.toThrow("TON tx-lock timeout (60s)");
+      await rejection;
+      finish?.();
+    });
+
+    it("should keep the lock until the timed-out function settles", async () => {
+      let finishFirst: (() => void) | undefined;
+      let secondStarted = false;
+
+      const first = withTxLock(
+        () =>
+          new Promise<void>((resolve) => {
+            finishFirst = resolve;
+          })
+      );
+      const second = withTxLock(async () => {
+        secondStarted = true;
+      });
+      const rejection = expect(first).rejects.toThrow("TON tx-lock timeout (60s)");
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      await rejection;
+      expect(secondStarted).toBe(false);
+
+      finishFirst?.();
+      await second;
+
+      expect(secondStarted).toBe(true);
+    });
+
+    it("should release the lock when a timed-out function later rejects", async () => {
+      let failFirst: ((error: Error) => void) | undefined;
+
+      const first = withTxLock(
+        () =>
+          new Promise<void>((_, reject) => {
+            failFirst = reject;
+          })
+      );
+      const second = withTxLock(async () => "next");
+      const timeout = expect(first).rejects.toThrow("TON tx-lock timeout (60s)");
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      await timeout;
+
+      failFirst?.(new Error("late failure"));
+
+      await expect(second).resolves.toBe("next");
     });
   });
 });

--- a/src/ton/tx-lock.ts
+++ b/src/ton/tx-lock.ts
@@ -8,7 +8,7 @@ let pending: Promise<void> = Promise.resolve();
 const TX_LOCK_TIMEOUT_MS = 60_000;
 
 export function withTxLock<T>(fn: () => Promise<T>): Promise<T> {
-  const guarded = () => {
+  const guarded = (): { execute: Promise<T>; completion: Promise<void> } => {
     let timerId: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<never>((_, reject) => {
       timerId = setTimeout(
@@ -16,12 +16,16 @@ export function withTxLock<T>(fn: () => Promise<T>): Promise<T> {
         TX_LOCK_TIMEOUT_MS
       );
     });
-    return Promise.race([fn(), timeoutPromise]).finally(() => clearTimeout(timerId));
+    const operation = fn();
+    const execute = Promise.race([operation, timeoutPromise]).finally(() => clearTimeout(timerId));
+    const completion = operation.then(
+      () => {},
+      () => {}
+    );
+    return { execute, completion };
   };
-  const execute = pending.then(guarded, guarded);
-  pending = execute.then(
-    () => {},
-    () => {}
-  );
+  const turn = pending.then(guarded, guarded);
+  const execute = turn.then(({ execute }) => execute);
+  pending = turn.then(({ completion }) => completion);
   return execute;
 }


### PR DESCRIPTION
## Что изменено

- очередь `withTxLock` теперь ждёт фактического завершения защищённой операции, а не результата `Promise.race` с таймаутом;
- таймаут по-прежнему возвращает вызывающему ошибку `TON tx-lock timeout (60s)`;
- позднее успешное завершение или ошибка операции безопасно освобождают очередь без повторного использования `seqno` и необработанных rejection.

## Воспроизведение

До исправления первая операция продолжала выполняться после 60-секундного таймаута, но второй вызов уже входил в критическую секцию. Регрессионный тест подтверждал это значением `secondStarted === true` до завершения первой операции.

## Проверка

- добавлены тесты, подтверждающие, что следующий вызов не начинается после таймаута до фактического завершения первого;
- добавлен сценарий позднего rejection просроченной операции;
- `npm run build:sdk`;
- `npm run typecheck`;
- `npm run lint`;
- `npm run format:check`;
- `npm test` — 248 файлов, 3774 теста успешно.

Fixes #694
