### PR TITLE
fix(config): не сбрасывать несохранённые правки при сохранении поля

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-14T06:16:17.946Z for PR creation at branch issue-706-afe1e4169f87 for issue https://github.com/xlabtg/teleton-agent/issues/706

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-14T06:16:17.946Z for PR creation at branch issue-706-afe1e4169f87 for issue https://github.com/xlabtg/teleton-agent/issues/706

--- a/web/src/hooks/__tests__/useConfigState.test.ts
+++ b/web/src/hooks/__tests__/useConfigState.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeSavedConfigInput } from '../useConfigState';
+
+describe('mergeSavedConfigInput', () => {
+  it('preserves unsaved edits in other fields after saving one key', () => {
+    const localInputs = {
+      'agent.model': 'local-model',
+      'agent.temperature': '0.8',
+      'agent.max_tokens': '4096',
+    };
+
+    expect(mergeSavedConfigInput(localInputs, 'agent.model', ' saved-model ')).toEqual({
+      'agent.model': 'saved-model',
+      'agent.temperature': '0.8',
+      'agent.max_tokens': '4096',
+    });
+  });
+});

--- a/web/src/hooks/useConfigState.ts
+++ b/web/src/hooks/useConfigState.ts
@@ -10,6 +10,14 @@ export interface ProviderMeta {
   displayName: string;
 }
 
+export function mergeSavedConfigInput(
+  inputs: Record<string, string>,
+  key: string,
+  value: string
+): Record<string, string> {
+  return { ...inputs, [key]: value.trim() };
+}
+
 export function useConfigState() {
   const [status, setStatus] = useState<StatusData | null>(null);
   const [stats, setStats] = useState<MemoryStats | null>(null);
@@ -81,11 +89,13 @@ export function useConfigState() {
   );
 
   const saveConfig = async (key: string, value: string) => {
-    if (!value.trim()) return; // never send empty values
+    const savedValue = value.trim();
+    if (!savedValue) return; // never send empty values
     try {
       setError(null);
-      await api.setConfigKey(key, value.trim());
-      await loadData();
+      await api.setConfigKey(key, savedValue);
+      setServerInputs((prev) => mergeSavedConfigInput(prev, key, savedValue));
+      setLocalInputs((prev) => mergeSavedConfigInput(prev, key, savedValue));
       showSuccess('Saved');
     } catch (err) {
       setError(errMsg(err));


### PR DESCRIPTION
## Что исправлено

При сохранении одного параметра конфигурации WebUI больше не перезагружает весь набор настроек и не затирает несохранённые изменения в соседних полях.

- сохранённое значение нормализуется и точечно обновляется в `serverInputs` и `localInputs`;
- остальные локальные значения остаются без изменений;
- добавлен регрессионный тест для сценария с несколькими одновременно отредактированными полями.

## Воспроизведение до исправления

1. Изменить несколько полей конфигурации, не сохраняя их.
2. Сохранить одно из полей.
3. Остальные поля возвращались к серверным значениям, а введённые данные терялись.

## Проверка

- `npx vitest run web/src/hooks/__tests__/useConfigState.test.ts`
- `npm run build:sdk && npm run typecheck`
- `npm run build:web`

Полный набор проверок также запускается в CI.

Fixes #706
