### PR TITLE
fix(agents): ограничить хранение межагентских сообщений

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-14T04:36:25.933Z for PR creation at branch issue-702-b1a561a6672e for issue https://github.com/xlabtg/teleton-agent/issues/702

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-14T04:36:25.933Z for PR creation at branch issue-702-b1a561a6672e for issue https://github.com/xlabtg/teleton-agent/issues/702

--- a/src/agents/__tests__/service.test.ts
+++ b/src/agents/__tests__/service.test.ts
@@ -445,6 +445,42 @@ mtproto:
     expect(service.readMessageResult(target.id, message.id)).toEqual(recorded);
   });
 
+  it("bounds persisted inter-agent messages and results", () => {
+    service = new ManagedAgentService({ rootDir, primaryConfigPath: configPath });
+
+    const sender = service.createAgent({
+      name: "Planner",
+      acknowledgePersonalAccountAccess: true,
+      messaging: { enabled: true, maxMessagesPerMinute: 2_000 },
+    });
+    const target = service.createAgent({
+      name: "Executor",
+      acknowledgePersonalAccountAccess: true,
+      messaging: { enabled: true, allowlist: [sender.id] },
+    });
+
+    const messages = [];
+    for (let index = 0; index < 1_001; index += 1) {
+      const message = service.sendMessage(sender.id, target.id, `Task ${index}`);
+      messages.push(message);
+      service.recordMessageResult(target.id, message.id, { content: "done" });
+    }
+
+    const persistedMessages = JSON.parse(
+      readFileSync(join(target.homePath, "messages", "inbox.json"), "utf-8")
+    ) as Array<{ id: string }>;
+    const persistedResults = JSON.parse(
+      readFileSync(join(target.homePath, "messages", "results.json"), "utf-8")
+    ) as Array<{ messageId: string }>;
+
+    expect(persistedMessages).toHaveLength(1_000);
+    expect(persistedResults).toHaveLength(1_000);
+    expect(persistedMessages[0]?.id).toBe(messages[1]?.id);
+    expect(persistedResults[0]?.messageId).toBe(messages[1]?.id);
+    expect(persistedMessages.at(-1)?.id).toBe(messages.at(-1)?.id);
+    expect(persistedResults.at(-1)?.messageId).toBe(messages.at(-1)?.id);
+  });
+
   it("exposes built-in archetypes and creates registry entries from them", () => {
     service = new ManagedAgentService({ rootDir, primaryConfigPath: configPath });
 

--- a/src/agents/service.ts
+++ b/src/agents/service.ts
@@ -53,6 +53,7 @@ const MANAGED_AGENTS_DIRNAME = "agents";
 const LOG_LINES_FALLBACK = 200;
 const STOP_GRACE_MS = 15_000;
 const MESSAGE_LINES_FALLBACK = 100;
+const MESSAGE_RETENTION_LIMIT = 1_000;
 const MESSAGE_RESULT_POLL_INTERVAL_MS = 250;
 const STARTUP_READY_TIMEOUT_MS = 120_000;
 const SECRET_KEY_FILENAME = ".secret-key";
@@ -180,6 +181,10 @@ function tailLines(text: string, lines: number): string[] {
   const normalized = text.replace(/\r\n/g, "\n").split("\n");
   if (normalized.length <= lines) return normalized;
   return normalized.slice(-lines);
+}
+
+function retainLatest<T>(items: T[], limit = MESSAGE_RETENTION_LIMIT): T[] {
+  return items.length > limit ? items.slice(-limit) : items;
 }
 
 function mergeResources(input?: Partial<ManagedAgentResourcePolicy>): ManagedAgentResourcePolicy {
@@ -1455,7 +1460,11 @@ export class ManagedAgentService {
 
   private writeMessages(definition: ManagedAgentDefinition, messages: ManagedAgentMessage[]): void {
     mkdirSync(join(definition.homePath, "messages"), { recursive: true, mode: 0o700 });
-    writeFileSync(this.messagesPath(definition), JSON.stringify(messages, null, 2), "utf-8");
+    writeFileSync(
+      this.messagesPath(definition),
+      JSON.stringify(retainLatest(messages), null, 2),
+      "utf-8"
+    );
   }
 
   private readMessageResultsFile(definition: ManagedAgentDefinition): ManagedAgentMessageResult[] {
@@ -1469,7 +1478,11 @@ export class ManagedAgentService {
     results: ManagedAgentMessageResult[]
   ): void {
     mkdirSync(join(definition.homePath, "messages"), { recursive: true, mode: 0o700 });
-    writeFileSync(this.messageResultsPath(definition), JSON.stringify(results, null, 2), "utf-8");
+    writeFileSync(
+      this.messageResultsPath(definition),
+      JSON.stringify(retainLatest(results), null, 2),
+      "utf-8"
+    );
   }
 
   private findMessageResult(messageId: string, agentId?: string): ManagedAgentMessageResult | null {


### PR DESCRIPTION
Исправляет #702

## Что изменено

- Добавлено окно хранения: `inbox.json` и `results.json` сохраняют не более 1000 последних записей.
- Ограничение применяется перед сериализацией, поэтому размер файла и стоимость последующего read-modify-write больше не растут с полной историей сессии.
- Сохранён прежний JSON-формат и порядок записей; миграция существующих файлов не требуется — они компактируются при следующей записи.
- Добавлен регрессионный тест для обоих файлов, включая проверку удаления самой старой и сохранения новейшей записи.

## Как воспроизвести исходную проблему

1. Создать двух managed agents с разрешённым inter-agent messaging.
2. Отправить более 1000 сообщений и записать результаты.
3. До исправления `inbox.json` и `results.json` продолжали расти (регрессионный тест получал 1001 запись вместо 1000).

## Проверка

- `npm run build:sdk`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npx vitest run src/agents/__tests__/service.test.ts` — 18 тестов пройдено



Fixes #702