### PR TITLE
fix(security): не падать на некорректных параметрах согласования

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-14T06:35:40.163Z for PR creation at branch issue-707-475d98669d39 for issue https://github.com/xlabtg/teleton-agent/issues/707

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-14T06:35:40.163Z for PR creation at branch issue-707-475d98669d39 for issue https://github.com/xlabtg/teleton-agent/issues/707

--- a/web/src/lib/formatApprovalParams.ts
+++ b/web/src/lib/formatApprovalParams.ts
@@ -1,0 +1,7 @@
+export function formatApprovalParams(params: string): string {
+  try {
+    return JSON.stringify(JSON.parse(params));
+  } catch {
+    return params;
+  }
+}

--- a/web/src/pages/Security.tsx
+++ b/web/src/pages/Security.tsx
@@ -16,6 +16,7 @@ import {
   type SecurityValidationLogEntry,
 } from "../lib/api";
 import { useTranslation } from "react-i18next";
+import { formatApprovalParams } from "../lib/formatApprovalParams";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -1017,7 +1018,7 @@ function ZeroTrustSection() {
                           fontSize: "11px",
                         }}
                       >
-                        {compactJson(JSON.parse(approval.params))}
+                        {formatApprovalParams(approval.params)}
                       </pre>
                       <button
                         onClick={() => resolveApproval(approval.id, "approve")}

--- a/web/src/pages/Security.tsx
+++ b/web/src/pages/Security.tsx
@@ -659,14 +659,6 @@ function PolicyActionBadge({ action }: { action: "allow" | "deny" | "require_app
   );
 }
 
-function compactJson(value: unknown): string {
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return "{}";
-  }
-}
-
 function policyToYaml(policy: SecurityPolicy): string {
   return JSON.stringify(
     {

--- a/web/src/pages/__tests__/Security.test.ts
+++ b/web/src/pages/__tests__/Security.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { formatApprovalParams } from "../../lib/formatApprovalParams";
+
+describe("formatApprovalParams", () => {
+  it("formats valid JSON approval params", () => {
+    expect(formatApprovalParams('{"command":"ls"}')).toBe('{"command":"ls"}');
+  });
+
+  it("returns malformed approval params as raw text", () => {
+    expect(formatApprovalParams("not json")).toBe("not json");
+  });
+});


### PR DESCRIPTION
## Что изменено

- вынесено безопасное форматирование `approval.params` в отдельную функцию;
- валидный JSON по-прежнему отображается компактно;
- некорректный JSON отображается как исходный текст и больше не роняет страницу Security;
- удалён ставший неиспользуемым старый форматтер;
- добавлен регрессионный тест для валидных и некорректных параметров.

## Как воспроизвести исходную проблему

1. Создать ожидающее согласование с `params: "not json"`.
2. Открыть Security → Zero-Trust Execution.
3. До исправления `JSON.parse` выбрасывал исключение во время render, и вся страница падала.

## Проверка

- `npx vitest run web/src/pages/__tests__/Security.test.ts` — 2 теста прошли;
- `npm run typecheck` — прошёл;
- `npm run typecheck --prefix web` — прошёл;
- `npm run lint` — прошёл;
- `npm run build:web` — прошёл;
- полный `npm test` после `npm run build:sdk`: 3802 теста прошли, 3 несвязанных теста `ManagedAgentService` не прошли (два ожидания асинхронного runtime-лога и один таймаут).

Fixes #707
