### PR TITLE
fix(sanitize): сохранять текст после закрытия тега

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-14T08:39:13.382Z for PR creation at branch issue-711-fb6ee98f2eb1 for issue https://github.com/xlabtg/teleton-agent/issues/711

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-14T08:39:13.382Z for PR creation at branch issue-711-fb6ee98f2eb1 for issue https://github.com/xlabtg/teleton-agent/issues/711

--- a/src/utils/__tests__/sanitize.test.ts
+++ b/src/utils/__tests__/sanitize.test.ts
@@ -265,6 +265,11 @@ describe("sanitizeForPrompt", () => {
       expect(sanitizeForPrompt(input)).toBe("3 < 5 and 7 > 2");
     });
 
+    it("should preserve plain text after a tag when it is followed by >", () => {
+      expect(sanitizeForPrompt("<a>foo>bar")).toBe("foo>bar");
+      expect(sanitizeForPrompt("<b>hello</b> world")).toBe("hello world");
+    });
+
     it("should handle malformed tags", () => {
       const input = "Text <incomplete";
       expect(sanitizeForPrompt(input)).toBe("Text <incomplete");
@@ -821,6 +826,10 @@ describe("sanitizeForContext", () => {
 });
 
 describe("sanitizeTaskDescription", () => {
+  it("should preserve plain text after a tag when it is followed by >", () => {
+    expect(sanitizeTaskDescription("<a>foo>bar")).toBe("foo>bar");
+  });
+
   it("should remove fragmented nested script tags", () => {
     const input = "<scrip<script>t>alert(1)</scrip<script>t>";
     const result = sanitizeTaskDescription(input);

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -13,13 +13,15 @@ function stripMarkupTags(text: string): string {
     if (text[i] === "<" && isTagStart(text, i)) {
       let end = text.indexOf(">", i + 1);
       if (end !== -1) {
-        let next = end + 1;
-        while (next < text.length) {
-          const fragmentEnd = text.indexOf(">", next);
-          if (fragmentEnd === -1) break;
-          if (!isTagNameFragment(text.slice(next, fragmentEnd))) break;
-          end = fragmentEnd;
-          next = end + 1;
+        if (text.slice(i + 1, end).includes("<")) {
+          let next = end + 1;
+          while (next < text.length) {
+            const fragmentEnd = text.indexOf(">", next);
+            if (fragmentEnd === -1) break;
+            if (!isTagNameFragment(text.slice(next, fragmentEnd))) break;
+            end = fragmentEnd;
+            next = end + 1;
+          }
         }
         i = end;
         continue;


### PR DESCRIPTION
## Что исправлено

`stripMarkupTags` больше не принимает обычный текст после закрывающего `>` за продолжение имени тега. Например, `<a>foo>bar` теперь корректно превращается в `foo>bar`, а не в `bar`.

Расширенное поглощение фрагментов оставлено только для реально фрагментированных вложенных тегов, содержащих новый `<` внутри текущего тега. Поэтому существующая защита от конструкций вроде `<scrip<script>t>` сохраняется.

## Как воспроизвести

До исправления:

```ts
sanitizeForPrompt("<a>foo>bar"); // "bar"
sanitizeTaskDescription("<a>foo>bar"); // "bar"
```

После исправления оба вызова возвращают `foo>bar`.

## Тесты

- Добавлены регрессионные тесты для `sanitizeForPrompt` и `sanitizeTaskDescription`.
- `npm test -- --run src/utils/__tests__/sanitize.test.ts` — 149/149.
- `npm run build:sdk` — успешно.
- `npm run typecheck` — успешно.
- `npm run lint` — успешно.
- `npm run format:check` — успешно.
- Полный `npm test`: 3817/3821; четыре несвязанных теста agent/CLI были нестабильны под общей нагрузкой, после отдельного повторного запуска соответствующих файлов — 22/22.

Fixes #711
