### PR TITLE
fix(ton): сохранить нулевую точность jetton

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-14T03:40:34.216Z for PR creation at branch issue-700-5068cd0c329e for issue https://github.com/xlabtg/teleton-agent/issues/700

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-14T03:40:34.216Z for PR creation at branch issue-700-5068cd0c329e for issue https://github.com/xlabtg/teleton-agent/issues/700

--- a/src/agent/tools/__tests__/jetton-decimals.test.ts
+++ b/src/agent/tools/__tests__/jetton-decimals.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  loadWallet: vi.fn(),
+  getCachedTonClient: vi.fn(),
+  tonapiFetch: vi.fn(),
+  openWallet: vi.fn(),
+  sendWalletTx: vi.fn(),
+  withTxLock: vi.fn(),
+  storeCoins: vi.fn(),
+}));
+
+vi.mock("../../../ton/wallet-service.js", () => ({
+  loadWallet: mocks.loadWallet,
+  getCachedTonClient: mocks.getCachedTonClient,
+}));
+
+vi.mock("../../../constants/api-endpoints.js", () => ({
+  tonapiFetch: mocks.tonapiFetch,
+}));
+
+vi.mock("../../../ton/wallet-open.js", () => ({ openWallet: mocks.openWallet }));
+vi.mock("../../../ton/confirm.js", () => ({
+  sendWalletTx: mocks.sendWalletTx,
+  tonExplorerTxUrl: vi.fn(() => "https://example.test/tx"),
+}));
+vi.mock("../../../ton/tx-lock.js", () => ({ withTxLock: mocks.withTxLock }));
+
+vi.mock("@ton/core", () => ({
+  Address: {
+    parse: vi.fn((address: string) => ({ toString: () => address })),
+  },
+  beginCell: vi.fn(() => ({
+    storeUint: vi.fn().mockReturnThis(),
+    storeCoins: mocks.storeCoins.mockReturnThis(),
+    storeAddress: vi.fn().mockReturnThis(),
+    storeBit: vi.fn().mockReturnThis(),
+    storeStringTail: vi.fn().mockReturnThis(),
+    storeRef: vi.fn().mockReturnThis(),
+    endCell: vi.fn(() => ({})),
+  })),
+}));
+
+vi.mock("@ton/ton", () => ({
+  internal: vi.fn(() => ({})),
+  toNano: vi.fn(() => 1n),
+}));
+
+import { jettonBalancesExecutor } from "../ton/jetton-balances.js";
+import { jettonSendExecutor } from "../ton/jetton-send.js";
+
+const walletAddress = "EQSender";
+const jettonAddress = "EQJetton";
+
+function response(body: unknown): Response {
+  return { ok: true, json: vi.fn().mockResolvedValue(body) } as unknown as Response;
+}
+
+describe("TON jetton decimal handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadWallet.mockReturnValue({ address: walletAddress });
+    mocks.getCachedTonClient.mockResolvedValue({});
+    mocks.openWallet.mockResolvedValue({ keyPair: { secretKey: new Uint8Array() }, contract: {} });
+    mocks.sendWalletTx.mockResolvedValue({ hash: "tx-hash" });
+    mocks.withTxLock.mockImplementation((callback: () => unknown) => callback());
+  });
+
+  it("sends five base units for a zero-decimal jetton", async () => {
+    mocks.tonapiFetch.mockResolvedValue(
+      response({
+        balances: [
+          {
+            balance: "5",
+            wallet_address: { address: "EQJettonWallet" },
+            jetton: { address: jettonAddress, decimals: 0, symbol: "ZERO" },
+          },
+        ],
+      })
+    );
+
+    const result = await jettonSendExecutor(
+      { jetton_address: jettonAddress, to: "EQRecipient", amount: 5 },
+      {} as never
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.storeCoins).toHaveBeenCalledWith(5n);
+  });
+
+  it("formats a zero-decimal balance without scaling it by 10^9", async () => {
+    mocks.tonapiFetch.mockResolvedValue(
+      response({
+        balances: [
+          {
+            balance: "5",
+            wallet_address: { address: "EQJettonWallet" },
+            jetton: {
+              address: jettonAddress,
+              decimals: 0,
+              symbol: "ZERO",
+              name: "Zero Decimal",
+              verification: "whitelist",
+              score: 100,
+            },
+          },
+        ],
+      })
+    );
+
+    const result = await jettonBalancesExecutor({}, {} as never);
+
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        balances: [{ balance: "5", rawBalance: "5", decimals: 0 }],
+      },
+    });
+  });
+});

--- a/src/agent/tools/stonfi/search.ts
+++ b/src/agent/tools/stonfi/search.ts
@@ -130,7 +130,7 @@ export const stonfiSearchExecutor: ToolExecutor<JettonSearchParams> = async (
         symbol: asset.symbol || "UNKNOWN",
         name: asset.display_name || "Unknown Token",
         address: asset.contract_address,
-        decimals: asset.decimals || 9,
+        decimals: asset.decimals ?? 9,
         priceUSD: asset.dex_price_usd || asset.third_party_price_usd || null,
         verified: !asset.community && !asset.blacklisted,
         image: asset.image_url || null,

--- a/src/agent/tools/ton/jetton-balances.ts
+++ b/src/agent/tools/ton/jetton-balances.ts
@@ -68,7 +68,7 @@ export const jettonBalancesExecutor: ToolExecutor<JettonBalancesParams> = async 
       }
 
       // Convert balance from blockchain units to human-readable
-      const decimals = jetton.decimals || 9;
+      const decimals = jetton.decimals ?? 9;
       const rawBalance = BigInt(balance);
       const divisor = BigInt(10 ** decimals);
       const wholePart = rawBalance / divisor;

--- a/src/agent/tools/ton/jetton-send.ts
+++ b/src/agent/tools/ton/jetton-send.ts
@@ -101,7 +101,7 @@ export const jettonSendExecutor: ToolExecutor<JettonSendParams> = async (
     }
 
     const senderJettonWallet = jettonBalance.wallet_address.address;
-    const decimals = jettonBalance.jetton.decimals || 9;
+    const decimals = jettonBalance.jetton.decimals ?? 9;
     const symbol = jettonBalance.jetton.symbol || "JETTON";
     const currentBalance = BigInt(jettonBalance.balance);
 


### PR DESCRIPTION
## Что исправлено

- `jetton_send` теперь сохраняет валидное значение `decimals = 0` и отправляет сумму в масштабе `10^0`;
- проверка достаточности и отображение jetton-баланса используют ту же нулевую точность;
- аудит числовых metadata-путей устранил аналогичный `decimals || 9` в `jetton_balances` и `stonfi_search`;
- строковые варианты `metadata.decimals || "9"` оставлены: строка `"0"` truthy и не воспроизводит дефект.

## Как воспроизвести

Для jetton с сырым балансом `5` и `decimals = 0` вызвать `jetton_send` с `amount = 5`.

До исправления точность подменялась на 9: перевод вычислялся как `5_000_000_000` base units и отклонялся проверкой баланса, а баланс отображался как `0.000000005`. После исправления в transfer body записывается `5n`, а баланс отображается как `5`.

## Автоматическая проверка

Добавлены сквозные регрессионные тесты для `jettonSendExecutor` и `jettonBalancesExecutor`.

- `npm run build:sdk` — успешно;
- `npm run typecheck` — успешно;
- `npm run lint` — успешно;
- Prettier для изменённых файлов — успешно;
- `npm test` — 251 файл, 3 794 теста успешно;
- `git diff --check` — успешно.

UI не изменялся, скриншоты не требуются. Версия и CHANGELOG не менялись вручную: релизом управляет release-please через `fix:` commit.

Fixes #700
