### PR TITLE
fix(memory): учитывать вес vector-only результатов гибридного поиска

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-07-14T01:08:05.098Z for PR creation at branch issue-694-0f55ae1727d8 for issue https://github.com/xlabtg/teleton-agent/issues/694
 # Updated: 2026-07-14T01:26:29.777Z
-# Updated: 2026-07-14T02:29:30.497Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-07-14T01:08:05.098Z for PR creation at branch issue-694-0f55ae1727d8 for issue https://github.com/xlabtg/teleton-agent/issues/694
 # Updated: 2026-07-14T01:26:29.777Z
+# Updated: 2026-07-14T02:29:30.497Z

--- a/src/memory/__tests__/hybrid-search.test.ts
+++ b/src/memory/__tests__/hybrid-search.test.ts
@@ -467,6 +467,37 @@ describe("HybridSearch — weight options", () => {
       })
     ).resolves.not.toThrow();
   });
+
+  it("weights vector-only and keyword-only results symmetrically", async () => {
+    const rawScore = 0.8;
+    const vectorWeight = 0.2;
+    const keywordWeight = 0.8;
+    const semanticVectorStore = {
+      isConfigured: true,
+      searchKnowledge: vi.fn().mockResolvedValue([]),
+      searchMessages: vi.fn().mockResolvedValue([
+        {
+          id: "vector-only",
+          text: "semantic match",
+          source: "chat-w",
+          score: rawScore,
+        },
+      ]),
+    };
+    search = new HybridSearch(db, false, semanticVectorStore as never);
+    insertMessage(db, "keyword-only", "chat-w", "exact keyword match");
+
+    const results = await search.searchMessages("exact keyword match", [0.1], {
+      vectorWeight,
+      keywordWeight,
+    });
+    const vectorOnly = results.find((result) => result.id === "vector-only");
+    const keywordOnly = results.find((result) => result.id === "keyword-only");
+
+    expect(vectorOnly?.score).toBeCloseTo(vectorWeight * rawScore);
+    expect(keywordOnly?.score).toBeGreaterThan(vectorOnly!.score);
+    expect(results[0].id).toBe("keyword-only");
+  });
 });
 
 // ─── HybridSearch — priority-aware retrieval ─────────────────────────────────

--- a/src/memory/search/hybrid.ts
+++ b/src/memory/search/hybrid.ts
@@ -398,7 +398,7 @@ export class HybridSearch {
     const byId = new Map<string, HybridSearchResult>();
 
     for (const r of vectorResults) {
-      byId.set(r.id, { ...r, vectorScore: r.score });
+      byId.set(r.id, { ...r, score: vectorWeight * r.score, vectorScore: r.score });
     }
 
     for (const r of keywordResults) {


### PR DESCRIPTION
## Что исправлено

- vector-only результаты гибридного поиска теперь получают итоговый `score`, умноженный на `vectorWeight`;
- исходная векторная оценка по-прежнему сохраняется в `vectorScore` для корректного объединения с keyword-результатом;
- добавлен регрессионный тест через публичный `searchMessages`, проверяющий масштабирование оценки и порядок выдачи.

## Как воспроизвести

До исправления vector-only документ с raw score `0.8` сохранял score `0.8`, даже при низком `vectorWeight`, и мог обгонять более релевантный keyword-only документ. После исправления score вычисляется как `vectorWeight × 0.8`.

## Проверки

- `npm run build:sdk`
- `npm run typecheck`
- ESLint для изменённых файлов
- Prettier для изменённых файлов
- `npm test -- --run src/memory/__tests__/hybrid-search.test.ts` — 44/44
- `npm test` — 3783/3783

Fixes #697
