### PR TITLE
fix(memory): удалять устаревший вектор при пустом re-embed

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-14T01:08:05.098Z for PR creation at branch issue-694-0f55ae1727d8 for issue https://github.com/xlabtg/teleton-agent/issues/694
-# Updated: 2026-07-14T01:26:29.777Z
-# Updated: 2026-07-14T02:59:58.589Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-07-14T01:08:05.098Z for PR creation at branch issue-694-0f55ae1727d8 for issue https://github.com/xlabtg/teleton-agent/issues/694
 # Updated: 2026-07-14T01:26:29.777Z
+# Updated: 2026-07-14T02:59:58.589Z

--- a/src/memory/__tests__/feed-messages.test.ts
+++ b/src/memory/__tests__/feed-messages.test.ts
@@ -448,6 +448,19 @@ describe("MessageStore", () => {
   // ============================================
 
   describe("vector insert isolation", () => {
+    it("removes the stale vector when a re-embed yields no embedding", async () => {
+      ensurePlainVectorTable(db);
+      const firstEmbedding = [0.1, 0.2, 0.3];
+      const changingEmbedder = makeEmbedder(firstEmbedding);
+      const vecStore = new MessageStore(db, changingEmbedder, true);
+
+      await vecStore.storeMessage(makeMessage({ id: "m1", text: "alpha" }));
+      vi.mocked(changingEmbedder.embedQuery).mockResolvedValueOnce([]);
+      await vecStore.storeMessage(makeMessage({ id: "m1", text: "beta" }));
+
+      expect(db.prepare("SELECT id FROM tg_messages_vec WHERE id = 'm1'").get()).toBeUndefined();
+    });
+
     it("stores message and vector for a non-384-dim provider (Voyage 1024)", async () => {
       const vdb = createVectorDb(1024);
       if (!vdb) return; // sqlite-vec unavailable in this environment

--- a/src/memory/feed/messages.ts
+++ b/src/memory/feed/messages.ts
@@ -148,13 +148,15 @@ export class MessageStore {
     // Insert the vector in its own transaction so a vec0 failure (e.g. a
     // dimension mismatch when the active embedder differs from the table's
     // configured dimension) cannot roll back the already-stored message row.
-    if (this.vectorEnabled && embedding.length > 0 && message.text) {
+    if (this.vectorEnabled) {
       try {
         this.db.transaction(() => {
           this.db.prepare(`DELETE FROM tg_messages_vec WHERE id = ?`).run(message.id);
-          this.db
-            .prepare(`INSERT INTO tg_messages_vec (id, embedding) VALUES (?, ?)`)
-            .run(message.id, embeddingBuffer);
+          if (embedding.length > 0 && message.text) {
+            this.db
+              .prepare(`INSERT INTO tg_messages_vec (id, embedding) VALUES (?, ?)`)
+              .run(message.id, embeddingBuffer);
+          }
         })();
       } catch (error) {
         log.warn(


### PR DESCRIPTION
## Что исправлено

- Очистка `tg_messages_vec` теперь выполняется при каждом upsert сообщения, если локальный vector index включён.
- Новый вектор вставляется только при наличии непустого embedding и текста.
- Удаление старого и вставка нового вектора остаются одной транзакцией, поэтому успешный re-embed заменяет вектор атомарно.

## Как воспроизвести

1. Сохранить сообщение `m1` с текстом `alpha` и успешным embedding — в `tg_messages_vec` появляется строка `m1`.
2. Повторно сохранить `m1` с текстом `beta`, когда embedder возвращает `[]`.
3. До исправления строка со старым embedding `alpha` оставалась в `tg_messages_vec`; после исправления она удаляется.

## Проверка

- Добавлен регрессионный тест `removes the stale vector when a re-embed yields no embedding`.
- `npm test -- --run src/memory/__tests__/feed-messages.test.ts` — 33/33.
- `npm run lint -- --no-cache` — успешно.
- `npm run typecheck` — успешно.
- `npm run format:check` — успешно.
- Полный suite после `npm run build:sdk`: 3783/3784; единственный несвязанный process-тест `ManagedAgentService` флакнул под общей нагрузкой и прошёл отдельно 17/17.

Fixes #698
