### PR TITLE
fix(agent): гарантировать лимит размера результата инструмента

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-14T03:24:57.001Z for PR creation at branch issue-699-b16e967740e8 for issue https://github.com/xlabtg/teleton-agent/issues/699

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-14T03:24:57.001Z for PR creation at branch issue-699-b16e967740e8 for issue https://github.com/xlabtg/teleton-agent/issues/699

--- a/src/agent/__tests__/tool-result-truncator.test.ts
+++ b/src/agent/__tests__/tool-result-truncator.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { truncateToolResult } from "../tool-result-truncator.js";
+
+describe("truncateToolResult", () => {
+  it.each([
+    {
+      name: "nested objects",
+      data: { nested: { payload: "x".repeat(10_000) } },
+    },
+    {
+      name: "large maps",
+      data: Object.fromEntries(Array.from({ length: 1_000 }, (_, index) => [`key${index}`, index])),
+    },
+    {
+      name: "large summaries",
+      data: { summary: "x".repeat(10_000) },
+    },
+  ])("caps $name at maxSize", ({ data }) => {
+    const maxSize = 2_000;
+
+    const output = truncateToolResult({ success: true, data }, maxSize);
+
+    expect(output.length).toBeLessThanOrEqual(maxSize);
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+
+  it.each([0, 1, 2, 10, 100])("respects a maxSize of %i", (maxSize) => {
+    const output = truncateToolResult(
+      { success: true, data: { summary: "x".repeat(10_000) } },
+      maxSize
+    );
+
+    expect(output.length).toBeLessThanOrEqual(maxSize);
+  });
+});

--- a/src/agent/tool-result-truncator.ts
+++ b/src/agent/tool-result-truncator.ts
@@ -11,15 +11,18 @@ export function truncateToolResult(
 
   const data = result.data as Record<string, unknown> | undefined;
   if (data?.summary || data?.message) {
-    return JSON.stringify({
-      success: result.success,
-      data: {
-        summary: data.summary || data.message,
-        _truncated: true,
-        _originalSize: resultText.length,
-        _message: "Full data truncated. Use limit parameter for smaller results.",
-      },
-    });
+    return capSerializedResult(
+      JSON.stringify({
+        success: result.success,
+        data: {
+          summary: data.summary || data.message,
+          _truncated: true,
+          _originalSize: resultText.length,
+          _message: "Full data truncated. Use limit parameter for smaller results.",
+        },
+      }),
+      maxSize
+    );
   }
 
   // Build a valid JSON summary instead of raw-slicing (which breaks JSON)
@@ -39,5 +42,20 @@ export function truncateToolResult(
       }
     }
   }
-  return JSON.stringify({ success: result.success, data: summarized });
+  return capSerializedResult(
+    JSON.stringify({ success: result.success, data: summarized }),
+    maxSize
+  );
+}
+
+function capSerializedResult(serialized: string, maxSize: number): string {
+  if (serialized.length <= maxSize) return serialized;
+  if (maxSize <= 0) return "";
+
+  const minimal = JSON.stringify({ _truncated: true });
+  if (minimal.length <= maxSize) return minimal;
+
+  // JSON strings are the only valid JSON values representable at every positive size.
+  if (maxSize === 1) return "0";
+  return `"${"x".repeat(maxSize - 2)}"`;
 }


### PR DESCRIPTION
## Что исправлено

- добавлен финальный контроль размера после обеих веток суммаризации результата инструмента;
- вложенные объекты, большие карты и чрезмерные `summary`/`message` больше не могут обойти `maxSize`;
- добавлен минимальный валидный JSON-backstop для малых положительных лимитов и пустой результат для нулевого лимита.

## Как воспроизвести

До исправления `truncateToolResult({ success: true, data: { nested: { payload: "x".repeat(10_000) } } }, 2_000)` возвращал строку длиннее 2 000 символов, потому что вложенный объект копировался целиком и итоговый JSON повторно не проверялся.

## Проверка

- `node node_modules/vitest/vitest.mjs run src/agent/__tests__/tool-result-truncator.test.ts` — 8 тестов пройдено;
- Prettier — пройден;
- ESLint — пройден;
- TypeScript (`tsc --noEmit`) — пройден;
- полный Vitest запускался локально, но окружение не собрало нативный binding `better-sqlite3`; целевой тест не зависит от SQLite и проходит. Полный набор дополнительно проверяется CI.

Добавленные регрессионные сценарии покрывают вложенный объект, большую карту, огромный `summary` и лимиты 0, 1, 2, 10 и 100.

Fixes #699
