### PR TITLE
fix(agents): сбрасывать бюджет перезапусков после стабилизации

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-14T05:00:19.606Z for PR creation at branch issue-703-10fe8655f8fd for issue https://github.com/xlabtg/teleton-agent/issues/703

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-14T05:00:19.606Z for PR creation at branch issue-703-10fe8655f8fd for issue https://github.com/xlabtg/teleton-agent/issues/703

--- a/src/agents/__tests__/service.test.ts
+++ b/src/agents/__tests__/service.test.ts
@@ -411,6 +411,43 @@ mtproto:
     });
   });
 
+  it("preserves the restart budget when recovery crashes before becoming stable", async () => {
+    service = new ManagedAgentService({
+      rootDir,
+      primaryConfigPath: configPath,
+      restartStabilityWindowMs: 500,
+      resolveCommand: () => ({
+        command: process.execPath,
+        args: [
+          "-e",
+          [
+            "console.log('Teleton Agent is running!');",
+            "setTimeout(() => process.exit(1), 50);",
+          ].join(" "),
+        ],
+      }),
+    });
+
+    const snapshot = service.createAgent({
+      name: "Repeatedly Crashing Bot",
+      mode: "bot",
+      botToken: "123456:ABCDEF",
+      resources: { restartBackoffMs: 0, maxRestarts: 1 },
+    });
+
+    service.startAgent(snapshot.id);
+    await expect
+      .poll(() => service?.getRuntimeStatus(snapshot.id).state, { timeout: 2_000 })
+      .toBe("error");
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(service.getRuntimeStatus(snapshot.id)).toMatchObject({
+      state: "error",
+      health: "error",
+      restartCount: 1,
+    });
+  });
+
   it("blocks non-isolated memory policies from starting", () => {
     service = new ManagedAgentService({ rootDir, primaryConfigPath: configPath });
 

--- a/src/agents/__tests__/service.test.ts
+++ b/src/agents/__tests__/service.test.ts
@@ -371,6 +371,46 @@ mtproto:
     expect(service.getRuntimeStatus(snapshot.id).state).toBe("starting");
   });
 
+  it("resets the restart budget after a stable uptime window", async () => {
+    let starts = 0;
+    service = new ManagedAgentService({
+      rootDir,
+      primaryConfigPath: configPath,
+      restartStabilityWindowMs: 50,
+      resolveCommand: () => ({
+        command: process.execPath,
+        args: [
+          "-e",
+          starts++ === 0
+            ? "process.exit(1)"
+            : [
+                "console.log('Teleton Agent is running!');",
+                "setTimeout(() => process.exit(0), 5000);",
+              ].join(" "),
+        ],
+      }),
+    });
+
+    const snapshot = service.createAgent({
+      name: "Recovering Bot",
+      mode: "bot",
+      botToken: "123456:ABCDEF",
+      resources: { restartBackoffMs: 0, maxRestarts: 1 },
+    });
+
+    service.startAgent(snapshot.id);
+    await expect
+      .poll(() => service?.getRuntimeStatus(snapshot.id).state, { timeout: 2_000 })
+      .toBe("running");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(service.getRuntimeStatus(snapshot.id)).toMatchObject({
+      state: "running",
+      health: "healthy",
+      restartCount: 0,
+    });
+  });
+
   it("blocks non-isolated memory policies from starting", () => {
     service = new ManagedAgentService({ rootDir, primaryConfigPath: configPath });
 

--- a/src/agents/service.ts
+++ b/src/agents/service.ts
@@ -56,6 +56,7 @@ const MESSAGE_LINES_FALLBACK = 100;
 const MESSAGE_RETENTION_LIMIT = 1_000;
 const MESSAGE_RESULT_POLL_INTERVAL_MS = 250;
 const STARTUP_READY_TIMEOUT_MS = 120_000;
+const RESTART_STABILITY_WINDOW_MS = 60_000;
 const SECRET_KEY_FILENAME = ".secret-key";
 const CREDENTIALS_FILENAME = "credentials.json";
 
@@ -101,6 +102,7 @@ interface ManagedAgentProcessRecord {
   lastExitSignal: string | null;
   messageTimestamps: number[];
   startupTimer: ReturnType<typeof setTimeout> | null;
+  restartStabilityTimer: ReturnType<typeof setTimeout> | null;
 }
 
 interface EncryptedSecret {
@@ -121,6 +123,7 @@ export interface ManagedAgentServiceOptions {
   rootDir?: string;
   primaryConfigPath: string;
   resolveCommand?: (configPath: string) => ManagedAgentCommand;
+  restartStabilityWindowMs?: number;
 }
 
 function slugifyAgentId(name: string): string {
@@ -292,6 +295,7 @@ export class ManagedAgentService {
   private readonly agentsRoot: string;
   private readonly primaryConfigPath: string;
   private readonly resolveCommand: (configPath: string) => ManagedAgentCommand;
+  private readonly restartStabilityWindowMs: number;
   private readonly processes = new Map<string, ManagedAgentProcessRecord>();
 
   constructor(options: ManagedAgentServiceOptions) {
@@ -299,6 +303,10 @@ export class ManagedAgentService {
     this.agentsRoot = join(this.rootDir, MANAGED_AGENTS_DIRNAME);
     this.primaryConfigPath = options.primaryConfigPath;
     this.resolveCommand = options.resolveCommand ?? this.defaultResolveCommand;
+    this.restartStabilityWindowMs = Math.max(
+      0,
+      options.restartStabilityWindowMs ?? RESTART_STABILITY_WINDOW_MS
+    );
   }
 
   listArchetypes(): ManagedAgentArchetype[] {
@@ -572,6 +580,7 @@ export class ManagedAgentService {
         record.state = "running";
         record.startedAt = Date.now();
         this.clearStartupTimer(record);
+        this.scheduleRestartCountReset(record, logStream);
       }
     });
 
@@ -586,6 +595,7 @@ export class ManagedAgentService {
       record.startedAt = null;
       this.clearStopTimer(record);
       this.clearStartupTimer(record);
+      this.clearRestartStabilityTimer(record);
       this.closeLogStream(record);
     });
 
@@ -596,6 +606,7 @@ export class ManagedAgentService {
       record.startedAt = null;
       this.clearStopTimer(record);
       this.clearStartupTimer(record);
+      this.clearRestartStabilityTimer(record);
 
       if (expectedStop || code === 0) {
         record.state = "stopped";
@@ -1384,6 +1395,7 @@ export class ManagedAgentService {
         lastExitSignal: null,
         messageTimestamps: [],
         startupTimer: null,
+        restartStabilityTimer: null,
       };
       this.processes.set(id, record);
     }
@@ -1410,6 +1422,32 @@ export class ManagedAgentService {
     if (record.startupTimer) {
       clearTimeout(record.startupTimer);
       record.startupTimer = null;
+    }
+  }
+
+  private scheduleRestartCountReset(
+    record: ManagedAgentProcessRecord,
+    logStream: WriteStream
+  ): void {
+    this.clearRestartStabilityTimer(record);
+    if (record.restartCount === 0) return;
+
+    record.restartStabilityTimer = setTimeout(() => {
+      if (record.state !== "running" || !record.child) return;
+      record.restartCount = 0;
+      record.restartStabilityTimer = null;
+      this.appendLog(
+        logStream,
+        `[${nowIso()}] Managed agent remained stable; restart budget reset\n`
+      );
+    }, this.restartStabilityWindowMs);
+    record.restartStabilityTimer.unref();
+  }
+
+  private clearRestartStabilityTimer(record: ManagedAgentProcessRecord): void {
+    if (record.restartStabilityTimer) {
+      clearTimeout(record.restartStabilityTimer);
+      record.restartStabilityTimer = null;
     }
   }
 


### PR DESCRIPTION
## Что изменено

- после подтверждения готовности перезапущенного managed-agent запускается 60-секундное окно стабильности;
- после успешного прохождения окна `restartCount` сбрасывается в `0`, поэтому `maxRestarts` ограничивает последовательные сбои, а health возвращается в `healthy`;
- таймер сброса очищается при ошибке/выходе процесса, поэтому ранний повторный сбой сохраняет использованный бюджет;
- в лог агента добавлена запись о восстановлении бюджета перезапусков.

## Как воспроизвести

1. Запустить managed-agent с `restartOnCrash: true` и `maxRestarts: 1`.
2. Аварийно завершить первый процесс и дождаться автоматического перезапуска.
3. До исправления восстановленный процесс навсегда сохранял `restartCount: 1` и health `degraded`; следующий сбой уже не перезапускался.

## Тесты

Добавлены регрессионные сценарии в `src/agents/__tests__/service.test.ts`:

- успешное восстановление сбрасывает `restartCount` и возвращает health `healthy`;
- повторный сбой до конца окна стабильности не сбрасывает бюджет.

Локально выполнено:

- `npm run build:sdk`
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npx vitest run src/agents/__tests__/service.test.ts` — 20/20
- `npx vitest run src/cli/__tests__/start-config-missing.test.ts` — 2/2
- `npm test` — 3797/3799; два существующих тяжёлых теста превысили общий 10-секундный лимит при параллельном прогоне. CLI-тест прошёл отдельно; тест хранения 1000 сообщений проходит в CI быстрее либо требует отдельного повышения производительности/лимита и не связан с изменённой логикой restart.

Fixes #703
