### PR TITLE
fix(sse): очищать lifecycle listener при ошибках стрима

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-14T05:29:58.844Z for PR creation at branch issue-704-54254ac8334f for issue https://github.com/xlabtg/teleton-agent/issues/704

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-14T05:29:58.844Z for PR creation at branch issue-704-54254ac8334f for issue https://github.com/xlabtg/teleton-agent/issues/704

--- a/src/webui/__tests__/sse-listener-cleanup.test.ts
+++ b/src/webui/__tests__/sse-listener-cleanup.test.ts
@@ -28,6 +28,8 @@ vi.mock("hono/streaming", () => ({
 
 import { auditTrailBus } from "../../services/audit-trail.js";
 import { notificationBus } from "../../services/notifications.js";
+import { AgentLifecycle } from "../../agent/lifecycle.js";
+import { createLifecycleSSE } from "../lifecycle-sse.js";
 import { createAuditRoutes } from "../routes/audit.js";
 import { createNotificationsRoutes } from "../routes/notifications.js";
 
@@ -94,5 +96,17 @@ describe("SSE listener cleanup", () => {
     expect(res.status).toBe(200);
     expect(streamHarness.error).toBeInstanceOf(Error);
     expect(auditTrailBus.listenerCount("event")).toBe(before);
+  });
+
+  it("removes lifecycle listeners when a heartbeat write fails", async () => {
+    const lifecycle = new AgentLifecycle();
+    const before = lifecycle.listenerCount("stateChange");
+    streamHarness.stream = createFailingHeartbeatStream();
+
+    const res = await createLifecycleSSE({} as never, lifecycle);
+
+    expect(res.status).toBe(200);
+    expect(streamHarness.error).toBeInstanceOf(Error);
+    expect(lifecycle.listenerCount("stateChange")).toBe(before);
   });
 });

--- a/src/webui/lifecycle-sse.ts
+++ b/src/webui/lifecycle-sse.ts
@@ -10,49 +10,67 @@ import type { AgentLifecycle, StateChangeEvent } from "../agent/lifecycle.js";
 export function createLifecycleSSE(c: Context, lifecycle: AgentLifecycle) {
   return streamSSE(c, async (stream) => {
     let aborted = false;
-
-    stream.onAbort(() => {
-      aborted = true;
-    });
-
-    // Push current state immediately on connection
-    const now = Date.now();
-    await stream.writeSSE({
-      event: "status",
-      id: String(now),
-      data: JSON.stringify({
-        state: lifecycle.getState(),
-        error: lifecycle.getError() ?? null,
-        timestamp: now,
-      }),
-      retry: 3000,
-    });
+    let listening = false;
 
     const onStateChange = (event: StateChangeEvent) => {
       if (aborted) return;
-      void stream.writeSSE({
-        event: "status",
-        id: String(event.timestamp),
-        data: JSON.stringify({
-          state: event.state,
-          error: event.error ?? null,
-          timestamp: event.timestamp,
-        }),
-      });
+      void stream
+        .writeSSE({
+          event: "status",
+          id: String(event.timestamp),
+          data: JSON.stringify({
+            state: event.state,
+            error: event.error ?? null,
+            timestamp: event.timestamp,
+          }),
+        })
+        .catch(() => {
+          aborted = true;
+          cleanup();
+        });
     };
 
-    lifecycle.on("stateChange", onStateChange);
-
-    // Heartbeat loop + keep connection alive
-    while (!aborted) {
-      await stream.sleep(30_000);
-      if (aborted) break;
-      await stream.writeSSE({
-        event: "ping",
-        data: "",
-      });
+    function cleanup() {
+      if (!listening) return;
+      listening = false;
+      lifecycle.off("stateChange", onStateChange);
     }
 
-    lifecycle.off("stateChange", onStateChange);
+    stream.onAbort(() => {
+      aborted = true;
+      cleanup();
+    });
+
+    try {
+      // Push current state immediately on connection
+      const now = Date.now();
+      await stream.writeSSE({
+        event: "status",
+        id: String(now),
+        data: JSON.stringify({
+          state: lifecycle.getState(),
+          error: lifecycle.getError() ?? null,
+          timestamp: now,
+        }),
+        retry: 3000,
+      });
+
+      if (aborted) return;
+
+      lifecycle.on("stateChange", onStateChange);
+      listening = true;
+
+      // Heartbeat loop + keep connection alive
+      while (!aborted) {
+        await stream.sleep(30_000);
+        if (aborted) break;
+        await stream.writeSSE({
+          event: "ping",
+          data: "",
+        });
+      }
+    } finally {
+      cleanup();
+    }
   });
 }


### PR DESCRIPTION
## Что исправлено

Fixes #704.

- `createLifecycleSSE` теперь снимает `stateChange` listener через идемпотентный `cleanup()` при `onAbort`, при ошибке записи события и в `finally`.
- Heartbeat `sleep`/`writeSSE`, завершившийся исключением, больше не оставляет listener на process-wide `AgentLifecycle`.
- Регистрация listener отслеживается явно, поэтому cleanup безопасен и до регистрации, и при повторных вызовах.
- Удалён временный `.gitkeep` из стартового WIP-коммита.

## Как воспроизвести исходную проблему

Regression test подменяет SSE stream так, чтобы heartbeat `writeSSE({ event: "ping" })` завершился ошибкой после регистрации listener, и сравнивает `lifecycle.listenerCount("stateChange")` с исходным значением.

До исправления тест падал:

```text
AssertionError: expected 1 to be +0
```

После исправления число listeners возвращается к исходному значению.

## Тесты

- `npm test -- src/webui/__tests__/sse-listener-cleanup.test.ts`
- `npm run build:sdk`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test` — 251 файл, 3800 тестов

UI не менялся, скриншоты не требуются.
