### PR TITLE
fix(web): показывать ошибки сетевых UI-действий

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-14T07:41:32.473Z for PR creation at branch issue-709-a86119ebe7ec for issue https://github.com/xlabtg/teleton-agent/issues/709

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-14T07:41:32.473Z for PR creation at branch issue-709-a86119ebe7ec for issue https://github.com/xlabtg/teleton-agent/issues/709

--- a/web/src/lib/__tests__/handleUiAction.test.ts
+++ b/web/src/lib/__tests__/handleUiAction.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleUiAction } from "../handleUiAction";
+
+describe("handleUiAction", () => {
+  it("surfaces a rejected action without rethrowing it", async () => {
+    const setError = vi.fn();
+
+    await expect(
+      handleUiAction(() => Promise.reject(new Error("boom")), setError)
+    ).resolves.toBeUndefined();
+
+    expect(setError).toHaveBeenCalledOnce();
+    expect(setError).toHaveBeenCalledWith("boom");
+  });
+
+  it("converts non-Error rejections to a readable message", async () => {
+    const setError = vi.fn();
+
+    await handleUiAction(() => Promise.reject("offline"), setError);
+
+    expect(setError).toHaveBeenCalledWith("offline");
+  });
+});

--- a/web/src/lib/handleUiAction.ts
+++ b/web/src/lib/handleUiAction.ts
@@ -1,0 +1,10 @@
+export async function handleUiAction(
+  action: () => Promise<unknown>,
+  setError: (message: string) => void
+): Promise<void> {
+  try {
+    await action();
+  } catch (error) {
+    setError(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/web/src/pages/Events.tsx
+++ b/web/src/pages/Events.tsx
@@ -6,6 +6,7 @@ import {
   WebhookRegistrationData,
 } from "../lib/api";
 import { useTranslation } from "react-i18next";
+import { handleUiAction } from "../lib/handleUiAction";
 
 function fmtTime(value: string | number | null): string {
   if (value === null) return "-";
@@ -419,7 +420,10 @@ export function Events() {
                   className="btn-ghost btn-sm"
                   onClick={() => {
                     setFilterType(type);
-                    api.eventsList({ type, limit: 100 }).then((result) => setEvents(result.data.events));
+                    void handleUiAction(async () => {
+                      const result = await api.eventsList({ type, limit: 100 });
+                      setEvents(result.data.events);
+                    }, setError);
                   }}
                 >
                   {type}

--- a/web/src/pages/Network.tsx
+++ b/web/src/pages/Network.tsx
@@ -10,6 +10,7 @@ import {
 } from "../lib/api";
 import { toast } from "../lib/toast-store";
 import { useTranslation } from "react-i18next";
+import { handleUiAction } from "../lib/handleUiAction";
 
 const TRUST_LEVELS: NetworkTrustLevel[] = ["trusted", "verified", "untrusted"];
 const AGENT_STATUSES: NetworkAgentStatus[] = ["available", "busy", "offline", "degraded"];
@@ -327,18 +328,24 @@ export function Network() {
   };
 
   const updateTrust = async (agent: NetworkAgentData, trustLevel: NetworkTrustLevel) => {
-    await api.updateNetworkAgentTrust(agent.id, { trustLevel });
-    await load();
+    await handleUiAction(async () => {
+      await api.updateNetworkAgentTrust(agent.id, { trustLevel });
+      await load();
+    }, setLastError);
   };
 
   const toggleBlocked = async (agent: NetworkAgentData) => {
-    await api.updateNetworkAgentTrust(agent.id, { blocked: !agent.blocked });
-    await load();
+    await handleUiAction(async () => {
+      await api.updateNetworkAgentTrust(agent.id, { blocked: !agent.blocked });
+      await load();
+    }, setLastError);
   };
 
   const removeAgent = async (agent: NetworkAgentData) => {
-    await api.removeNetworkAgent(agent.id);
-    await load();
+    await handleUiAction(async () => {
+      await api.removeNetworkAgent(agent.id);
+      await load();
+    }, setLastError);
   };
 
   const delegateTask = async () => {


### PR DESCRIPTION
## Что изменено

- добавлена общая безопасная обёртка для асинхронных UI-действий: она преобразует отклонение promise в текст для существующего error banner и не оставляет `unhandledrejection`;
- обработка подключена к изменению trust level, блокировке/разблокировке и удалению агента на странице Network;
- фильтрация по типу события на странице Events теперь также показывает ошибку API;
- добавлены unit-тесты для `Error` и произвольных значений rejection.

## Как воспроизвести

1. Открыть Network или Events.
2. Инициировать одно из затронутых действий при недоступном API либо ответе 500.
3. До исправления действие молча не выполнялось, а rejection оставался необработанным.
4. После исправления существующий баннер показывает сообщение API, а promise завершается без необработанного rejection.

## Проверки

- `npm test -- --run web/src/lib/__tests__/handleUiAction.test.ts` — 2/2 успешно;
- `npm run build:sdk && npm run typecheck` — успешно;
- `npm run typecheck --prefix web` — успешно;
- `npm run lint` — успешно;
- `npm run check:i18n --prefix web` — успешно;
- `npm run build:web` — успешно;
- полный `npm test`: 3813 тестов успешно; два существующих несвязанных теста `src/agents/__tests__/service.test.ts` падают также при отдельном повторе (ожидание лога дочернего процесса и существующий timeout 10 с).

Fixes #709
