### PR TITLE
fix(workspace): закрыть права новых файлов

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-14T05:52:19.618Z for PR creation at branch issue-705-1d93f6e33fe9 for issue https://github.com/xlabtg/teleton-agent/issues/705

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-14T05:52:19.618Z for PR creation at branch issue-705-1d93f6e33fe9 for issue https://github.com/xlabtg/teleton-agent/issues/705

--- a/src/agent/tools/workspace/__tests__/write.test.ts
+++ b/src/agent/tools/workspace/__tests__/write.test.ts
@@ -1,0 +1,45 @@
+import { mkdirSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+const { tempWorkspace } = vi.hoisted(() => ({
+  tempWorkspace: "/tmp/teleton-workspace-write-test",
+}));
+
+rmSync(tempWorkspace, { recursive: true, force: true });
+mkdirSync(tempWorkspace, { recursive: true });
+
+vi.mock("../../../../workspace/paths.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../../../workspace/paths.js")>();
+  return {
+    ...original,
+    WORKSPACE_ROOT: tempWorkspace,
+  };
+});
+
+import { workspaceWriteExecutor } from "../write.js";
+
+afterAll(() => {
+  rmSync(tempWorkspace, { recursive: true, force: true });
+});
+
+describe("workspaceWriteExecutor", () => {
+  it("creates binary files with owner-only permissions", async () => {
+    const previousUmask = process.umask(0o022);
+    try {
+      const result = await workspaceWriteExecutor(
+        {
+          path: "private.bin",
+          content: Buffer.from("private content").toString("base64"),
+          encoding: "base64",
+        },
+        {} as never
+      );
+
+      expect(result.success).toBe(true);
+      expect(statSync(join(tempWorkspace, "private.bin")).mode & 0o777).toBe(0o600);
+    } finally {
+      process.umask(previousUmask);
+    }
+  });
+});

--- a/src/agent/tools/workspace/write.ts
+++ b/src/agent/tools/workspace/write.ts
@@ -96,7 +96,7 @@ export const workspaceWriteExecutor: ToolExecutor<WorkspaceWriteParams> = async 
       const { openSync, writeSync, closeSync, constants } = await import("fs");
       const flags =
         constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW;
-      const fd = openSync(validated.absolutePath, flags, 0o666);
+      const fd = openSync(validated.absolutePath, flags, 0o600);
       try {
         writeSync(fd, writeContent);
       } finally {

--- a/src/workspace/__tests__/validator.test.ts
+++ b/src/workspace/__tests__/validator.test.ts
@@ -1,6 +1,14 @@
 // src/workspace/__tests__/validator.test.ts
 
-import { mkdtempSync, rmSync, writeFileSync, symlinkSync, mkdirSync, readFileSync } from "fs";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  symlinkSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { vi } from "vitest";
@@ -536,6 +544,18 @@ describe("Workspace Path Validator", () => {
         safeWriteFileSync(filePath, "hello safe write");
         expect(readFileSync(filePath, "utf-8")).toBe("hello safe write");
       } finally {
+        rmSync(filePath, { force: true });
+      }
+    });
+
+    it("should create files with owner-only permissions", () => {
+      const filePath = join(tempWorkspace, "private-write-test.txt");
+      const previousUmask = process.umask(0o022);
+      try {
+        safeWriteFileSync(filePath, "private content");
+        expect(statSync(filePath).mode & 0o777).toBe(0o600);
+      } finally {
+        process.umask(previousUmask);
         rmSync(filePath, { force: true });
       }
     });

--- a/src/workspace/validator.ts
+++ b/src/workspace/validator.ts
@@ -289,7 +289,7 @@ export function safeWriteFileSync(validatedAbsolutePath: string, content: string
   // O_NOFOLLOW causes open() to fail with ELOOP if the path is a symlink,
   // closing the TOCTOU window between validateWritePath() and the write.
   const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | constants.O_NOFOLLOW;
-  const fd = openSync(validatedAbsolutePath, flags, 0o666);
+  const fd = openSync(validatedAbsolutePath, flags, 0o600);
   try {
     writeSync(fd, content);
   } finally {


### PR DESCRIPTION
## Описание

Новые файлы, создаваемые `workspace_write`, теперь получают права `0o600` во всех путях записи: строковом и binary/base64. Поведение согласовано с уже защищённым append-путём.

Режим применяется при создании файла и не меняет права уже существующих пользовательских файлов при overwrite.

## Воспроизведение

До исправления при `umask 022` оба overwrite-пути открывали новый файл с create-mode `0o666`, поэтому итоговый режим был `0o644` и файл оставался доступен для чтения группе и другим пользователям.

Новые регрессионные тесты устанавливают `umask 022`, создают string и binary файлы и проверяют точный режим `0o600`. До фикса оба теста получали `0o644` (`420`) вместо `0o600` (`384`).

## Изменения

- `safeWriteFileSync` создаёт строковые файлы с mode `0o600`.
- Binary/base64 путь `workspaceWriteExecutor` создаёт файлы с mode `0o600`.
- Добавлены отдельные регрессионные тесты для обоих путей.
- Удалён служебный `.gitkeep` подготовки PR.

## Проверки

- [x] `npm run lint`
- [x] `npm run build:sdk`
- [x] `npm run typecheck`
- [x] `npx vitest run src/workspace/__tests__/validator.test.ts src/agent/tools/workspace/__tests__/write.test.ts` — 80/80
- [x] Полный `npm test` — 3799/3802; три несвязанных нагрузочных сбоя
- [x] Изолированный повтор трёх сбоев — 22/22
- [x] `git diff --check`

UI не менялся, скриншоты не требуются.

Fixes #705
