### PR TITLE
fix(telegram): сохранять dollar-паттерны при форматировании Markdown

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-07-14T01:08:05.098Z for PR creation at branch issue-694-0f55ae1727d8 for issue https://github.com/xlabtg/teleton-agent/issues/694
+# Updated: 2026-07-14T01:26:29.777Z

--- a/src/telegram/__tests__/formatting.test.ts
+++ b/src/telegram/__tests__/formatting.test.ts
@@ -124,7 +124,7 @@ describe("markdownToTelegramHtml", () => {
   ])("should preserve dollar replacement patterns in %s", (_name, content, markdown) => {
     const result = markdownToTelegramHtml(markdown(content));
 
-    expect(result).toContain(content.replace("&", "&amp;"));
+    expect(result).toContain(content.replaceAll("&", "&amp;"));
     expect(result).not.toContain("\x00");
   });
 });

--- a/src/telegram/__tests__/formatting.test.ts
+++ b/src/telegram/__tests__/formatting.test.ts
@@ -116,4 +116,15 @@ describe("markdownToTelegramHtml", () => {
     expect(result).toContain("&lt;item&gt;");
     expect(result).not.toContain("<item>");
   });
+
+  it.each([
+    ["code block", "$ $& $' $` $1 $$", (content: string) => `\`\`\`\n${content}\n\`\`\``],
+    ["inline code", "$ $& $' $1 $$", (content: string) => `before \`${content}\` after`],
+    ["blockquote", "$ $& $' $` $1 $$", (content: string) => `> ${content}`],
+  ])("should preserve dollar replacement patterns in %s", (_name, content, markdown) => {
+    const result = markdownToTelegramHtml(markdown(content));
+
+    expect(result).toContain(content.replace("&", "&amp;"));
+    expect(result).not.toContain("\x00");
+  });
 });

--- a/src/telegram/formatting.ts
+++ b/src/telegram/formatting.ts
@@ -94,15 +94,15 @@ export function markdownToTelegramHtml(markdown: string): string {
   );
 
   blockquotes.forEach((quote, index) => {
-    html = html.replace(`\x00BLOCKQUOTE${index}\x00`, quote);
+    html = html.replace(`\x00BLOCKQUOTE${index}\x00`, () => quote);
   });
 
   codeBlocks.forEach((block, index) => {
-    html = html.replace(`\x00CODEBLOCK${index}\x00`, block);
+    html = html.replace(`\x00CODEBLOCK${index}\x00`, () => block);
   });
 
   inlineCodes.forEach((code, index) => {
-    html = html.replace(`\x00INLINECODE${index}\x00`, code);
+    html = html.replace(`\x00INLINECODE${index}\x00`, () => code);
   });
 
   return html;


### PR DESCRIPTION
## Что исправлено

`markdownToTelegramHtml` больше не интерпретирует `$`-последовательности как шаблоны замены при восстановлении защищённых фрагментов.

- восстановление code blocks, inline code и blockquotes переведено на функциональный replacer;
- добавлен параметризованный регрессионный тест для `$`, `$&`, `$'`, `` $` ``, `$1` и `$$`;
- тест также гарантирует, что NUL-placeholder `\x00…\x00` не попадает в результат.

## Как воспроизвести

До исправления:

```ts
markdownToTelegramHtml("\`\`\`\nawk '{print $&}'\n\`\`\`")
```

возвращал повреждённый HTML с утечкой `CODEBLOCK0` и NUL-байтов, поскольку строковый replacement трактовал `$&` как специальный шаблон.

После исправления исходная последовательность сохраняется как `$&amp;` (HTML-экранирование амперсанда), без placeholder-байтов.

## Проверка

- `npm run build:sdk`
- `npm run lint`
- `npm run typecheck`
- `npm test` — 248 файлов, 3777 тестов
- Prettier check для изменённых файлов
- `git diff --check`

Fixes #695
