### PR TITLE
fix(workflows): предотвратить параллельный запуск workflow

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-14T04:05:46.349Z for PR creation at branch issue-701-8d284f5e2835 for issue https://github.com/xlabtg/teleton-agent/issues/701

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-14T04:05:46.349Z for PR creation at branch issue-701-8d284f5e2835 for issue https://github.com/xlabtg/teleton-agent/issues/701

--- a/src/services/__tests__/workflow-scheduler.test.ts
+++ b/src/services/__tests__/workflow-scheduler.test.ts
@@ -2,6 +2,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
 import { WorkflowStore } from "../workflows.js";
 import { WorkflowScheduler } from "../workflow-scheduler.js";
+import { WorkflowExecutor } from "../workflow-executor.js";
+
+const executeWorkflow = vi.hoisted(() => vi.fn());
+
+vi.mock("../workflow-executor.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../workflow-executor.js")>();
+  return {
+    WorkflowExecutor: class extends actual.WorkflowExecutor {
+      execute = executeWorkflow;
+    },
+  };
+});
 
 vi.mock("../../utils/logger.js", () => ({
   createLogger: vi.fn(() => ({
@@ -40,6 +52,13 @@ describe("WorkflowScheduler", () => {
     db = createTestDb();
     store = new WorkflowStore(db);
     vi.useFakeTimers();
+    executeWorkflow.mockReset();
+    executeWorkflow.mockImplementation(function (
+      this: WorkflowExecutor,
+      ...args: Parameters<WorkflowExecutor["execute"]>
+    ) {
+      return WorkflowExecutor.prototype.execute.apply(this, args);
+    });
   });
 
   afterEach(() => {
@@ -95,6 +114,32 @@ describe("WorkflowScheduler", () => {
     expect(updated.runCount).toBe(0);
   });
 
+  it("does not run the same workflow concurrently across event triggers", async () => {
+    store.create({
+      name: "On start",
+      config: {
+        trigger: { type: "event", event: "agent.start" },
+        actions: [],
+      },
+    });
+    let finishExecution!: () => void;
+    executeWorkflow.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishExecution = resolve;
+        })
+    );
+
+    const scheduler = new WorkflowScheduler(db);
+    const firstRun = scheduler.fireEvent("agent.start");
+    await vi.waitFor(() => expect(executeWorkflow).toHaveBeenCalledTimes(1));
+    const overlappingRun = scheduler.fireEvent("agent.start");
+
+    await vi.waitFor(() => expect(executeWorkflow).toHaveBeenCalledTimes(1));
+    finishExecution();
+    await Promise.all([firstRun, overlappingRun]);
+  });
+
   it("handleWebhook triggers matching webhook workflows", async () => {
     const wf = store.create({
       name: "Webhook",
@@ -136,6 +181,32 @@ describe("WorkflowScheduler", () => {
     expect(updated.runCount).toBe(0);
   });
 
+  it("does not run the same workflow concurrently across webhook triggers", async () => {
+    store.create({
+      name: "Webhook",
+      config: {
+        trigger: { type: "webhook", secret: "secret123" },
+        actions: [],
+      },
+    });
+    let finishExecution!: () => void;
+    executeWorkflow.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishExecution = resolve;
+        })
+    );
+
+    const scheduler = new WorkflowScheduler(db);
+    const firstRun = scheduler.handleWebhook("secret123");
+    await vi.waitFor(() => expect(executeWorkflow).toHaveBeenCalledTimes(1));
+    const overlappingRun = scheduler.handleWebhook("secret123");
+
+    await vi.waitFor(() => expect(executeWorkflow).toHaveBeenCalledTimes(1));
+    finishExecution();
+    await expect(Promise.all([firstRun, overlappingRun])).resolves.toEqual([true, true]);
+  });
+
   it("start and stop do not throw", () => {
     const scheduler = new WorkflowScheduler(db);
     scheduler.start();
@@ -158,6 +229,13 @@ describe("Cron matching (via tick)", () => {
     db = createTestDb();
     store = new WorkflowStore(db);
     vi.useFakeTimers();
+    executeWorkflow.mockReset();
+    executeWorkflow.mockImplementation(function (
+      this: WorkflowExecutor,
+      ...args: Parameters<WorkflowExecutor["execute"]>
+    ) {
+      return WorkflowExecutor.prototype.execute.apply(this, args);
+    });
   });
 
   afterEach(() => {
@@ -220,6 +298,13 @@ describe("WorkflowScheduler deduplication (AUDIT-M7)", () => {
     db = createTestDb();
     store = new WorkflowStore(db);
     vi.useFakeTimers();
+    executeWorkflow.mockReset();
+    executeWorkflow.mockImplementation(function (
+      this: WorkflowExecutor,
+      ...args: Parameters<WorkflowExecutor["execute"]>
+    ) {
+      return WorkflowExecutor.prototype.execute.apply(this, args);
+    });
   });
 
   afterEach(() => {

--- a/src/services/workflow-scheduler.ts
+++ b/src/services/workflow-scheduler.ts
@@ -121,11 +121,15 @@ export class WorkflowScheduler {
   }
 
   private async execute(workflowId: string): Promise<void> {
-    const wf = this.store.get(workflowId);
-    if (!wf) return;
+    if (this.runningWorkflowIds.has(workflowId)) {
+      log.warn({ workflowId }, "Skipping workflow already running");
+      return;
+    }
     this.runningWorkflowIds.add(workflowId);
-    const executor = new WorkflowExecutor({ store: this.store, bridge: this.bridge });
+    const wf = this.store.get(workflowId);
     try {
+      if (!wf) return;
+      const executor = new WorkflowExecutor({ store: this.store, bridge: this.bridge });
       await executor.execute(wf);
     } catch (err) {
       log.error({ err, workflowId }, "Workflow execution failed");


### PR DESCRIPTION
## Что исправлено

- Перенесена защита от повторного входа в общий `WorkflowScheduler.execute()`, поэтому она одинаково действует для cron-, event- и webhook-триггеров.
- Проверка и регистрация `workflowId` выполняются синхронно до первого `await`; параллельный запуск того же workflow пропускается.
- Сохранено прежнее поведение webhook: совпавший секрет возвращает `true`, даже если повторное исполнение было объединено с уже активным.

## Как воспроизвести

1. Создать event- или webhook-workflow.
2. Заблокировать первое исполнение до завершения.
3. Повторно вызвать тот же event или webhook.
4. До исправления `WorkflowExecutor.execute()` вызывается дважды параллельно; после исправления — один раз.

## Автоматические тесты

- Добавлены регрессионные тесты параллельных event- и webhook-вызовов.
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test` — 251 файл, 3 796 тестов
- `npm run build:sdk` и backend build
- `cd web && npm ci && npm run build`

Fixes #701
